### PR TITLE
Feat/spacer

### DIFF
--- a/apps/docs/src/components/Demo/SpacerDemo.tsx
+++ b/apps/docs/src/components/Demo/SpacerDemo.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { Spacer } from '@site/src/components/UI/spacer';
+import VariantSelector from './VariantSelector';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+
+const spacerSizes = [
+  { value: 'xs', label: 'Extra Small (xs)' },
+  { value: 'sm', label: 'Small (sm)' },
+  { value: 'md', label: 'Medium (md)' },
+  { value: 'lg', label: 'Large (lg)' },
+  { value: 'xl', label: 'Extra Large (xl)' },
+  { value: '24px', label: 'Custom 24px' },
+];
+
+const spacerDirections = [
+  { value: 'vertical', label: 'Vertical' },
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'both', label: 'Both' },
+];
+
+const SpacerDemo = () => {
+  const [size, setSize] = useState<string | number>('md');
+  const [direction, setDirection] = useState<'vertical' | 'horizontal' | 'both'>('vertical');
+  const [responsive, setResponsive] = useState<{
+    mobile?: string;
+    tablet?: string;
+    desktop?: string;
+  }>({
+    mobile: undefined,
+    tablet: undefined,
+    desktop: undefined,
+  });
+
+  const codeString = `
+    <Spacer 
+      size="${size}" 
+      direction="${direction}" 
+      responsive={{
+        mobile: "${responsive.mobile ?? ''}",
+        tablet: "${responsive.tablet ?? ''}",
+        desktop: "${responsive.desktop ?? ''}"
+      }}
+    />
+    `;
+
+  return (
+    <div className="space-y-6 mb-8">
+      <div className="flex flex-wrap gap-4 justify-start sm:justify-end">
+        <VariantSelector
+          variants={spacerSizes.map(s => s.value)}
+          selectedVariant={size.toString()}
+          onSelectVariant={setSize}
+          type="Base Size"
+        />
+        <VariantSelector
+          variants={spacerDirections.map(d => d.value)}
+          selectedVariant={direction}
+          onSelectVariant={(val) =>
+            setDirection(val as 'vertical' | 'horizontal' | 'both')
+          }
+          type="Direction"
+        />
+        <VariantSelector
+          variants={spacerSizes.map(s => s.value)}
+          selectedVariant={responsive.mobile ?? ''}
+          onSelectVariant={(val) => setResponsive(r => ({ ...r, mobile: val }))}
+          type="Mobile"
+        />
+        <VariantSelector
+          variants={spacerSizes.map(s => s.value)}
+          selectedVariant={responsive.tablet ?? ''}
+          onSelectVariant={(val) => setResponsive(r => ({ ...r, tablet: val }))}
+          type="Tablet"
+        />
+        <VariantSelector
+          variants={spacerSizes.map(s => s.value)}
+          selectedVariant={responsive.desktop ?? ''}
+          onSelectVariant={(val) => setResponsive(r => ({ ...r, desktop: val }))}
+          type="Desktop"
+        />
+      </div>
+
+      <Tabs>
+        <TabItem value="preview" label="Preview">
+          <div className="p-6 border rounded-lg mt-4 flex items-center justify-center">
+            <div
+              className={`flex items-center ${
+                direction === 'horizontal' ? 'flex-row' : 'flex-col'
+              }`}
+            >
+              <div className="bg-blue-500 w-16 h-8" />
+              <Spacer size={size} direction={direction} responsive={responsive} />
+              <div className="bg-red-500 w-16 h-8" />
+            </div>
+          </div>
+        </TabItem>
+
+        <TabItem value="code" label="Code">
+          <div className="mt-4">
+            <CodeBlock language="tsx" className="text-sm">
+              {codeString}
+            </CodeBlock>
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  );
+};
+
+export default SpacerDemo;

--- a/apps/docs/src/components/UI/spacer/index.tsx
+++ b/apps/docs/src/components/UI/spacer/index.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../../utils/cn';
+
+export interface SpacerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+  direction?: 'vertical' | 'horizontal' | 'both';
+  responsive?: {
+    mobile?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+    tablet?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+    desktop?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+  };
+}
+
+const spacerVariants = cva('', {
+  variants: {
+    size: {
+      xs: 'h-1 w-1',
+      sm: 'h-2 w-2',
+      md: 'h-4 w-4',
+      lg: 'h-6 w-6',
+      xl: 'h-8 w-8',
+    },
+    direction: {
+      vertical: 'w-0',
+      horizontal: 'h-0',
+      both: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    direction: 'vertical',
+  },
+});
+
+const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
+  (
+    { className, size = 'md', direction = 'vertical', responsive, style, ...props },
+    ref
+  ) => {
+    const designTokenSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+    const responsiveClasses: string[] = [];
+    if (responsive) {
+      if (responsive.mobile && designTokenSizes.includes(responsive.mobile as string)) {
+        responsiveClasses.push(spacerVariants({ size: responsive.mobile as any, direction }));
+      }
+      if (responsive.tablet && designTokenSizes.includes(responsive.tablet as string)) {
+        responsiveClasses.push(
+          `sm:${spacerVariants({ size: responsive.tablet as any, direction })}`
+        );
+      }
+      if (responsive.desktop && designTokenSizes.includes(responsive.desktop as string)) {
+        responsiveClasses.push(
+          `md:${spacerVariants({ size: responsive.desktop as any, direction })}`
+        );
+      }
+    }
+
+    const isCustomSize = size && !designTokenSizes.includes(size as string);
+    const dynamicStyle: React.CSSProperties = { ...style };
+
+    if (isCustomSize) {
+      const value =
+        typeof size === 'number'
+          ? `${size}px`
+          : /^\d+$/.test(size as string)
+          ? `${size}px`
+          : size;
+
+      if (direction === 'vertical') {
+        dynamicStyle.height = value;
+        dynamicStyle.width = 0;
+      } else if (direction === 'horizontal') {
+        dynamicStyle.width = value;
+        dynamicStyle.height = 0;
+      } else {
+        dynamicStyle.height = value;
+        dynamicStyle.width = value;
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          !isCustomSize && spacerVariants({ size: size as any, direction }),
+          responsiveClasses,
+          className
+        )}
+        style={dynamicStyle}
+        aria-hidden="true"
+        {...props}
+      />
+    );
+  }
+);
+
+Spacer.displayName = 'Spacer';
+
+export { Spacer, spacerVariants };

--- a/apps/docs/versioned_docs/version-1.0.0/layout/spacer.mdx
+++ b/apps/docs/versioned_docs/version-1.0.0/layout/spacer.mdx
@@ -1,0 +1,90 @@
+---
+sidebar_position: 5
+title: Spacer
+description: A simple spacing component for consistent vertical or horizontal gaps.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import { Spacer } from '@site/src/components/UI/spacer';
+import SpacerDemo from '@site/src/components/Demo/SpacerDemo';
+
+## Overview
+
+The **Spacer** component adds consistent spacing between elements, without writing custom CSS or margin classes.
+
+## Preview
+
+<Tabs defaultValue="preview">
+  <TabItem value="preview" label="Preview" default>
+    <div className="p-4 border rounded-lg flex flex-col items-center">
+      <div className="bg-blue-500 w-16 h-8" />
+      <Spacer size="md" direction="vertical" />
+      <div className="bg-red-500 w-16 h-8" />
+    </div>
+  </TabItem>
+  <TabItem value="code" label="Code">
+    ```tsx
+    import { Spacer } from './components/ui';
+
+    function MyComponent() {
+      return (
+        <>
+          <div className="bg-blue-500 w-16 h-8" />
+          <Spacer size="md" direction="vertical" />
+          <div className="bg-red-500 w-16 h-8" />
+        </>
+      );
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## Installation
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npx @mindfiredigital/ignix-ui add spacer
+    ```
+  </TabItem>
+  <TabItem value="yarn" label="Yarn">
+    ```bash
+    yarn @mindfiredigital/ignix-ui add spacer
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm @mindfiredigital/ignix-ui add spacer
+    ```
+  </TabItem>
+</Tabs>
+
+## Usage
+
+Import the component:
+
+```tsx
+import { Spacer } from './components/ui';
+```
+
+### Basic Usage
+
+```tsx
+function BasicSpacer() {
+  return (
+    <>
+      <div className="bg-blue-500 w-16 h-8" />
+      <Spacer size="lg" direction="vertical" />
+      <div className="bg-red-500 w-16 h-8" />
+    </>
+  );
+}
+```
+
+## Examples
+
+<SpacerDemo />
+
+
+

--- a/apps/docs/versioned_sidebars/version-1.0.0-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.0-sidebars.json
@@ -33,6 +33,13 @@
         "components/tooltip"
       ]
     },
+        {
+      "type": "category",
+      "label": "Layout",
+      "items": [
+        "layout/spacer"
+      ]
+    },
     {
       "type": "category",
       "label": "Contribution Guide",

--- a/packages/registry/components/layout/spacer/index.tsx
+++ b/packages/registry/components/layout/spacer/index.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../../utils/cn';
+
+export interface SpacerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+  direction?: 'vertical' | 'horizontal' | 'both';
+  responsive?: {
+    mobile?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+    tablet?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+    desktop?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string;
+  };
+}
+
+const spacerVariants = cva('', {
+  variants: {
+    size: {
+      xs: 'h-1 w-1',
+      sm: 'h-2 w-2',
+      md: 'h-4 w-4',
+      lg: 'h-6 w-6',
+      xl: 'h-8 w-8',
+    },
+    direction: {
+      vertical: 'w-0',
+      horizontal: 'h-0',
+      both: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    direction: 'vertical',
+  },
+});
+
+const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
+  (
+    { className, size = 'md', direction = 'vertical', responsive, style, ...props },
+    ref
+  ) => {
+    const designTokenSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+    const responsiveClasses: string[] = [];
+    if (responsive) {
+      if (responsive.mobile && designTokenSizes.includes(responsive.mobile as string)) {
+        responsiveClasses.push(spacerVariants({ size: responsive.mobile as any, direction }));
+      }
+      if (responsive.tablet && designTokenSizes.includes(responsive.tablet as string)) {
+        responsiveClasses.push(
+          `sm:${spacerVariants({ size: responsive.tablet as any, direction })}`
+        );
+      }
+      if (responsive.desktop && designTokenSizes.includes(responsive.desktop as string)) {
+        responsiveClasses.push(
+          `md:${spacerVariants({ size: responsive.desktop as any, direction })}`
+        );
+      }
+    }
+
+    const isCustomSize = size && !designTokenSizes.includes(size as string);
+    const dynamicStyle: React.CSSProperties = { ...style };
+
+    if (isCustomSize) {
+      const value =
+        typeof size === 'number'
+          ? `${size}px`
+          : /^\d+$/.test(size as string)
+          ? `${size}px`
+          : size;
+
+      if (direction === 'vertical') {
+        dynamicStyle.height = value;
+        dynamicStyle.width = 0;
+      } else if (direction === 'horizontal') {
+        dynamicStyle.width = value;
+        dynamicStyle.height = 0;
+      } else {
+        dynamicStyle.height = value;
+        dynamicStyle.width = value;
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          !isCustomSize && spacerVariants({ size: size as any, direction }),
+          responsiveClasses,
+          className
+        )}
+        style={dynamicStyle}
+        aria-hidden="true"
+        {...props}
+      />
+    );
+  }
+);
+
+Spacer.displayName = 'Spacer';
+
+export { Spacer, spacerVariants };

--- a/packages/registry/components/spacer/index.tsx
+++ b/packages/registry/components/spacer/index.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../../utils/cn';
+
+export interface SpacerProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof spacerVariants> {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' ;
+  direction?: 'vertical' | 'horizontal' | 'both';
+}
+
+const spacerVariants = cva('', {
+  variants: {
+    size: {
+      xs: 'h-1 w-1',
+      sm: 'h-2 w-2',
+      md: 'h-4 w-4',
+      lg: 'h-6 w-6',
+      xl: 'h-8 w-8',
+    },
+    direction: {
+      vertical: 'w-0',
+      horizontal: 'h-0',
+      both: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    direction: 'vertical',
+  },
+});
+
+const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
+  ({ className, size, direction, style, ...props }, ref) => {
+    // Handle custom numeric/string size (e.g., "12px", "2rem", "20")
+    const isCustomSize =
+      size && !['xs', 'sm', 'md', 'lg', 'xl'].includes(size);
+
+    const dynamicStyle: React.CSSProperties = { ...style };
+    if (isCustomSize) {
+      const value = /^\d+$/.test(size as string) ? `${size}px` : size;
+      if (direction === 'vertical') dynamicStyle.height = value;
+      else if (direction === 'horizontal') dynamicStyle.width = value;
+      else {
+        dynamicStyle.height = value;
+        dynamicStyle.width = value;
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(spacerVariants({ size, direction }), className)}
+        style={dynamicStyle}
+        aria-hidden="true"
+        {...props}
+      />
+    );
+  }
+);
+
+Spacer.displayName = 'Spacer';
+
+export { Spacer, spacerVariants };

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -199,6 +199,17 @@
         }
       }
     },
+    "spacer": {
+      "name": "Spacer",
+      "description": "A utility component that provides adjustable spacing between elements without adding extra visual content.",
+      "dependencies": ["class-variance-authority"],
+      "files": {
+        "main": {
+          "path": "components/layout/spacer/index.tsx",
+          "type": "component"
+        }
+      }
+    },
     "steppers": {
       "name": "Steppers",
       "description": "An animated steppers component with different variants",


### PR DESCRIPTION
## Spacer component
---

## Description

### What does this PR do?

This PR extends the `<Spacer>` component to support **responsive spacing** across breakpoints (`mobile`, `tablet`, and `desktop`).  
Previously, the component only handled fixed `size` values. Now, developers can define responsive spacing behavior, ensuring consistent layout across different screen sizes.

Key changes include:
- Added a new `responsive` prop to accept spacing values for `mobile`, `tablet`, and `desktop`.
- Integrated Tailwind responsive utilities (`sm:`, `md:`) for breakpoint-based spacing.
- Maintained support for both **design token sizes** (`xs`, `sm`, `md`, `lg`, `xl`) and **custom values** (numbers or strings like `"24px"`).
- Improved flexibility while preserving the existing API (`size` and `direction`).

- Closes #206 

## Type of Change

- [x] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
