### PR TITLE
Fix/layout/lazyload

### DIFF
--- a/apps/docs/src/components/Demo/LazyloadDemo.tsx
+++ b/apps/docs/src/components/Demo/LazyloadDemo.tsx
@@ -8,7 +8,7 @@ import CodeBlock from "@theme/CodeBlock";
 const LazyLoadDemo = () => {
   const [threshold, setThreshold] = useState("0px");
   const [animation, setAnimation] = useState("fade");
-  const [once, setOnce] = useState(true);
+  const [once, setOnce] = useState(false);
 
   const thresholds = ["0px", "100px", "200px", "400px"];
   const animations = ["none", "fade", "slide"];

--- a/apps/docs/src/components/Demo/LazyloadDemo.tsx
+++ b/apps/docs/src/components/Demo/LazyloadDemo.tsx
@@ -1,103 +1,94 @@
 import React, { useState } from "react";
-import { LazyLoad } from "../UI/lazyload";
+import {LazyLoad} from "@site/src/components/UI/lazyload";
+import VariantSelector from "./VariantSelector";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
 
-const LazyloadDemo: React.FC = () => {
-  const [threshold, setThreshold] = useState("100px");
-  const [animation, setAnimation] = useState<"fade" | "slide" | "none">("fade");
+const LazyLoadDemo = () => {
+  const [threshold, setThreshold] = useState("0px");
+  const [animation, setAnimation] = useState("fade");
   const [once, setOnce] = useState(true);
+
+  const thresholds = ["0px", "100px", "200px", "400px"];
+  const animations = ["none", "fade", "slide"];
+  const onceOptions = ["true", "false"];
+
+  const colors = [
+    "bg-blue-600 p-12",
+    "bg-green-600 p-20",
+    "bg-pink-600 p-16",
+    "bg-purple-600 p-24",
+    "bg-yellow-600 p-14",
+  ];
 
   const codeString = `
 <LazyLoad 
-  threshold="${threshold}" 
-  animation="${animation}" 
+  threshold="${threshold}"
+  animation="${animation}"
   once={${once}}
-  placeholder={<div style={{ height: "200px", background: "#eee" }}>Loading...</div>}
+  placeholder={<div className="p-6 text-center">Loading...</div>}
 >
-  <div style={{
-    height: "200px", 
-    background: "#ccc", 
-    display: "flex", 
-    justifyContent: "center", 
-    alignItems: "center"
-  }}>
-    Loaded Content
+  <div className="bg-gray-200 rounded-lg shadow text-center p-10">
+    Your Content
   </div>
 </LazyLoad>
 `;
 
   return (
     <div className="space-y-6 mb-8">
-      {/* Variant selectors */}
-      <div className="flex flex-wrap gap-4 justify-start sm:justify-end">
-        {/* Threshold */}
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">Threshold</label>
-          <input
-            type="text"
-            value={threshold}
-            onChange={(e) => setThreshold(e.target.value)}
-            className="border rounded px-2 py-1 text-sm"
-          />
-        </div>
-
-        {/* Animation */}
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">Animation</label>
-          <select
-            value={animation}
-            onChange={(e) => setAnimation(e.target.value as "fade" | "slide" | "none")}
-            className="border rounded px-2 py-1 text-sm"
-          >
-            <option value="fade">Fade</option>
-            <option value="slide">Slide</option>
-            <option value="none">None</option>
-          </select>
-        </div>
-
-        {/* Once */}
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">Load Once</label>
-          <input
-            type="checkbox"
-            checked={once}
-            onChange={(e) => setOnce(e.target.checked)}
-            className="border rounded px-2 py-1 text-sm"
-          />
-        </div>
+      {/* Uniform controls */}
+      <div className="flex flex-wrap gap-6 justify-start sm:justify-end">
+        <VariantSelector
+          variants={thresholds}
+          selectedVariant={threshold}
+          onSelectVariant={setThreshold}
+          type="Threshold"
+        />
+        <VariantSelector
+          variants={animations}
+          selectedVariant={animation}
+          onSelectVariant={setAnimation}
+          type="Animation"
+        />
+        <VariantSelector
+          variants={onceOptions}
+          selectedVariant={String(once)}
+          onSelectVariant={(val) => setOnce(val === "true")}
+          type="Once"
+        />
       </div>
 
       {/* Tabs for preview/code */}
       <Tabs>
         <TabItem value="preview" label="Preview">
-          <div className="border p-6 rounded-lg">
-            <LazyLoad
-              threshold={threshold}
-              animation={animation}
-              once={once}
-              placeholder={<div style={{ height: "200px", background: "#eee" }}>Loading...</div>}
-            >
-              <div
-                style={{
-                  height: "200px",
-                  background: "#ccc",
-                  display: "flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                }}
+          <div className="border p-6 rounded-lg space-y-6">
+            {colors.map((color, i) => (
+              <LazyLoad
+                key={`${animation}-${threshold}-${once}-${i}`}
+                threshold={threshold}
+                animation={animation as "fade" | "slide" | "none"}
+                once={once}
+                placeholder={
+                  <div className="p-6 text-center bg-gray-100 rounded-lg shadow">
+                    Loading...
+                  </div>
+                }
               >
-                Loaded Content
-              </div>
-            </LazyLoad>
+                <div
+                  className={`${color} text-white rounded-lg shadow-md text-center`}
+                >
+                  Item {i + 1}
+                </div>
+              </LazyLoad>
+            ))}
           </div>
         </TabItem>
 
         <TabItem value="code" label="Code">
           <div className="mt-4">
             <CodeBlock language="tsx" className="text-sm">
-              {codeString.trim()}
+              {codeString}
             </CodeBlock>
           </div>
         </TabItem>
@@ -106,4 +97,4 @@ const LazyloadDemo: React.FC = () => {
   );
 };
 
-export default LazyloadDemo;
+export default LazyLoadDemo;

--- a/apps/docs/src/components/UI/lazyload/index.tsx
+++ b/apps/docs/src/components/UI/lazyload/index.tsx
@@ -1,62 +1,63 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export interface LazyLoadProps {
   children: React.ReactNode;
   className?: string;
-  threshold?: string; // Distance from viewport to trigger loading
-  placeholder?: React.ReactNode; // Placeholder content
-  once?: boolean; // Load only once
-  animation?: "fade" | "slide" | "none"; // Animation type
+  threshold?: string; // e.g. "100px"
+  placeholder?: React.ReactNode;
+  once?: boolean;
+  animation?: "fade" | "slide" | "none";
 }
 
 export const LazyLoad: React.FC<LazyLoadProps> = ({
   children,
   className,
-  threshold = "100px",
+  threshold = "0px",
   placeholder = null,
   once = true,
-  animation = "fade",
+  animation = "none",
 }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
   const [isVisible, setIsVisible] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!ref.current) return;
+
     const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-          if (once) observer.disconnect(); // Stop observing if `once` is true
-        }
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            if (once) {
+              observer.disconnect(); // unobserve after first load
+            }
+          } else if (!once) {
+            setIsVisible(false); // re-hide if once=false
+          }
+        });
       },
       { rootMargin: threshold }
     );
 
-    if (containerRef.current) {
-      observer.observe(containerRef.current);
-    }
+    observer.observe(ref.current);
 
-    return () => {
-      if (containerRef.current) observer.unobserve(containerRef.current);
-    };
+    return () => observer.disconnect();
   }, [threshold, once]);
 
-  const getAnimationStyle = () => {
-    switch (animation) {
-      case "fade":
-        return { opacity: isVisible ? 1 : 0, transition: "opacity 0.5s ease" };
-      case "slide":
-        return {
-          transform: isVisible ? "translateY(0)" : "translateY(20px)",
-          opacity: isVisible ? 1 : 0,
-          transition: "transform 0.5s ease, opacity 0.5s ease",
-        };
-      default:
-        return {};
-    }
-  };
+  // Animation classes
+  const animationClass =
+    animation === "fade"
+      ? "transition-opacity duration-700 ease-in-out opacity-0 data-[visible=true]:opacity-100"
+      : animation === "slide"
+      ? "transition-transform duration-700 ease-in-out translate-y-4 opacity-0 data-[visible=true]:translate-y-0 data-[visible=true]:opacity-100"
+      : "";
 
   return (
-    <div ref={containerRef} className={className} style={getAnimationStyle()}>
+    <div
+      ref={ref}
+      className={`${className ?? ""} ${animationClass}`}
+      data-visible={isVisible}
+    >
       {isVisible ? children : placeholder}
     </div>
   );

--- a/apps/docs/versioned_docs/version-1.0.2/layouts/lazyload.mdx
+++ b/apps/docs/versioned_docs/version-1.0.2/layouts/lazyload.mdx
@@ -38,77 +38,74 @@ This improves initial page load times and enhances performance.
     ```
   </TabItem>
 
-  <TabItem value="manual" label="manual" className="max-h-[500px] overflow-y-auto">
+  <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
 
     ```tsx
-      import React, { useEffect, useState, useRef } from "react";
+    import React, { useEffect, useState, useRef } from "react";
 
-export interface LazyLoadProps {
-  children: React.ReactNode;
-  className?: string;
-  threshold?: string; // Distance from viewport to trigger loading
-  placeholder?: React.ReactNode; // Placeholder content
-  once?: boolean; // Load only once
-  animation?: "fade" | "slide" | "none"; // Animation type
-}
+    export interface LazyLoadProps {
+      children: React.ReactNode;
+      className?: string;
+      threshold?: string; // Distance from viewport to trigger loading
+      placeholder?: React.ReactNode; // Placeholder content
+      once?: boolean; // Load only once
+      animation?: "fade" | "slide" | "none"; // Animation type
+    }
 
-export const LazyLoad: React.FC<LazyLoadProps> = ({
-  children,
-  className,
-  threshold = "100px",
-  placeholder = null,
-  once = true,
-  animation = "fade",
-}) => {
-  const [isVisible, setIsVisible] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+    export const LazyLoad: React.FC<LazyLoadProps> = ({
+      children,
+      className,
+      threshold = "100px",
+      placeholder = null,
+      once = true,
+      animation = "fade",
+    }) => {
+      const [isVisible, setIsVisible] = useState(false);
+      const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-          if (once) observer.disconnect(); // Stop observing if `once` is true
+      useEffect(() => {
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (entry.isIntersecting) {
+              setIsVisible(true);
+              if (once) observer.disconnect(); // Stop observing if `once` is true
+            }
+          },
+          { rootMargin: threshold }
+        );
+
+        if (containerRef.current) {
+          observer.observe(containerRef.current);
         }
-      },
-      { rootMargin: threshold }
-    );
 
-    if (containerRef.current) {
-      observer.observe(containerRef.current);
-    }
-
-    return () => {
-      if (containerRef.current) observer.unobserve(containerRef.current);
-    };
-  }, [threshold, once]);
-
-  const getAnimationStyle = () => {
-    switch (animation) {
-      case "fade":
-        return { opacity: isVisible ? 1 : 0, transition: "opacity 0.5s ease" };
-      case "slide":
-        return {
-          transform: isVisible ? "translateY(0)" : "translateY(20px)",
-          opacity: isVisible ? 1 : 0,
-          transition: "transform 0.5s ease, opacity 0.5s ease",
+        return () => {
+          if (containerRef.current) observer.unobserve(containerRef.current);
         };
-      default:
-        return {};
-    }
-  };
+      }, [threshold, once]);
 
-  return (
-    <div ref={containerRef} className={className} style={getAnimationStyle()}>
-      {isVisible ? children : placeholder}
-    </div>
-  );
-};
+      const getAnimationStyle = () => {
+        switch (animation) {
+          case "fade":
+            return { opacity: isVisible ? 1 : 0, transition: "opacity 0.5s ease" };
+          case "slide":
+            return {
+              transform: isVisible ? "translateY(0)" : "translateY(20px)",
+              opacity: isVisible ? 1 : 0,
+              transition: "transform 0.5s ease, opacity 0.5s ease",
+            };
+          default:
+            return {};
+        }
+      };
 
-
+      return (
+        <div ref={containerRef} className={className} style={getAnimationStyle()}>
+          {isVisible ? children : placeholder}
+        </div>
+      );
+    };
     ```
   </TabItem>
-
 </Tabs>
 
 ## Usage
@@ -118,6 +115,8 @@ Import the component:
 ```tsx
 import { LazyLoad } from './components/ui';
 ```
+
+Example usage:
 
 ```tsx
 <LazyLoad 
@@ -129,3 +128,14 @@ import { LazyLoad } from './components/ui';
   <HeavyContent />
 </LazyLoad>
 ```
+
+## Props
+
+| Prop        | Type                         | Default     | Description |
+|-------------|------------------------------|-------------|-------------|
+| `children`  | `React.ReactNode`            | **required** | The content to lazy load. |
+| `className` | `string`                     | `""`        | Custom CSS class names. |
+| `threshold` | `string`                     | `"100px"`   | Distance from the viewport to start loading (e.g., `"0px"`, `"200px"`). |
+| `placeholder` | `React.ReactNode`          | `null`      | Placeholder shown until the content is loaded. |
+| `once`      | `boolean`                    | `true`      | If true, content loads only once. If false, it toggles visibility when entering/exiting viewport. |
+| `animation` | `"fade"` \| `"slide"` \| `"none"` | `"fade"` | Animation effect applied when content appears. |

--- a/apps/docs/versioned_docs/version-1.0.2/layouts/lazyload.mdx
+++ b/apps/docs/versioned_docs/version-1.0.2/layouts/lazyload.mdx
@@ -41,69 +41,71 @@ This improves initial page load times and enhances performance.
   <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
 
     ```tsx
-    import React, { useEffect, useState, useRef } from "react";
+    import React, { useEffect, useRef, useState } from "react";
 
-    export interface LazyLoadProps {
-      children: React.ReactNode;
-      className?: string;
-      threshold?: string; // Distance from viewport to trigger loading
-      placeholder?: React.ReactNode; // Placeholder content
-      once?: boolean; // Load only once
-      animation?: "fade" | "slide" | "none"; // Animation type
-    }
+export interface LazyLoadProps {
+  children: React.ReactNode;
+  className?: string;
+  threshold?: string; // e.g. "100px"
+  placeholder?: React.ReactNode;
+  once?: boolean;
+  animation?: "fade" | "slide" | "none";
+}
 
-    export const LazyLoad: React.FC<LazyLoadProps> = ({
-      children,
-      className,
-      threshold = "100px",
-      placeholder = null,
-      once = true,
-      animation = "fade",
-    }) => {
-      const [isVisible, setIsVisible] = useState(false);
-      const containerRef = useRef<HTMLDivElement>(null);
+export const LazyLoad: React.FC<LazyLoadProps> = ({
+  children,
+  className,
+  threshold = "0px",
+  placeholder = null,
+  once = true,
+  animation = "none",
+}) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
 
-      useEffect(() => {
-        const observer = new IntersectionObserver(
-          ([entry]) => {
-            if (entry.isIntersecting) {
-              setIsVisible(true);
-              if (once) observer.disconnect(); // Stop observing if `once` is true
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            if (once) {
+              observer.disconnect(); // unobserve after first load
             }
-          },
-          { rootMargin: threshold }
-        );
+          } else if (!once) {
+            setIsVisible(false); // re-hide if once=false
+          }
+        });
+      },
+      { rootMargin: threshold }
+    );
 
-        if (containerRef.current) {
-          observer.observe(containerRef.current);
-        }
+    observer.observe(ref.current);
 
-        return () => {
-          if (containerRef.current) observer.unobserve(containerRef.current);
-        };
-      }, [threshold, once]);
+    return () => observer.disconnect();
+  }, [threshold, once]);
 
-      const getAnimationStyle = () => {
-        switch (animation) {
-          case "fade":
-            return { opacity: isVisible ? 1 : 0, transition: "opacity 0.5s ease" };
-          case "slide":
-            return {
-              transform: isVisible ? "translateY(0)" : "translateY(20px)",
-              opacity: isVisible ? 1 : 0,
-              transition: "transform 0.5s ease, opacity 0.5s ease",
-            };
-          default:
-            return {};
-        }
-      };
+  // Animation classes
+  const animationClass =
+    animation === "fade"
+      ? "transition-opacity duration-700 ease-in-out opacity-0 data-[visible=true]:opacity-100"
+      : animation === "slide"
+      ? "transition-transform duration-700 ease-in-out translate-y-4 opacity-0 data-[visible=true]:translate-y-0 data-[visible=true]:opacity-100"
+      : "";
 
-      return (
-        <div ref={containerRef} className={className} style={getAnimationStyle()}>
-          {isVisible ? children : placeholder}
-        </div>
-      );
-    };
+  return (
+    <div
+      ref={ref}
+      className={`${className ?? ""} ${animationClass}`}
+      data-visible={isVisible}
+    >
+      {isVisible ? children : placeholder}
+    </div>
+  );
+};
+
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION


##  Pull Request Title
Fix: LazyLoad props handling and consistent variant selectors

---

##  Description

This PR fixes issues with the **LazyLoad** component where props (`threshold`, `once`, `animation`) were not working as expected.  

### Key Fixes
- Corrected `IntersectionObserver` configuration to properly respect `threshold` (`rootMargin`) values.  
- Ensured `once` prop correctly disconnects observer after first load.  
- Fixed `animation` styles (`fade` and `slide`) for smoother transitions.  
- Unified **variant selectors** (Threshold, Animation, Once) for consistent styling in `LazyloadDemo`.  
- Updated documentation with clear prop descriptions and usage examples.  

---


### Related Issues
- Closes #310 

##  Type of Change

- [x] 🐛 Bug fix  
- [x] 📄 Documentation update  
- [ ] 🚀 New feature  
- [ ] ⚙️ Code refactoring  
- [ ] 🔧 Configuration / CI/CD change  
- [ ] 🧹 Maintenance / dependency update  

---

##  Checklist

- [x] Fixed props handling in `LazyLoad` component  
- [x] Updated `LazyloadDemo` with uniform variant selectors  
- [x] Verified lazy loading works correctly (tested with scroll)  
- [x] Updated MDX documentation with prop table  
- [x] Verified animations work (`fade`, `slide`, `none`)  

---

## Screenshots 
<img width="1912" height="889" alt="image" src="https://github.com/user-attachments/assets/e07e255c-b970-4849-9540-868f7c04a5f3" />



### Before  
Props (`threshold`, `once`, `animation`) not applied correctly; inconsistent variant selector styling.  

### After  
-  Threshold working correctly  
-  `once` disconnects observer  
- Animations working as expected  
-  Variant selectors styled uniformly  

---

## Additional Context
This PR improves **performance optimization** for deferred loading of off-screen content and ensures the component is production-ready.  
