### PR TITLE
Fix/registry

### DIFF
--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -546,46 +546,46 @@
           "path": "components/DebugBox/index.tsx",
           "type": "component"
         }
-      },
-      "header-layout": {
-        "name": "HeaderLayout",
-        "description": "A flexible layout component with header, sidebar, and footer that supports responsive design and various configuration options.",
-        "dependencies": [
-          "framer-motion",
-          "lucide-react",
-          "class-variance-authority"
-        ],
-        "files": {
-          "main": {
-            "path": "components/layouts/header-layout/index.tsx",
-            "type": "component"
-          }
+      }
+    },
+    "header-layout": {
+      "name": "HeaderLayout",
+      "description": "A flexible layout component with header, sidebar, and footer that supports responsive design and various configuration options.",
+      "dependencies": [
+        "framer-motion",
+        "lucide-react",
+        "class-variance-authority"
+      ],
+      "files": {
+        "main": {
+          "path": "components/layouts/header-layout/index.tsx",
+          "type": "component"
         }
-      },
-      "drawer": {
-        "name": "Drawer",
-        "description": "A drawer component with animation and different variants",
-        "dependencies": [
-          "framer-motion",
-          "lucide-react",
-          "class-variance-authority"
-        ],
-        "files": {
-          "main": {
-            "path": "components/drawer/index.tsx",
-            "type": "component"
-          }
+      }
+    },
+    "drawer": {
+      "name": "Drawer",
+      "description": "A drawer component with animation and different variants",
+      "dependencies": [
+        "framer-motion",
+        "lucide-react",
+        "class-variance-authority"
+      ],
+      "files": {
+        "main": {
+          "path": "components/drawer/index.tsx",
+          "type": "component"
         }
-      },
-      "lazyload": {
-        "name": "Lazyload",
-        "description": "A layout component for  lazy loading is a strategy to identify resources as non-blocking (non-critical) and load these only when needed",
-        "dependencies": [],
-        "files": {
-          "main": {
-            "path": "components/layouts/lazyload/index.tsx",
-            "type": "component"
-          }
+      }
+    },
+    "lazyload": {
+      "name": "Lazyload",
+      "description": "A layout component for lazy loading...",
+      "dependencies": [],
+      "files": {
+        "main": {
+          "path": "components/layouts/lazyload/index.tsx",
+          "type": "component"
         }
       }
     }


### PR DESCRIPTION
## Pull Request Title

**Fix: Invalid registry format error in component registry structure**

---

## Description

### What does this PR do?

This PR fixes a bug in the Ignix UI component registry where certain components (`header-layout`, `drawer`, and `lazyload`) were nested inside the `DebugBox` object instead of being defined at the top level under `"components"`.  

The incorrect nested structure was causing the CLI command:

```bash
npx @mindfiredigital/ignix-ui add center
```

to fail with the error:

```
Registry error: Invalid registry format
```

### Related Issues

- Closes #344 

---

## Type of Change

- [x] 🐛 Bug fix  
- [ ] 🚀 New feature  
- [ ] 📄 Documentation update  
- [ ] ⚙️ Code refactoring  
- [ ] 🔧 Configuration or CI/CD change  
- [ ] 🧹 Maintenance or dependency update  

---

## Checklist

- [x] I have linted my code using `npm run lint`  
- [x] I have updated the registry JSON structure correctly  
- [x] I have verified that `npx @mindfiredigital/ignix-ui add center` now works  
- [ ] I have added or updated tests for the changes in this PR  
- [ ] I have updated documentation as needed  

---

## Screenshots
<img width="1259" height="635" alt="image" src="https://github.com/user-attachments/assets/5e487e56-ea87-443e-9961-d878a9dd4bcf" />



---

## Additional Context

_The bug was caused by nested component definitions in the registry. Flattening the JSON fixes the CLI registry parsing issue._