### PR TITLE
fix(cli): fix the key of app-shell in the registry

### DIFF
--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -131,7 +131,7 @@
         }
       }
     },
-    "appShell": {
+    "app-shell": {
       "name": "AppShell",
       "description": "A high-level layout component that structures the entire application frame, providing responsive navigation (side, top, or drawer), brand placement, user profile integration, and optional footer support.",
       "dependencies": [


### PR DESCRIPTION
## Pull Request Title

**[BUG]: Fix key error in registry for AppShell component**

---

## Description

### What does this PR do?

This PR fixes a **key error in the registry configuration** where the component key was incorrectly listed as `appShell` instead of `app-shell`.  
The incorrect key was causing registry resolution and component fetching to fail.

### Related Issues

- Closes #344 

## Type of Change

- [x] 🐛 Bug fix  
- [ ] 🚀 New feature  
- [ ] 📄 Documentation update  
- [ ] ⚙️ Code refactoring  
- [ ] 🔧 Configuration or CI/CD change  
- [ ] 🧹 Maintenance or dependency update  

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.  
- [x] I have verified the fix resolves the registry key mismatch.  
- [ ] I have updated related documentation if necessary.  
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).  

## Screenshots

<img width="1338" height="272" alt="image" src="https://github.com/user-attachments/assets/716cb989-0075-4ab3-a932-e22e77a9fde8" />

## Additional Context

This fix corrects the registry key naming convention to match the expected kebab-case (`app-shell`).  
It ensures consistent component resolution and prevents registry lookup failures during `npx ignix-ui add` commands.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._
