### PR TITLE
Fix/layout-spacer component

### DIFF
--- a/apps/storybook/src/components/layouts/spacer/spacer.stories.tsx
+++ b/apps/storybook/src/components/layouts/spacer/spacer.stories.tsx
@@ -3,7 +3,7 @@ import { Spacer } from '.';
 import React from 'react';
 
 const meta = {
-  title: 'Components/Spacer',
+  title: 'Layouts/Spacer',
   component: Spacer,
   tags: ['autodocs'],
   parameters: {

--- a/packages/registry/components/layouts/spacer/spacer.test.tsx
+++ b/packages/registry/components/layouts/spacer/spacer.test.tsx
@@ -30,35 +30,35 @@ describe("Spacer", () => {
   });
 
   describe("token sizes — horizontal direction", () => {
-    it("horizontal direction applies w-0 alongside height class", () => {
+    it("horizontal direction applies h-0 alongside height class", () => {
       const { container } = render(<Spacer size="md" direction="horizontal" />);
       expect(container.firstChild).toHaveClass("h-0");
     });
   });
 
-describe("custom sizes", () => {
-  it("applies inline height for custom string size (vertical)", () => {
-    const { container } = render(<Spacer size={"48px" as any} direction="vertical" />);
-    expect(container.firstChild).toHaveStyle({ height: "48px" });
-    expect(container.firstChild).not.toHaveStyle({ width: "48px" });
-  });
+  describe("custom sizes", () => {
+    it("applies inline height for custom string size (vertical)", () => {
+      const { container } = render(<Spacer size={"48px" as any} direction="vertical" />);
+      expect(container.firstChild).toHaveStyle({ height: "48px" });
+      expect(container.firstChild).not.toHaveStyle({ width: "48px" });
+    });
 
-  it("applies inline width for custom string size (horizontal)", () => {
-    const { container } = render(<Spacer size={"2rem" as any} direction="horizontal" />);
-    expect(container.firstChild).toHaveStyle({ width: "2rem" });
-    expect(container.firstChild).not.toHaveStyle({ height: "2rem" });
-  });
+    it("applies inline width for custom string size (horizontal)", () => {
+      const { container } = render(<Spacer size={"2rem" as any} direction="horizontal" />);
+      expect(container.firstChild).toHaveStyle({ width: "2rem" });
+      expect(container.firstChild).not.toHaveStyle({ height: "2rem" });
+    });
 
-  it("applies both dimensions for direction='both'", () => {
-    const { container } = render(<Spacer size={"32px" as any} direction="both" />);
-    expect(container.firstChild).toHaveStyle({ height: "32px", width: "32px" });
-  });
+    it("applies both dimensions for direction='both'", () => {
+      const { container } = render(<Spacer size={"32px" as any} direction="both" />);
+      expect(container.firstChild).toHaveStyle({ height: "32px", width: "32px" });
+    });
 
-  it("converts bare numeric string to px", () => {
-    const { container } = render(<Spacer size={"16" as any} direction="vertical" />);
-    expect(container.firstChild).toHaveStyle({ height: "16px" });
+    it("converts bare numeric string to px", () => {
+      const { container } = render(<Spacer size={"16" as any} direction="vertical" />);
+      expect(container.firstChild).toHaveStyle({ height: "16px" });
+    });
   });
-});
 
   describe("custom className", () => {
     it("merges custom className", () => {

--- a/packages/registry/components/layouts/spacer/spacer.test.tsx
+++ b/packages/registry/components/layouts/spacer/spacer.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import "@testing-library/jest-dom";
+import { Spacer } from ".";
+
+describe("Spacer", () => {
+  describe("aria", () => {
+    it("is hidden from assistive technology", () => {
+      const { container } = render(<Spacer />);
+      expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("token sizes — vertical direction", () => {
+    const cases = [
+      { size: "xs" as const, expectedClass: "h-1" },
+      { size: "sm" as const, expectedClass: "h-2" },
+      { size: "md" as const, expectedClass: "h-4" },
+      { size: "lg" as const, expectedClass: "h-6" },
+      { size: "xl" as const, expectedClass: "h-8" },
+    ];
+
+    cases.forEach(({ size, expectedClass }) => {
+      it(`size="${size}" applies ${expectedClass}`, () => {
+        const { container } = render(<Spacer size={size} direction="vertical" />);
+        expect(container.firstChild).toHaveClass(expectedClass);
+      });
+    });
+  });
+
+  describe("token sizes — horizontal direction", () => {
+    it("horizontal direction applies w-0 alongside height class", () => {
+      const { container } = render(<Spacer size="md" direction="horizontal" />);
+      expect(container.firstChild).toHaveClass("h-0");
+    });
+  });
+
+describe("custom sizes", () => {
+  it("applies inline height for custom string size (vertical)", () => {
+    const { container } = render(<Spacer size={"48px" as any} direction="vertical" />);
+    expect(container.firstChild).toHaveStyle({ height: "48px" });
+    expect(container.firstChild).not.toHaveStyle({ width: "48px" });
+  });
+
+  it("applies inline width for custom string size (horizontal)", () => {
+    const { container } = render(<Spacer size={"2rem" as any} direction="horizontal" />);
+    expect(container.firstChild).toHaveStyle({ width: "2rem" });
+    expect(container.firstChild).not.toHaveStyle({ height: "2rem" });
+  });
+
+  it("applies both dimensions for direction='both'", () => {
+    const { container } = render(<Spacer size={"32px" as any} direction="both" />);
+    expect(container.firstChild).toHaveStyle({ height: "32px", width: "32px" });
+  });
+
+  it("converts bare numeric string to px", () => {
+    const { container } = render(<Spacer size={"16" as any} direction="vertical" />);
+    expect(container.firstChild).toHaveStyle({ height: "16px" });
+  });
+});
+
+  describe("custom className", () => {
+    it("merges custom className", () => {
+      const { container } = render(<Spacer className="my-spacer" />);
+      expect(container.firstChild).toHaveClass("my-spacer");
+    });
+  });
+
+  describe("forwarded ref and props", () => {
+    it("forwards extra HTML attributes", () => {
+      render(<Spacer data-testid="spacer" />);
+      expect(screen.getByTestId("spacer")).toBeInTheDocument();
+    });
+
+    it("forwards ref to the underlying div", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<Spacer ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Title

Fixes issue #647 - add storybook stories for layout/spacer component

---

## Description

### What does this PR do?

- Adds storybook stories for layout/spacer component
- Adds unit test cases for layout/spacer component

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #ISSUE_NUMBER (if applicable)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [x] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## New components or component API changes
- None

## Bug fixes
- None

## Tooling / config changes
- None

## Docs / Storybook updates
- Added Storybook stories for Spacer component (`apps/storybook/src/components/layouts/spacer/spacer.stories.tsx`) with six stories:
  - Playground: interactive controls for vertical/horizontal spacer between two blocks
  - AllSizes: vertical demonstration of token sizes (xs → xl)
  - AllSizesHorizontal: horizontal demonstration of token sizes
  - DirectionComparison: side-by-side comparison of vertical, horizontal, and both directions
  - CustomSize: demonstrates non-token sizes (e.g., "20px", "2rem", numeric values)
  - Accessibility: shows spacer used in a list context with aria-hidden="true"
- Included helper components in stories: Block (labeled endpoints) and SpacerDebug (visual overlay background)
- Adjusted existing Spacer story metadata (`apps/storybook/src/components/spacer/spacer.stories.tsx`): title changed from "Layouts/Spacer" to "Components/Spacer"

## Tests
- Added unit tests for Spacer (`packages/registry/components/layouts/spacer/spacer.test.tsx`) covering:
  - aria-hidden="true" on the root element
  - token sizes (xs–xl) mapping to expected Tailwind height classes for vertical direction
  - horizontal direction sizing behavior (includes h-0)
  - custom size strings applying inline height/width; numeric strings converted to pixels
  - merging of className
  - forwarding of arbitrary HTML attributes and React ref

## Breaking changes
None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->