### PR TITLE
Fix/badge 775

### DIFF
--- a/apps/docs/src/components/Demo/BadgeDemo.tsx
+++ b/apps/docs/src/components/Demo/BadgeDemo.tsx
@@ -16,9 +16,16 @@ const BadgeDemo = () => {
   const codeString = `
 import { Badge } from '@ignix-ui/badge';
 
-<div className="relative inline-flex items-center">
-  <Mail className="h-6 w-6" />
-  <Badge text="3" type="${type}" variant="${variant}" />
+<div className="flex items-center gap-8 border rounded-lg p-4 mt-4">
+  <div className="relative inline-flex items-center">
+      <Badge mode="attached" text="3" type="${type}" variant="${variant}">
+      <Mail className="h-11 w-11" />
+    </Badge>
+  </div>
+  <div className="flex items-center gap-1">
+    <span className="text-lg font-medium">Notifications</span>
+    <Badge text="99+" type="${type}" variant="${variant}" />
+  </div>
 </div>
 `;
 
@@ -41,8 +48,13 @@ import { Badge } from '@ignix-ui/badge';
         <TabItem value="preview" label="Preview">
           <div className="flex items-center gap-8 border rounded-lg p-4 mt-4">
             <div className="relative inline-flex items-center">
-              <Mail className="h-11 w-11" />
-              <Badge text="3" type={type as any} variant={variant as any} />
+               <Badge mode="attached" text="3" type={type as any} variant={variant as any}>
+                <Mail className="h-11 w-11" />
+              </Badge>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="text-lg font-medium">Notifications</span>
+              <Badge text="99+" type={type as any} variant={variant as any}/>
             </div>
           </div>
         </TabItem>

--- a/apps/docs/src/components/UI/badge/index.tsx
+++ b/apps/docs/src/components/UI/badge/index.tsx
@@ -2,16 +2,24 @@ import React from "react";
 import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
-type BadgeMode = "inline" | "attached"
-
-interface BadgeProps {
+type BadgeBaseProps = {
   text?: string;
   type?: "primary" | "secondary" | "success" | "warning" | "error";
   variant?: "pulse" | "bounce" | "tinypop";
-  mode?: BadgeMode;
   className?: string;
-  children?: React.ReactNode;
-}
+};
+
+type InlineBadgeProps = BadgeBaseProps & {
+  mode?: "inline";
+  children?: never;
+};
+
+type AttachedBadgeProps = BadgeBaseProps & {
+  mode: "attached";
+  children: React.ReactNode;
+};
+
+type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,
@@ -24,7 +32,6 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -87,7 +94,6 @@ const Badge: React.FC<BadgeProps> = ({
   };
 
   const isAttached = mode === "attached";
-  const isInline = mode === "inline";
 
   // Base styles
   const baseStyles = cn(
@@ -95,9 +101,6 @@ const Badge: React.FC<BadgeProps> = ({
     "rounded-full font-bold tracking-tight",
     "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
 
-    isInline
-      ? "shadow-none ring-0"
-      : "shadow-lg ring-2",
     types[type],
     className
   );

--- a/apps/docs/src/components/UI/badge/index.tsx
+++ b/apps/docs/src/components/UI/badge/index.tsx
@@ -1,159 +1,139 @@
 import React from "react";
-import { motion, Variants} from "framer-motion";
+import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
+type BadgeMode = "inline" | "attached"
+
 interface BadgeProps {
-    text: string;
-    type?: "primary" | "secondary" | "success" | "warning" | "error";
-    variant?: "pulse" | "bounce" | "tinypop";
-    className?: string;
-    children?: React.ReactNode;
+  text?: string;
+  type?: "primary" | "secondary" | "success" | "warning" | "error";
+  variant?: "pulse" | "bounce" | "tinypop";
+  mode?: BadgeMode;
+  className?: string;
+  children?: React.ReactNode;
 }
 
 const Badge: React.FC<BadgeProps> = ({
-    text,
-    type = "primary",
-    className,
-    variant = "tinypop",
-    children
+  text,
+  type = "primary",
+  variant = "tinypop",
+  mode = "inline",
+  className,
+  children,
 }) => {
-    const types = {
-        primary: cn(
-            "bg-primary text-primary-foreground",
-            "shadow-lg shadow-primary/25",
-            "ring-2 ring-primary/20"
-        ),
-        secondary: cn(
-            "bg-secondary text-secondary-foreground",
-            "shadow-lg shadow-secondary/25",
-            "ring-2 ring-secondary/20"
-        ),
-        success: cn(
-            "bg-success text-success-foreground",
-            "shadow-lg shadow-success/25",
-            "ring-2 ring-success/20"
-        ),
-        warning: cn(
-            "bg-warning text-warning-foreground",
-            "shadow-lg shadow-warning/25",
-            "ring-2 ring-warning/30"
-        ),
-        error: cn(
-            "bg-destructive text-destructive-foreground",
-            "shadow-lg shadow-destructive/25",
-            "ring-2 ring-destructive/20"
-        ),
-    };
+  const types = {
+    primary: cn(
+      "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
+      "ring-2 ring-primary/20"
+    ),
+    secondary: cn(
+      "bg-secondary text-secondary-foreground",
+      "shadow-lg shadow-secondary/25",
+      "ring-2 ring-secondary/20"
+    ),
+    success: cn(
+      "bg-success text-success-foreground",
+      "shadow-lg shadow-success/25",
+      "ring-2 ring-success/20"
+    ),
+    warning: cn(
+      "bg-warning text-warning-foreground",
+      "shadow-lg shadow-warning/25",
+      "ring-2 ring-warning/30"
+    ),
+    error: cn(
+      "bg-destructive text-destructive-foreground",
+      "shadow-lg shadow-destructive/25",
+      "ring-2 ring-destructive/20"
+    ),
+  };
 
-    const getAnimationShadows = (type: string) => {
-        const shadowColors = {
-            primary: "var(--primary)",
-            secondary: "var(--secondary)",
-            success: "var(--success)",
-            warning: "var(--warning)",
-            error: "var(--destructive)",
-        };
-        return shadowColors[type as keyof typeof shadowColors] || shadowColors.primary;
-    };
-
-    const animationVariants:{'pulse': Variants, 'bounce': Variants, tinypop: Variants} = {
-        pulse: {
-            initial: {
-                scale: 1,
-                boxShadow: `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-            },
-            animate: {
-                scale: [1, 1.1, 1],
-                boxShadow: [
-                    `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-                    `0 0 0 8px rgba(${getAnimationShadows(type)}, 0.1)`,
-                    `0 0 0 12px rgba(${getAnimationShadows(type)}, 0)`
-                ],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                    times: [0, 0.5, 1]
-                },
-            },
+  const animationVariants: Record<string, Variants> = {
+    pulse: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.1, 1],
+        transition: {
+          duration: 2,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        bounce: {
-            initial: { 
-                y: 0,
-                opacity: 1,
-                rotate: 0,
-                scale: 1 
-            },
-            animate: {
-                y: [0, -70, 0, 50, 0, 0, 0],
-                rotate: [0, -5, 0, -2, 0, -1, 0],
-                scale: [1, 1.2, 0.95, 1.1, 0.98, 1.05, 1],
-                transition: {
-                    duration: 1.5,
-                    repeat: Infinity,
-                    repeatType: 'loop',
-                    ease: "easeOut",
-                    times: [0, 0.2, 0.4, 0.6, 0.75, 0.9, 1]
-                },
-            },
+      },
+    },
+    bounce: {
+      initial: { y: 0, scale: 1 },
+      animate: {
+        y: [0, -6, 0],
+        scale: [1, 1.15, 1],
+        transition: {
+          duration: 0.8,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        tinypop: {
-            initial: { scale: 1 },
-            animate: {
-                scale: [1, 1.5, 1],
-                rotate: [0, 2, -2, 0],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                    times: [0, 0.3, 1]
-                }
-            },           
-        }
-    };
+      },
+    },
+    tinypop: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.25, 1],
+        transition: {
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        },
+      },
+    },
+  };
 
+  const isAttached = mode === "attached";
+  const isInline = mode === "inline";
+
+  // Base styles
+  const baseStyles = cn(
+    "flex items-center justify-center",
+    "rounded-full font-bold tracking-tight",
+    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
+
+    isInline
+      ? "shadow-none ring-0"
+      : "shadow-lg ring-2",
+    types[type],
+    className
+  );
+
+  const positionStyles = isAttached
+    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
+    : "relative -top-2 sm:-top-2";
+
+  const badgeContent = (
+    <motion.div
+      variants={animationVariants[variant]}
+      initial="initial"
+      animate="animate"
+      className={cn(baseStyles, positionStyles)}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+    >
+    <span className="leading-none">{text}</span>
+
+    <div
+        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
+        aria-hidden="true"
+    />
+    </motion.div>
+  );
+
+  if (isAttached) {
     return (
-        <div className="relative inline-flex items-center">
-            {children}
-            <motion.div
-                variants={animationVariants[variant]}
-                initial="initial"
-                animate="animate"
-                className={cn(
-                    "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
-                    "min-w-2 h-2 sm:min-w-6 sm:h-6",
-                    "rounded-full flex items-center justify-center",
-                    "text-xs sm:text-sm font-bold tracking-tight",
-                    "backdrop-blur-sm",
-                    "border border-white/20 dark:border-black/20",
-                    "transition-all duration-200",
-                    "px-1.5 sm:px-2",
-                    "z-10",
-                    "hover:scale-105 active:scale-95",
-                    "hover:shadow-xl transition-transform duration-200",
-                    types[type],
-                    className
-                )}
-                whileHover={{ 
-                    scale: 1.05,
-                    transition: { duration: 0.2 }
-                }}
-                whileTap={{ 
-                    scale: 0.95,
-                    transition: { duration: 0.1 }
-                }}
-            >
-                <span className="relative z-10 leading-none">
-                    {text}
-                </span>
-                
-                <div 
-                    className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none" 
-                    aria-hidden="true"
-                />
-            </motion.div>
-        </div>
+      <div className="relative inline-flex items-center">
+        {children}
+        {badgeContent}
+      </div>
     );
+  }
+
+  return badgeContent;
 };
 
 Badge.displayName = "Badge";

--- a/apps/docs/src/components/UI/badge/index.tsx
+++ b/apps/docs/src/components/UI/badge/index.tsx
@@ -1,142 +1,143 @@
 import React from "react";
-import { motion, Variants } from "framer-motion";
+import { motion, type Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
 type BadgeBaseProps = {
-  text?: string;
-  type?: "primary" | "secondary" | "success" | "warning" | "error";
-  variant?: "pulse" | "bounce" | "tinypop";
-  className?: string;
+    text?: string;
+    type?: "primary" | "secondary" | "success" | "warning" | "error";
+    variant?: "pulse" | "bounce" | "tinypop";
+    className?: string;
 };
 
 type InlineBadgeProps = BadgeBaseProps & {
-  mode?: "inline";
-  children?: never;
+    mode?: "inline";
+    children?: never;
 };
 
 type AttachedBadgeProps = BadgeBaseProps & {
-  mode: "attached";
-  children: React.ReactNode;
+    mode: "attached";
+    children: React.ReactNode;
 };
 
 type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
-  text,
-  type = "primary",
-  variant = "tinypop",
-  mode = "inline",
-  className,
-  children,
+    text,
+    type = "primary",
+    variant = "tinypop",
+    mode = "inline",
+    className,
+    children,
 }) => {
-  const types = {
-    primary: cn(
-      "bg-primary text-primary-foreground",
-      "ring-2 ring-primary/20"
-    ),
-    secondary: cn(
-      "bg-secondary text-secondary-foreground",
-      "shadow-lg shadow-secondary/25",
-      "ring-2 ring-secondary/20"
-    ),
-    success: cn(
-      "bg-success text-success-foreground",
-      "shadow-lg shadow-success/25",
-      "ring-2 ring-success/20"
-    ),
-    warning: cn(
-      "bg-warning text-warning-foreground",
-      "shadow-lg shadow-warning/25",
-      "ring-2 ring-warning/30"
-    ),
-    error: cn(
-      "bg-destructive text-destructive-foreground",
-      "shadow-lg shadow-destructive/25",
-      "ring-2 ring-destructive/20"
-    ),
-  };
+    const types = {
+        primary: cn(
+            "bg-primary text-primary-foreground",
+            "shadow-lg shadow-primary/25",
+            "ring-2 ring-primary/20"
+        ),
+        secondary: cn(
+            "bg-secondary text-secondary-foreground",
+            "shadow-lg shadow-secondary/25",
+            "ring-2 ring-secondary/20"
+        ),
+        success: cn(
+            "bg-success text-success-foreground",
+            "shadow-lg shadow-success/25",
+            "ring-2 ring-success/20"
+        ),
+        warning: cn(
+            "bg-warning text-warning-foreground",
+            "shadow-lg shadow-warning/25",
+            "ring-2 ring-warning/30"
+        ),
+        error: cn(
+            "bg-destructive text-destructive-foreground",
+            "shadow-lg shadow-destructive/25",
+            "ring-2 ring-destructive/20"
+        ),
+    };
 
-  const animationVariants: Record<string, Variants> = {
-    pulse: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.1, 1],
-        transition: {
-          duration: 2,
-          repeat: Infinity,
-          ease: "easeOut",
+    const animationVariants: Record<string, Variants> = {
+        pulse: {
+            initial: { scale: 1 },
+            animate: {
+                scale: [1, 1.1, 1],
+                transition: {
+                    duration: 2,
+                    repeat: Infinity,
+                    ease: "easeOut",
+                },
+            },
         },
-      },
-    },
-    bounce: {
-      initial: { y: 0, scale: 1 },
-      animate: {
-        y: [0, -6, 0],
-        scale: [1, 1.15, 1],
-        transition: {
-          duration: 0.8,
-          repeat: Infinity,
-          ease: "easeOut",
+        bounce: {
+            initial: { y: 0, scale: 1 },
+            animate: {
+                y: [0, -6, 0],
+                scale: [1, 1.15, 1],
+                transition: {
+                    duration: 0.8,
+                    repeat: Infinity,
+                    ease: "easeOut",
+                },
+            },
         },
-      },
-    },
-    tinypop: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.25, 1],
-        transition: {
-          duration: 1.5,
-          repeat: Infinity,
-          ease: "easeInOut",
+        tinypop: {
+            initial: { scale: 1 },
+            animate: {
+                scale: [1, 1.25, 1],
+                transition: {
+                    duration: 1.5,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                },
+            },
         },
-      },
-    },
-  };
+    };
 
-  const isAttached = mode === "attached";
+    const isAttached = mode === "attached";
 
-  // Base styles
-  const baseStyles = cn(
-    "flex items-center justify-center",
-    "rounded-full font-bold tracking-tight",
-    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
+    // Base styles
+    const baseStyles = cn(
+        "flex items-center justify-center",
+        "rounded-full font-bold tracking-tight",
+        "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
 
-    types[type],
-    className
-  );
-
-  const positionStyles = isAttached
-    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
-    : "relative -top-2 sm:-top-2";
-
-  const badgeContent = (
-    <motion.div
-      variants={animationVariants[variant]}
-      initial="initial"
-      animate="animate"
-      className={cn(baseStyles, positionStyles)}
-      whileHover={{ scale: 1.05 }}
-      whileTap={{ scale: 0.95 }}
-    >
-    <span className="leading-none">{text}</span>
-
-    <div
-        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
-        aria-hidden="true"
-    />
-    </motion.div>
-  );
-
-  if (isAttached) {
-    return (
-      <div className="relative inline-flex items-center">
-        {children}
-        {badgeContent}
-      </div>
+        types[type],
+        className
     );
-  }
 
-  return badgeContent;
+    const positionStyles = isAttached
+        ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
+        : "relative -top-2 sm:-top-2";
+
+    const badgeContent = (
+        <motion.div
+            variants={animationVariants[variant]}
+            initial="initial"
+            animate="animate"
+            className={cn(baseStyles, positionStyles)}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+        >
+            <span className="leading-none">{text}</span>
+
+            <div
+                className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
+                aria-hidden="true"
+            />
+        </motion.div>
+    );
+
+    if (isAttached) {
+        return (
+            <div className="relative inline-flex items-center">
+                {children}
+                {badgeContent}
+            </div>
+        );
+    }
+
+    return badgeContent;
 };
 
 Badge.displayName = "Badge";

--- a/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
@@ -31,16 +31,24 @@ Badges are small status descriptors that can be used to highlight specific infor
 import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
-type BadgeMode = "inline" | "attached"
-
-interface BadgeProps {
+type BadgeBaseProps = {
   text?: string;
   type?: "primary" | "secondary" | "success" | "warning" | "error";
   variant?: "pulse" | "bounce" | "tinypop";
-  mode?: BadgeMode;
   className?: string;
-  children?: React.ReactNode;
-}
+};
+
+type InlineBadgeProps = BadgeBaseProps & {
+  mode?: "inline";
+  children?: never;
+};
+
+type AttachedBadgeProps = BadgeBaseProps & {
+  mode: "attached";
+  children: React.ReactNode;
+};
+
+type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,
@@ -53,7 +61,6 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -116,7 +123,6 @@ const Badge: React.FC<BadgeProps> = ({
   };
 
   const isAttached = mode === "attached";
-  const isInline = mode === "inline";
 
   // Base styles
   const baseStyles = cn(
@@ -124,9 +130,6 @@ const Badge: React.FC<BadgeProps> = ({
     "rounded-full font-bold tracking-tight",
     "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
 
-    isInline
-      ? "shadow-none ring-0"
-      : "shadow-lg ring-2",
     types[type],
     className
   );

--- a/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
@@ -15,43 +15,7 @@ import BadgeDemo from '@site/src/components/Demo/BadgeDemo';
 Badges are small status descriptors that can be used to highlight specific information, such as notification counts, status indicators, or labels. They can include text, numbers, or just a dot indicator.
 
 ## Preview
-
-<Tabs defaultValue="preview">
-  <TabItem value="preview" label="Preview" default>
-    <div className="flex items-center gap-8 border rounded-lg p-4">
-      <div className="relative inline-flex items-center">
-        <Mail className="h-11 w-11" />
-        <Badge text="3" type="primary" />
-      </div>
-      <div className="relative inline-flex items-center">
-        <span className="text-lg font-medium">Notifications</span>
-        <Badge text="99+" type="error" variant="pulse" />
-      </div>
-    </div>
-  </TabItem>
-  <TabItem value="code" label="Code">
-    ```tsx
-    import { Badge } from '@ignix-ui/badge';
-    import { Mail } from 'lucide-react';
-
-
-    function BadgeDemo() {
-      return (
-        <div className="flex items-center gap-8">
-          <div className="relative inline-flex items-center">
-            <Mail className="h-6 w-6" />
-            <Badge text="3" type="primary" />
-          </div>
-          <div className="relative inline-flex items-center">
-            <span className="text-lg font-medium">Notifications</span>
-            <Badge text="99+" type="error" variant="pulse" />
-          </div>
-        </div>
-      );
-    }
-    ```
-  </TabItem>
-</Tabs>
+<BadgeDemo />
 
 ## Installation
 
@@ -63,162 +27,142 @@ Badges are small status descriptors that can be used to highlight specific infor
   </TabItem>
   <TabItem value="manual" label="manual" className="max-h-[500px] overflow-y-auto">
     ```tsx
-    import React from "react";
-import { motion, Variants} from "framer-motion";
+  import React from "react";
+import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
+type BadgeMode = "inline" | "attached"
+
 interface BadgeProps {
-    text: string;
-    type?: "primary" | "secondary" | "success" | "warning" | "error";
-    variant?: "pulse" | "bounce" | "tinypop";
-    className?: string;
-    children?: React.ReactNode;
+  text?: string;
+  type?: "primary" | "secondary" | "success" | "warning" | "error";
+  variant?: "pulse" | "bounce" | "tinypop";
+  mode?: BadgeMode;
+  className?: string;
+  children?: React.ReactNode;
 }
 
 const Badge: React.FC<BadgeProps> = ({
-    text,
-    type = "primary",
-    className,
-    variant = "tinypop",
-    children
+  text,
+  type = "primary",
+  variant = "tinypop",
+  mode = "inline",
+  className,
+  children,
 }) => {
-    const types = {
-        primary: cn(
-            "bg-primary text-primary-foreground",
-            "shadow-lg shadow-primary/25",
-            "ring-2 ring-primary/20"
-        ),
-        secondary: cn(
-            "bg-secondary text-secondary-foreground",
-            "shadow-lg shadow-secondary/25",
-            "ring-2 ring-secondary/20"
-        ),
-        success: cn(
-            "bg-success text-success-foreground",
-            "shadow-lg shadow-success/25",
-            "ring-2 ring-success/20"
-        ),
-        warning: cn(
-            "bg-warning text-warning-foreground",
-            "shadow-lg shadow-warning/25",
-            "ring-2 ring-warning/30"
-        ),
-        error: cn(
-            "bg-destructive text-destructive-foreground",
-            "shadow-lg shadow-destructive/25",
-            "ring-2 ring-destructive/20"
-        ),
-    };
+  const types = {
+    primary: cn(
+      "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
+      "ring-2 ring-primary/20"
+    ),
+    secondary: cn(
+      "bg-secondary text-secondary-foreground",
+      "shadow-lg shadow-secondary/25",
+      "ring-2 ring-secondary/20"
+    ),
+    success: cn(
+      "bg-success text-success-foreground",
+      "shadow-lg shadow-success/25",
+      "ring-2 ring-success/20"
+    ),
+    warning: cn(
+      "bg-warning text-warning-foreground",
+      "shadow-lg shadow-warning/25",
+      "ring-2 ring-warning/30"
+    ),
+    error: cn(
+      "bg-destructive text-destructive-foreground",
+      "shadow-lg shadow-destructive/25",
+      "ring-2 ring-destructive/20"
+    ),
+  };
 
-    const getAnimationShadows = (type: string) => {
-        const shadowColors = {
-            primary: "var(--primary)",
-            secondary: "var(--secondary)",
-            success: "var(--success)",
-            warning: "var(--warning)",
-            error: "var(--destructive)",
-        };
-        return shadowColors[type as keyof typeof shadowColors] || shadowColors.primary;
-    };
-
-    const animationVariants:{'pulse': Variants, 'bounce': Variants, tinypop: Variants} = {
-        pulse: {
-            initial: {
-                scale: 1,
-                boxShadow: `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-            },
-            animate: {
-                scale: [1, 1.1, 1],
-                boxShadow: [
-                    `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-                    `0 0 0 8px rgba(${getAnimationShadows(type)}, 0.1)`,
-                    `0 0 0 12px rgba(${getAnimationShadows(type)}, 0)`
-                ],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                    times: [0, 0.5, 1]
-                },
-            },
+  const animationVariants: Record<string, Variants> = {
+    pulse: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.1, 1],
+        transition: {
+          duration: 2,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        bounce: {
-            initial: { 
-                y: 0,
-                opacity: 1,
-                rotate: 0,
-                scale: 1 
-            },
-            animate: {
-                y: [0, -70, 0, 50, 0, 0, 0],
-                rotate: [0, -5, 0, -2, 0, -1, 0],
-                scale: [1, 1.2, 0.95, 1.1, 0.98, 1.05, 1],
-                transition: {
-                    duration: 1.5,
-                    repeat: Infinity,
-                    repeatType: 'loop',
-                    ease: "easeOut",
-                    times: [0, 0.2, 0.4, 0.6, 0.75, 0.9, 1]
-                },
-            },
+      },
+    },
+    bounce: {
+      initial: { y: 0, scale: 1 },
+      animate: {
+        y: [0, -6, 0],
+        scale: [1, 1.15, 1],
+        transition: {
+          duration: 0.8,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        tinypop: {
-            initial: { scale: 1 },
-            animate: {
-                scale: [1, 1.5, 1],
-                rotate: [0, 2, -2, 0],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                    times: [0, 0.3, 1]
-                }
-            },           
-        }
-    };
+      },
+    },
+    tinypop: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.25, 1],
+        transition: {
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        },
+      },
+    },
+  };
 
+  const isAttached = mode === "attached";
+  const isInline = mode === "inline";
+
+  // Base styles
+  const baseStyles = cn(
+    "flex items-center justify-center",
+    "rounded-full font-bold tracking-tight",
+    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
+
+    isInline
+      ? "shadow-none ring-0"
+      : "shadow-lg ring-2",
+    types[type],
+    className
+  );
+
+  const positionStyles = isAttached
+    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
+    : "relative -top-2 sm:-top-2";
+
+  const badgeContent = (
+    <motion.div
+      variants={animationVariants[variant]}
+      initial="initial"
+      animate="animate"
+      className={cn(baseStyles, positionStyles)}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+    >
+    <span className="leading-none">{text}</span>
+
+    <div
+        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
+        aria-hidden="true"
+    />
+    </motion.div>
+  );
+
+  if (isAttached) {
     return (
-        <div className="relative inline-flex items-center">
-            {children}
-            <motion.div
-                variants={animationVariants[variant]}
-                initial="initial"
-                animate="animate"
-                className={cn(
-                    "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
-                    "min-w-2 h-2 sm:min-w-6 sm:h-6",
-                    "rounded-full flex items-center justify-center",
-                    "text-xs sm:text-sm font-bold tracking-tight",
-                    "backdrop-blur-sm",
-                    "border border-white/20 dark:border-black/20",
-                    "transition-all duration-200",
-                    "px-1.5 sm:px-2",
-                    "z-10",
-                    "hover:scale-105 active:scale-95",
-                    "hover:shadow-xl transition-transform duration-200",
-                    types[type],
-                    className
-                )}
-                whileHover={{ 
-                    scale: 1.05,
-                    transition: { duration: 0.2 }
-                }}
-                whileTap={{ 
-                    scale: 0.95,
-                    transition: { duration: 0.1 }
-                }}
-            >
-                <span className="relative z-10 leading-none">
-                    {text}
-                </span>
-                
-                <div 
-                    className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none" 
-                    aria-hidden="true"
-                />
-            </motion.div>
-        </div>
+      <div className="relative inline-flex items-center">
+        {children}
+        {badgeContent}
+      </div>
     );
+  }
+
+  return badgeContent;
 };
 
 Badge.displayName = "Badge";
@@ -241,13 +185,24 @@ import { Badge } from '@ignix-ui/badge';
 function BasicBadge() {
   return (
     <div className="relative inline-flex items-center">
-      <Mail className="h-6 w-6" />
-      <Badge text="3" type="primary" />
+      <Badge mode="attached" text="3" type={type as any} variant={variant as any}>
+        <Mail className="h-11 w-11" />
+      </Badge>
     </div>
   );
 }
 ```
 
-## Variants
 
-<BadgeDemo />
+## Props
+
+| Prop | Type | Default | Description |
+|-----|-----|-----|-----|
+| `text` | `string` | — | Content displayed inside the badge (number or label) |
+| `type` | `"primary" \| "secondary" \| "success" \| "warning" \| "error"` | `"primary"` | Visual style of the badge |
+| `variant` | `"pulse" \| "bounce" \| "tinypop"` | `"tinypop"` | Animation style applied to the badge |
+| `mode` | `"inline" \| "attached"` | `"inline"` | When inline is used, Badge is rendered in normal layout flow (used with text, labels). When attached is used, Badge is positioned relative to its child (used with icons, buttons, avatars) |
+| `children` | `React.ReactNode` | — | Element to attach the badge to (required for `attached` mode) |
+| `className` | `string` | — | Additional custom styles |
+
+---

--- a/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
@@ -188,7 +188,7 @@ import { Badge } from '@ignix-ui/badge';
 function BasicBadge() {
   return (
     <div className="relative inline-flex items-center">
-      <Badge mode="attached" text="3" type={type as any} variant={variant as any}>
+      <Badge mode="attached" text="3" type="primary" variant="pulse">
         <Mail className="h-11 w-11" />
       </Badge>
     </div>

--- a/apps/storybook/src/components/badge/badge.stories.tsx
+++ b/apps/storybook/src/components/badge/badge.stories.tsx
@@ -1,95 +1,132 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Badge } from "./index";
-import { Bell } from "lucide-react";
+import { Mail } from "lucide-react";
 
 const meta: Meta<typeof Badge> = {
-    title: "Components/Badge",
-    component: Badge,
-    tags: ["autodocs"],
-    parameters: {
-        docs: {
-            description: {
-                component: `
-The **Badge** component is a small animated indicator often used for notifications, statuses, or counts.  
-It supports multiple **types** (primary, success, warning, etc.) and **animation variants** (pulse, bounce, tinypop).
+  title: "Components/Badge",
+  component: Badge,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The **Badge** component is a small status indicator used for notifications, counts, and labels.
 
-###  Features
-- Type-based color variants (primary, success, warning, error, etc.)
-- Built-in animations (pulse, bounce, tinypop)
-- Works with or without a parent icon/element
+### Features
+- Inline and attached modes
+- Multiple color types (primary, success, warning, error)
+- Built-in animation variants (pulse, bounce, tinypop)
+- Works with text, icons, buttons, and avatars
         `,
-            },
-        },
+      },
     },
-    argTypes: {
-        text: {
-            control: "text",
-            description: "Text or number displayed inside the badge",
-            defaultValue: "3",
-        },
-        type: {
-            control: "select",
-            options: ["primary", "secondary", "success", "warning", "error"],
-            description: "Color style of the badge",
-        },
-        variant: {
-            control: "select",
-            options: ["pulse", "bounce", "tinypop"],
-            description: "Animation style of the badge",
-        },
-        className: {
-            control: "text",
-            description: "Custom Tailwind or CSS class names",
-        },
-        children: {
-            table: { disable: true },
-            description: "Optional parent element or icon (like a bell or avatar)",
-        },
+  },
+  argTypes: {
+    text: {
+      control: "text",
+      description: "Content displayed inside the badge",
+      defaultValue: "5",
     },
+    type: {
+      control: "select",
+      options: ["primary", "secondary", "success", "warning", "error"],
+      description: "Color style of the badge",
+    },
+    variant: {
+      control: "select",
+      options: ["pulse", "bounce", "tinypop"],
+      description: "Animation style",
+    },
+    mode: {
+      control: "select",
+      options: ["inline", "attached"],
+      description: "Layout behavior of the badge",
+    },
+    className: {
+      control: "text",
+      description: "Custom styles",
+    },
+    children: {
+      table: { disable: true },
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof Badge>;
 
 
-export const Default: Story = {
-    args: {
-        text: "5",
-        type: "primary",
-        variant: "tinypop",
-    },
+// Inline Badge (default usage)
+export const Inline: Story = {
+  args: {
+    text: "99+",
+    type: "error",
+    mode: "inline",
+  },
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <span className="text-lg font-medium">Notifications</span>
+      <Badge {...args} />
+    </div>
+  ),
 };
 
-export const WithIcon: Story = {
-    args: {
-        text: "12",
-        type: "success",
-        variant: "pulse",
-        children: (
-            <div className="p-4 bg-gray-200 rounded-full">
-                <Bell className="w-6 h-6 text-gray-700" />
-            </div>
-        ),
-    },
+
+// Attached to Icon
+export const AttachedIcon: Story = {
+  args: {
+    text: "3",
+    type: "primary",
+    variant: "pulse",
+    mode: "attached",
+  },
+  render: (args) => (
+    <Badge {...args}>
+      <Mail className="h-10 w-10" />
+    </Badge>
+  ),
 };
 
-export const Warning: Story = {
-    args: {
-        text: "99+",
-        type: "warning",
-        variant: "bounce",
-        children: (
-            <div className="p-4 bg-gray-100 rounded-full">
-                <Bell className="w-6 h-6 text-gray-700" />
-            </div>
-        ),
-    },
+
+// Attached to Button
+export const AttachedButton: Story = {
+  args: {
+    text: "New",
+    type: "error",
+    variant: "tinypop",
+    mode: "attached",
+  },
+  render: (args) => (
+    <Badge {...args}>
+      <button className="px-4 py-2 bg-muted rounded-lg shadow">
+        Components
+      </button>
+    </Badge>
+  ),
 };
 
-export const ErrorBadge: Story = {
-    args: {
-        text: "9",
-        type: "error",
-        variant: "pulse",
-    },
+
+// Variants Showcase
+export const Variants: Story = {
+  render: () => (
+    <div className="flex gap-4 items-center">
+      <Badge text="5" variant="pulse" type="primary" />
+      <Badge text="5" variant="bounce" type="success" />
+      <Badge text="5" variant="tinypop" type="warning" />
+    </div>
+  ),
+};
+
+
+// Types Showcase
+export const Types: Story = {
+  render: () => (
+    <div className="flex gap-4 items-center">
+      <Badge text="1" type="primary" />
+      <Badge text="2" type="secondary" />
+      <Badge text="3" type="success" />
+      <Badge text="4" type="warning" />
+      <Badge text="5" type="error" />
+    </div>
+  ),
 };

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -2,16 +2,24 @@ import React from "react";
 import { motion, type Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
-type BadgeMode = "inline" | "attached"
-
-interface BadgeProps {
+type BadgeBaseProps = {
   text?: string;
   type?: "primary" | "secondary" | "success" | "warning" | "error";
   variant?: "pulse" | "bounce" | "tinypop";
-  mode?: BadgeMode;
   className?: string;
-  children?: React.ReactNode;
-}
+};
+
+type InlineBadgeProps = BadgeBaseProps & {
+  mode?: "inline";
+  children?: never;
+};
+
+type AttachedBadgeProps = BadgeBaseProps & {
+  mode: "attached";
+  children: React.ReactNode;
+};
+
+type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,
@@ -24,7 +32,6 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -87,7 +94,6 @@ const Badge: React.FC<BadgeProps> = ({
   };
 
   const isAttached = mode === "attached";
-  const isInline = mode === "inline";
 
   // Base styles
   const baseStyles = cn(
@@ -95,9 +101,6 @@ const Badge: React.FC<BadgeProps> = ({
     "rounded-full font-bold tracking-tight",
     "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
 
-    isInline
-      ? "shadow-none ring-0"
-      : "shadow-lg ring-2",
     types[type],
     className
   );

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -32,6 +32,7 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -118,12 +119,12 @@ const Badge: React.FC<BadgeProps> = ({
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
     >
-    <span className="leading-none">{text}</span>
+      <span className="leading-none">{text}</span>
 
-    <div
+      <div
         className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
         aria-hidden="true"
-    />
+      />
     </motion.div>
   );
 

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -1,159 +1,139 @@
 import React from "react";
-import { motion} from "framer-motion";
-import type { Variants } from "framer-motion"
+import { motion, type Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
+type BadgeMode = "inline" | "attached"
+
 interface BadgeProps {
-    text: string;
-    type?: "primary" | "secondary" | "success" | "warning" | "error";
-    variant?: "pulse" | "bounce" | "tinypop";
-    className?: string;
-    children?: React.ReactNode;
+  text?: string;
+  type?: "primary" | "secondary" | "success" | "warning" | "error";
+  variant?: "pulse" | "bounce" | "tinypop";
+  mode?: BadgeMode;
+  className?: string;
+  children?: React.ReactNode;
 }
 
 const Badge: React.FC<BadgeProps> = ({
-    text,
-    type = "primary",
-    className,
-    variant = "tinypop",
-    children
+  text,
+  type = "primary",
+  variant = "tinypop",
+  mode = "inline",
+  className,
+  children,
 }) => {
-    const types = {
-        primary: cn(
-            "bg-primary text-primary-foreground",
-            "shadow-lg shadow-primary/25",
-            "ring-2 ring-primary/20"
-        ),
-        secondary: cn(
-            "bg-secondary text-secondary-foreground",
-            "shadow-lg shadow-secondary/25",
-            "ring-2 ring-secondary/20"
-        ),
-        success: cn(
-            "bg-success text-success-foreground",
-            "shadow-lg shadow-success/25",
-            "ring-2 ring-success/20"
-        ),
-        warning: cn(
-            "bg-warning text-warning-foreground",
-            "shadow-lg shadow-warning/25",
-            "ring-2 ring-warning/30"
-        ),
-        error: cn(
-            "bg-destructive text-destructive-foreground",
-            "shadow-lg shadow-destructive/25",
-            "ring-2 ring-destructive/20"
-        ),
-    };
+  const types = {
+    primary: cn(
+      "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
+      "ring-2 ring-primary/20"
+    ),
+    secondary: cn(
+      "bg-secondary text-secondary-foreground",
+      "shadow-lg shadow-secondary/25",
+      "ring-2 ring-secondary/20"
+    ),
+    success: cn(
+      "bg-success text-success-foreground",
+      "shadow-lg shadow-success/25",
+      "ring-2 ring-success/20"
+    ),
+    warning: cn(
+      "bg-warning text-warning-foreground",
+      "shadow-lg shadow-warning/25",
+      "ring-2 ring-warning/30"
+    ),
+    error: cn(
+      "bg-destructive text-destructive-foreground",
+      "shadow-lg shadow-destructive/25",
+      "ring-2 ring-destructive/20"
+    ),
+  };
 
-    const getAnimationShadows = (type: string) => {
-        const shadowColors = {
-            primary: "hsl(var(--primary))",
-            secondary: "hsl(var(--secondary))",
-            success: "hsl(var(--success))",
-            warning: "hsl(var(--warning))",
-            error: "hsl(var(--destructive))",
-        };
-        return shadowColors[type as keyof typeof shadowColors] || shadowColors.primary;
-    };
-
-    const animationVariants:{'pulse': Variants, 'bounce': Variants, tinypop: Variants} = {
-        pulse: {
-            initial: {
-                scale: 1,
-                boxShadow: `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-            },
-            animate: {
-                scale: [1, 1.1, 1],
-                boxShadow: [
-                    `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-                    `0 0 0 8px rgba(${getAnimationShadows(type)}, 0.1)`,
-                    `0 0 0 12px rgba(${getAnimationShadows(type)}, 0)`
-                ],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                    times: [0, 0.5, 1]
-                },
-            },
+  const animationVariants: Record<string, Variants> = {
+    pulse: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.1, 1],
+        transition: {
+          duration: 2,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        bounce: {
-            initial: { 
-                y: -50, 
-                opacity: 0,
-                rotate: -15,
-                scale: 0.5 
-            },
-            animate: {
-                y: [-50, 0, -20, 0, -8, 0, -3, 0],
-                opacity: 1,
-                rotate: [-15, 0, -5, 0, -2, 0],
-                scale: [0.5, 1.2, 0.9, 1.1, 0.95, 1],
-                transition: {
-                    duration: 1.5,
-                    ease: "easeOut",
-                    times: [0, 0.2, 0.35, 0.5, 0.65, 0.8, 0.9, 1]
-                },
-            },
+      },
+    },
+    bounce: {
+      initial: { y: 0, scale: 1 },
+      animate: {
+        y: [0, -6, 0],
+        scale: [1, 1.15, 1],
+        transition: {
+          duration: 0.8,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        tinypop: {
-            initial: { scale: 1 },
-            animate: { 
-                scale: [1, 1.15, 1],
-                rotate: [0, 2, -2, 0],
-                transition: { 
-                    duration: 2.5,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                    times: [0, 0.3, 1]
-                }
-            },           
-        }
-    };
+      },
+    },
+    tinypop: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.25, 1],
+        transition: {
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        },
+      },
+    },
+  };
 
+  const isAttached = mode === "attached";
+  const isInline = mode === "inline";
+
+  // Base styles
+  const baseStyles = cn(
+    "flex items-center justify-center",
+    "rounded-full font-bold tracking-tight",
+    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
+
+    isInline
+      ? "shadow-none ring-0"
+      : "shadow-lg ring-2",
+    types[type],
+    className
+  );
+
+  const positionStyles = isAttached
+    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
+    : "relative -top-2 sm:-top-2";
+
+  const badgeContent = (
+    <motion.div
+      variants={animationVariants[variant]}
+      initial="initial"
+      animate="animate"
+      className={cn(baseStyles, positionStyles)}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+    >
+    <span className="leading-none">{text}</span>
+
+    <div
+        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
+        aria-hidden="true"
+    />
+    </motion.div>
+  );
+
+  if (isAttached) {
     return (
-        <div className="relative inline-flex items-center">
-            {children}
-            <motion.div
-                variants={animationVariants[variant]}
-                initial="initial"
-                animate="animate"
-                className={cn(
-                    "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
-                    "min-w-5 h-5 sm:min-w-6 sm:h-6",
-                    "rounded-full flex items-center justify-center",
-                    "text-xs sm:text-sm font-bold tracking-tight",
-                    "backdrop-blur-sm",
-                    "border border-white/20 dark:border-black/20",
-                    "transition-all duration-200",
-                    "px-1.5 sm:px-2",
-                    "z-10",
-                    "hover:scale-105 active:scale-95",
-                    "hover:shadow-xl transition-transform duration-200",
-                    types[type],
-                    className
-                )}
-                whileHover={{ 
-                    scale: 1.05,
-                    transition: { duration: 0.2 }
-                }}
-                whileTap={{ 
-                    scale: 0.95,
-                    transition: { duration: 0.1 }
-                }}
-            >
-                <span className="relative z-10 leading-none">
-                    {text}
-                </span>
-                
-                <div 
-                    className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none" 
-                    aria-hidden="true"
-                />
-            </motion.div>
-        </div>
+      <div className="relative inline-flex items-center">
+        {children}
+        {badgeContent}
+      </div>
     );
+  }
+
+  return badgeContent;
 };
 
 Badge.displayName = "Badge";

--- a/packages/registry/components/badge/badge.test.tsx
+++ b/packages/registry/components/badge/badge.test.tsx
@@ -4,46 +4,22 @@ import { Badge } from "./index";
 import React from "react";
 
 vi.mock("framer-motion", () => {
-  type MotionProps = {
-    children?: React.ReactNode;
-    initial?: unknown;
-    animate?: unknown;
-    exit?: unknown;
-    variants?: unknown;
-    transition?: unknown;
-    whileHover?: unknown;
-    whileTap?: unknown;
-  };
-
   const motion = new Proxy(
     {},
     {
       get: (_target, tag: string) =>
-        React.forwardRef<HTMLElement, MotionProps>(
-          (
-            {
-              children,
-              initial: _i,
-              animate: _a,
-              exit: _e,
-              variants: _v,
-              transition: _t,
-              whileHover: _wh,
-              whileTap: _wt,
-              ...rest
-            },
-            ref
-          ) =>
-            React.createElement(
-              tag,
-              { ...(rest as Record<string, unknown>), ref },
-              children
-            )
+        React.forwardRef(({ children, ...rest }: any, ref) =>
+          React.createElement(tag, { ...rest, ref }, children)
         ),
     }
   );
 
-  return { motion, AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children) };
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
 });
 
 const renderBadge = (props: Partial<React.ComponentProps<typeof Badge>> = {}) =>
@@ -62,51 +38,44 @@ describe("Badge rendering", () => {
 
   it("renders the badge text inside a <span>", () => {
     renderBadge({ text: "Hello" });
-    const span = screen.getByText("Hello");
-    expect(span.tagName).toBe("SPAN");
+    expect(screen.getByText("Hello").tagName).toBe("SPAN");
   });
 
-  it("renders a gradient overlay div with aria-hidden", () => {
-    const { container } = renderBadge();
-    const overlay = container.querySelector("div[aria-hidden='true']");
-    expect(overlay).toHaveClass(
-      "bg-gradient-to-t",
-      "rounded-full",
-      "pointer-events-none"
+  it("renders overlay only in attached mode", () => {
+    const { container } = render(
+      <Badge mode="attached" text="1">
+        <div>child</div>
+      </Badge>
     );
+
+    const overlay = container.querySelector("div[aria-hidden='true']");
+    expect(overlay).toBeInTheDocument();
   });
 });
 
 describe("Badge children", () => {
-  it("renders children alongside the badge", () => {
+  it("renders children only in attached mode", () => {
+    render(
+      <Badge mode="attached" text="3">
+        <button>Bell</button>
+      </Badge>
+    );
+
+    expect(screen.getByRole("button", { name: "Bell" })).toBeInTheDocument();
+  });
+
+  it("does NOT render children in inline mode", () => {
     render(
       <Badge text="3">
         <button>Bell</button>
       </Badge>
     );
-    expect(screen.getByRole("button", { name: "Bell" })).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
-  });
 
-  it("renders without children", () => {
-    renderBadge();
-    expect(screen.getByText("Badge Text")).toBeInTheDocument();
-  });
-
-  it("renders multiple children", () => {
-    render(
-      <Badge text="5">
-        <span>Icon</span>
-        <span>Label</span>
-      </Badge>
-    );
-    expect(screen.getByText("Icon")).toBeInTheDocument();
-    expect(screen.getByText("Label")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });
 
-
-describe("Badge type prop applies correct classes", () => {
+describe("Badge type prop", () => {
   const typeCases: Array<[React.ComponentProps<typeof Badge>["type"], string]> = [
     ["primary", "bg-primary"],
     ["secondary", "bg-secondary"],
@@ -117,74 +86,70 @@ describe("Badge type prop applies correct classes", () => {
 
   it.each(typeCases)('type="%s" applies class "%s"', (type, expectedClass) => {
     render(<Badge text="X" type={type} />);
-    const motionDiv = screen.getByText("X").closest("span")?.parentElement;
-    expect(motionDiv?.className).toContain(expectedClass);
+    const badge = screen.getByText("X").parentElement;
+    expect(badge?.className).toContain(expectedClass);
   });
 
-  it('defaults to "primary" type when type prop is omitted', () => {
+  it("defaults to primary type", () => {
     render(<Badge text="X" />);
-    const motionDiv = screen.getByText("X").closest("span")?.parentElement;
-    expect(motionDiv?.className).toContain("bg-primary");
+    const badge = screen.getByText("X").parentElement;
+    expect(badge?.className).toContain("bg-primary");
   });
 });
 
 describe("Badge variant prop", () => {
-  const variants: Array<React.ComponentProps<typeof Badge>["variant"]> = [
-    "pulse",
-    "bounce",
-    "tinypop",
-  ];
+  it.each(["pulse", "bounce", "tinypop"] as const)(
+    'variant="%s" renders',
+    (variant) => {
+      renderBadge({ variant });
+      expect(screen.getByText("Badge Text")).toBeInTheDocument();
+    }
+  );
+});
 
-  it.each(variants)('variant="%s" renders without crashing', (variant) => {
-    renderBadge({ variant });
-    expect(screen.getByText("Badge Text")).toBeInTheDocument();
+describe("Badge className", () => {
+  it("applies custom className", () => {
+    render(<Badge text="X" className="custom" />);
+    const badge = screen.getByText("X").parentElement;
+    expect(badge?.className).toContain("custom");
   });
 
-  it('defaults to "tinypop" variant when variant prop is omitted', () => {
-    renderBadge();
-    expect(screen.getByText("Badge Text")).toBeInTheDocument();
+  it("merges with default classes", () => {
+    render(<Badge text="X" type="success" className="extra" />);
+    const badge = screen.getByText("X").parentElement;
+    expect(badge?.className).toContain("bg-success");
+    expect(badge?.className).toContain("extra");
   });
 });
 
-describe("Badge className passthrough", () => {
-  it("applies custom className to the badge element", () => {
-    render(<Badge text="X" className="my-custom-badge" />);
-    const motionDiv = screen.getByText("X").parentElement;
-    expect(motionDiv?.className).toContain("my-custom-badge");
-  });
-
-  it("merges custom className with default classes", () => {
-    render(<Badge text="X" type="success" className="extra-class" />);
-    const motionDiv = screen.getByText("X").parentElement;
-    expect(motionDiv?.className).toContain("bg-success");
-    expect(motionDiv?.className).toContain("extra-class");
-  });
-});
-
-describe("Badge structural classes", () => {
-  it("outer wrapper has class 'relative inline-flex items-center'", () => {
+describe("Badge structure", () => {
+  it("inline mode has no wrapper", () => {
     const { container } = renderBadge();
+    const root = container.firstElementChild;
+    expect(root?.className).not.toContain("relative inline-flex");
+  });
+
+  it("attached mode has wrapper", () => {
+    const { container } = render(
+      <Badge mode="attached" text="1">
+        <div>child</div>
+      </Badge>
+    );
+
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toContain("relative");
     expect(wrapper?.className).toContain("inline-flex");
-    expect(wrapper?.className).toContain("items-center");
   });
 
-  it("badge element has 'rounded-full' class", () => {
+  it("badge has rounded-full", () => {
     renderBadge();
-    const motionDiv = screen.getByText("Badge Text").parentElement;
-    expect(motionDiv?.className).toContain("rounded-full");
-  });
-
-  it("badge element has 'z-10' class", () => {
-    renderBadge();
-    const motionDiv = screen.getByText("Badge Text").parentElement;
-    expect(motionDiv?.className).toContain("z-10");
+    const badge = screen.getByText("Badge Text").parentElement;
+    expect(badge?.className).toContain("rounded-full");
   });
 });
 
 describe("Badge displayName", () => {
-  it('has displayName "Badge"', () => {
+  it("has correct displayName", () => {
     expect(Badge.displayName).toBe("Badge");
   });
 });

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion, Variants } from "framer-motion";
+import { motion, type Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
 type BadgeBaseProps = {
@@ -32,6 +32,7 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -118,12 +119,12 @@ const Badge: React.FC<BadgeProps> = ({
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
     >
-    <span className="leading-none">{text}</span>
+      <span className="leading-none">{text}</span>
 
-    <div
+      <div
         className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
         aria-hidden="true"
-    />
+      />
     </motion.div>
   );
 

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -2,16 +2,24 @@ import React from "react";
 import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
-type BadgeMode = "inline" | "attached"
-
-interface BadgeProps {
+type BadgeBaseProps = {
   text?: string;
   type?: "primary" | "secondary" | "success" | "warning" | "error";
   variant?: "pulse" | "bounce" | "tinypop";
-  mode?: BadgeMode;
   className?: string;
-  children?: React.ReactNode;
-}
+};
+
+type InlineBadgeProps = BadgeBaseProps & {
+  mode?: "inline";
+  children?: never;
+};
+
+type AttachedBadgeProps = BadgeBaseProps & {
+  mode: "attached";
+  children: React.ReactNode;
+};
+
+type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,
@@ -24,7 +32,6 @@ const Badge: React.FC<BadgeProps> = ({
   const types = {
     primary: cn(
       "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
       "ring-2 ring-primary/20"
     ),
     secondary: cn(
@@ -87,7 +94,6 @@ const Badge: React.FC<BadgeProps> = ({
   };
 
   const isAttached = mode === "attached";
-  const isInline = mode === "inline";
 
   // Base styles
   const baseStyles = cn(
@@ -95,9 +101,6 @@ const Badge: React.FC<BadgeProps> = ({
     "rounded-full font-bold tracking-tight",
     "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
 
-    isInline
-      ? "shadow-none ring-0"
-      : "shadow-lg ring-2",
     types[type],
     className
   );

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -1,158 +1,139 @@
 import React from "react";
-import { motion, Variants} from "framer-motion";
+import { motion, Variants } from "framer-motion";
 import { cn } from "../../../utils/cn";
 
+type BadgeMode = "inline" | "attached"
+
 interface BadgeProps {
-    text: string;
-    type?: "primary" | "secondary" | "success" | "warning" | "error";
-    variant?: "pulse" | "bounce" | "tinypop";
-    className?: string;
-    children?: React.ReactNode;
+  text?: string;
+  type?: "primary" | "secondary" | "success" | "warning" | "error";
+  variant?: "pulse" | "bounce" | "tinypop";
+  mode?: BadgeMode;
+  className?: string;
+  children?: React.ReactNode;
 }
 
 const Badge: React.FC<BadgeProps> = ({
-    text,
-    type = "primary",
-    className,
-    variant = "tinypop",
-    children
+  text,
+  type = "primary",
+  variant = "tinypop",
+  mode = "inline",
+  className,
+  children,
 }) => {
-    const types = {
-        primary: cn(
-            "bg-primary text-primary-foreground",
-            "shadow-lg shadow-primary/25",
-            "ring-2 ring-primary/20"
-        ),
-        secondary: cn(
-            "bg-secondary text-secondary-foreground",
-            "shadow-lg shadow-secondary/25",
-            "ring-2 ring-secondary/20"
-        ),
-        success: cn(
-            "bg-success text-success-foreground",
-            "shadow-lg shadow-success/25",
-            "ring-2 ring-success/20"
-        ),
-        warning: cn(
-            "bg-warning text-warning-foreground",
-            "shadow-lg shadow-warning/25",
-            "ring-2 ring-warning/30"
-        ),
-        error: cn(
-            "bg-destructive text-destructive-foreground",
-            "shadow-lg shadow-destructive/25",
-            "ring-2 ring-destructive/20"
-        ),
-    };
+  const types = {
+    primary: cn(
+      "bg-primary text-primary-foreground",
+      "shadow-lg shadow-primary/25",
+      "ring-2 ring-primary/20"
+    ),
+    secondary: cn(
+      "bg-secondary text-secondary-foreground",
+      "shadow-lg shadow-secondary/25",
+      "ring-2 ring-secondary/20"
+    ),
+    success: cn(
+      "bg-success text-success-foreground",
+      "shadow-lg shadow-success/25",
+      "ring-2 ring-success/20"
+    ),
+    warning: cn(
+      "bg-warning text-warning-foreground",
+      "shadow-lg shadow-warning/25",
+      "ring-2 ring-warning/30"
+    ),
+    error: cn(
+      "bg-destructive text-destructive-foreground",
+      "shadow-lg shadow-destructive/25",
+      "ring-2 ring-destructive/20"
+    ),
+  };
 
-    const getAnimationShadows = (type: string) => {
-        const shadowColors = {
-            primary: "hsl(var(--primary))",
-            secondary: "hsl(var(--secondary))",
-            success: "hsl(var(--success))",
-            warning: "hsl(var(--warning))",
-            error: "hsl(var(--destructive))",
-        };
-        return shadowColors[type as keyof typeof shadowColors] || shadowColors.primary;
-    };
-
-    const animationVariants:{'pulse': Variants, 'bounce': Variants, tinypop: Variants} = {
-        pulse: {
-            initial: {
-                scale: 1,
-                boxShadow: `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-            },
-            animate: {
-                scale: [1, 1.1, 1],
-                boxShadow: [
-                    `0 0 0 0 rgba(${getAnimationShadows(type)}, 0.7)`,
-                    `0 0 0 8px rgba(${getAnimationShadows(type)}, 0.1)`,
-                    `0 0 0 12px rgba(${getAnimationShadows(type)}, 0)`
-                ],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                    times: [0, 0.5, 1]
-                },
-            },
+  const animationVariants: Record<string, Variants> = {
+    pulse: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.1, 1],
+        transition: {
+          duration: 2,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        bounce: {
-            initial: { 
-                y: -50, 
-                opacity: 0,
-                rotate: -15,
-                scale: 0.5 
-            },
-            animate: {
-                y: [-50, 0, -20, 0, -8, 0, -3, 0],
-                opacity: 1,
-                rotate: [-15, 0, -5, 0, -2, 0],
-                scale: [0.5, 1.2, 0.9, 1.1, 0.95, 1],
-                transition: {
-                    duration: 1.5,
-                    ease: "easeOut",
-                    times: [0, 0.2, 0.35, 0.5, 0.65, 0.8, 0.9, 1]
-                },
-            },
+      },
+    },
+    bounce: {
+      initial: { y: 0, scale: 1 },
+      animate: {
+        y: [0, -6, 0],
+        scale: [1, 1.15, 1],
+        transition: {
+          duration: 0.8,
+          repeat: Infinity,
+          ease: "easeOut",
         },
-        tinypop: {
-            initial: { scale: 1 },
-            animate: { 
-                scale: [1, 1.15, 1],
-                rotate: [0, 2, -2, 0],
-                transition: { 
-                    duration: 2.5,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                    times: [0, 0.3, 1]
-                }
-            },           
-        }
-    };
+      },
+    },
+    tinypop: {
+      initial: { scale: 1 },
+      animate: {
+        scale: [1, 1.25, 1],
+        transition: {
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        },
+      },
+    },
+  };
 
+  const isAttached = mode === "attached";
+  const isInline = mode === "inline";
+
+  // Base styles
+  const baseStyles = cn(
+    "flex items-center justify-center",
+    "rounded-full font-bold tracking-tight",
+    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
+
+    isInline
+      ? "shadow-none ring-0"
+      : "shadow-lg ring-2",
+    types[type],
+    className
+  );
+
+  const positionStyles = isAttached
+    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
+    : "relative -top-2 sm:-top-2";
+
+  const badgeContent = (
+    <motion.div
+      variants={animationVariants[variant]}
+      initial="initial"
+      animate="animate"
+      className={cn(baseStyles, positionStyles)}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+    >
+    <span className="leading-none">{text}</span>
+
+    <div
+        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
+        aria-hidden="true"
+    />
+    </motion.div>
+  );
+
+  if (isAttached) {
     return (
-        <div className="relative inline-flex items-center">
-            {children}
-            <motion.div
-                variants={animationVariants[variant]}
-                initial="initial"
-                animate="animate"
-                className={cn(
-                    "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
-                    "min-w-5 h-5 sm:min-w-6 sm:h-6",
-                    "rounded-full flex items-center justify-center",
-                    "text-xs sm:text-sm font-bold tracking-tight",
-                    "backdrop-blur-sm",
-                    "border border-white/20 dark:border-black/20",
-                    "transition-all duration-200",
-                    "px-1.5 sm:px-2",
-                    "z-10",
-                    "hover:scale-105 active:scale-95",
-                    "hover:shadow-xl transition-transform duration-200",
-                    types[type],
-                    className
-                )}
-                whileHover={{ 
-                    scale: 1.05,
-                    transition: { duration: 0.2 }
-                }}
-                whileTap={{ 
-                    scale: 0.95,
-                    transition: { duration: 0.1 }
-                }}
-            >
-                <span className="relative z-10 leading-none">
-                    {text}
-                </span>
-                
-                <div 
-                    className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none" 
-                    aria-hidden="true"
-                />
-            </motion.div>
-        </div>
+      <div className="relative inline-flex items-center">
+        {children}
+        {badgeContent}
+      </div>
     );
+  }
+
+  return badgeContent;
 };
 
 Badge.displayName = "Badge";


### PR DESCRIPTION
## Pull Request Title

**"Fixed issue #775 ".**

---

## Description

### What does this PR do?

_Provide a concise summary of your changes and what issue or feature they address._

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #ISSUE_NUMBER (if applicable)

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Component API changes
  - Badge props refactor: replaced single interface with a discriminated union (mode = "inline" | "attached"); mode defaults to "inline".
  - text is now optional (text?: string).
  - children are now conditional: disallowed for inline mode (children?: never) and required/allowed for attached mode (children: React.ReactNode).
  - Framer Motion animation simplified: removed type-dependent box-shadow animations; variants (pulse, bounce, tinypop) now animate scale/position only.
  - Rendering/layout refactor: badgeContent consolidated; "attached" mode wraps children in a relative container with an absolutely-positioned badge, "inline" mode renders the badge standalone with inline offsets.
  - Styling reorganized into shared baseStyles + computed positionStyles.

- Bug fixes
  - Addressed badge layout/behavior issue referenced as #775 by refactoring rendering and animation to correctly support inline and attached positioning modes.

- Tooling / config changes
  - None.

- Docs / Storybook updates
  - Demo updated (BadgeDemo) to show an attached Mail icon badge and a separate inline badge with label.
  - Versioned docs (badge.mdx) updated to reflect the new mode prop and API examples.
  - Storybook stories replaced: removed legacy stories (Default, WithIcon, Warning, ErrorBadge) and added Inline, AttachedIcon, AttachedButton, Variants, Types.
  - Example icon changed from Bell to Mail.

- Tests
  - framer-motion test mock simplified; tests updated to reflect new DOM structure and mode-dependent behavior (overlay and children present only for attached mode).
  - Assertions adjusted to target new wrapper/container structure.

- Breaking changes
  - Potentially breaking TypeScript/usage changes:
    - children are no longer accepted in inline mode; code that previously passed children to Badge in inline usage will now fail type-checks or behavior expectations.
    - Prop shape changed (text became optional, mode added). Update call sites to adopt the new discriminated union if strict typings are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->