### PR TITLE
Fix dot-bounce variant issue in Button component

### DIFF
--- a/apps/docs/src/components/UI/button-with-spinner/index.tsx
+++ b/apps/docs/src/components/UI/button-with-spinner/index.tsx
@@ -97,9 +97,9 @@ export const ButtonWithSpinner = React.forwardRef<
       if (spinnerColor) return spinnerColor;
       
       // For variants with dark backgrounds, use white/light spinner
-      const darkBackgroundVariants = ['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'pill', 'neon'];
+      const darkBackgroundVariants = ['default', 'success', 'warning', 'danger', 'pill', 'neon'];
       // For variants with light/transparent backgrounds, use dark spinner
-      const lightBackgroundVariants = ['outline', 'ghost', 'subtle', 'elevated', 'glass'];
+      const lightBackgroundVariants = ['primary', 'secondary', 'outline', 'ghost', 'subtle', 'elevated', 'glass'];
       
       if (variant && darkBackgroundVariants.includes(variant)) {
         // For bars and dots-bounce, use bg-white
@@ -132,7 +132,7 @@ export const ButtonWithSpinner = React.forwardRef<
         variant={variant}
         {...props}
       >
-        {isLoading && (
+        {isLoading && spinnerVariant !== 'dots-bounce' && (
           <Spinner
             size={spinnerSize}
             variant={spinnerVariant}
@@ -141,6 +141,14 @@ export const ButtonWithSpinner = React.forwardRef<
           />
         )}
         <span>{isLoading ? loadingText : children}</span>
+        {isLoading && spinnerVariant === 'dots-bounce' && (
+          <Spinner
+            size={spinnerSize}
+            variant={spinnerVariant}
+            color={getSpinnerColor()}
+            className="ml-2"
+          />
+        )}
       </Button>
     );
   }

--- a/apps/docs/versioned_docs/version-1.0.3/components/button-with-spinner.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/button-with-spinner.mdx
@@ -70,8 +70,8 @@ export const ButtonWithSpinner = React.forwardRef<
     const getSpinnerColor = (): string => {
       if (spinnerColor) return spinnerColor;
       
-      const darkBackgroundVariants = ['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'pill', 'neon'];
-      const lightBackgroundVariants = ['outline', 'ghost', 'subtle', 'elevated', 'glass'];
+      const darkBackgroundVariants = ['default', 'success', 'warning', 'danger', 'pill', 'neon'];
+      const lightBackgroundVariants = ['primary', 'secondary', 'outline', 'ghost', 'subtle', 'elevated', 'glass'];
       
       if (variant && darkBackgroundVariants.includes(variant)) {
         if (spinnerVariant === 'bars' || spinnerVariant === 'dots-bounce') {
@@ -85,6 +85,7 @@ export const ButtonWithSpinner = React.forwardRef<
         return 'border-primary';
       }
       
+      // Default fallback - assume dark background
       if (spinnerVariant === 'bars' || spinnerVariant === 'dots-bounce') {
         return 'bg-white';
       }
@@ -99,7 +100,7 @@ export const ButtonWithSpinner = React.forwardRef<
         variant={variant}
         {...props}
       >
-        {isLoading && (
+        {isLoading && spinnerVariant !== 'dots-bounce' && (
           <Spinner
             size={spinnerSize}
             variant={spinnerVariant}
@@ -108,6 +109,14 @@ export const ButtonWithSpinner = React.forwardRef<
           />
         )}
         <span>{isLoading ? loadingText : children}</span>
+        {isLoading && spinnerVariant === 'dots-bounce' && (
+          <Spinner
+            size={spinnerSize}
+            variant={spinnerVariant}
+            color={getSpinnerColor()}
+            className="ml-2"
+          />
+        )}
       </Button>
     );
   }

--- a/apps/storybook/src/components/button-with-spinner/index.tsx
+++ b/apps/storybook/src/components/button-with-spinner/index.tsx
@@ -97,9 +97,9 @@ export const ButtonWithSpinner = React.forwardRef<
       if (spinnerColor) return spinnerColor;
       
       // For variants with dark backgrounds, use white/light spinner
-      const darkBackgroundVariants = ['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'pill', 'neon'];
+      const darkBackgroundVariants = ['default', 'success', 'warning', 'danger', 'pill', 'neon'];
       // For variants with light/transparent backgrounds, use dark spinner
-      const lightBackgroundVariants = ['outline', 'ghost', 'subtle', 'elevated', 'glass'];
+      const lightBackgroundVariants = ['primary', 'secondary', 'outline', 'ghost', 'subtle', 'elevated', 'glass'];
       
       if (variant && darkBackgroundVariants.includes(variant)) {
         // For bars and dots-bounce, use bg-white
@@ -132,7 +132,7 @@ export const ButtonWithSpinner = React.forwardRef<
         variant={variant}
         {...props}
       >
-        {isLoading && (
+        {isLoading && spinnerVariant !== 'dots-bounce' && (
           <Spinner
             size={spinnerSize}
             variant={spinnerVariant}
@@ -141,6 +141,14 @@ export const ButtonWithSpinner = React.forwardRef<
           />
         )}
         <span>{isLoading ? loadingText : children}</span>
+        {isLoading && spinnerVariant === 'dots-bounce' && (
+          <Spinner
+            size={spinnerSize}
+            variant={spinnerVariant}
+            color={getSpinnerColor()}
+            className="ml-2"
+          />
+        )}
       </Button>
     );
   }

--- a/packages/registry/components/button-with-spinner/index.tsx
+++ b/packages/registry/components/button-with-spinner/index.tsx
@@ -97,9 +97,9 @@ export const ButtonWithSpinner = React.forwardRef<
       if (spinnerColor) return spinnerColor;
       
       // For variants with dark backgrounds, use white/light spinner
-      const darkBackgroundVariants = ['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'pill', 'neon'];
+      const darkBackgroundVariants = ['default', 'success', 'warning', 'danger', 'pill', 'neon'];
       // For variants with light/transparent backgrounds, use dark spinner
-      const lightBackgroundVariants = ['outline', 'ghost', 'subtle', 'elevated', 'glass'];
+      const lightBackgroundVariants = ['primary', 'secondary', 'outline', 'ghost', 'subtle', 'elevated', 'glass'];
       
       if (variant && darkBackgroundVariants.includes(variant)) {
         // For bars and dots-bounce, use bg-white
@@ -132,7 +132,7 @@ export const ButtonWithSpinner = React.forwardRef<
         variant={variant}
         {...props}
       >
-        {isLoading && (
+        {isLoading && spinnerVariant !== 'dots-bounce' && (
           <Spinner
             size={spinnerSize}
             variant={spinnerVariant}
@@ -141,6 +141,14 @@ export const ButtonWithSpinner = React.forwardRef<
           />
         )}
         <span>{isLoading ? loadingText : children}</span>
+        {isLoading && spinnerVariant === 'dots-bounce' && (
+          <Spinner
+            size={spinnerSize}
+            variant={spinnerVariant}
+            color={getSpinnerColor()}
+            className="ml-2"
+          />
+        )}
       </Button>
     );
   }


### PR DESCRIPTION
## Pull Request Title

Fixes issue #835 and #836 

---

## Description

### What does this PR do?

_Provide a concise summary of your changes and what issue or feature they address._

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #835 
- Closes #836 

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug fixes
- **Fixed dot-bounce visibility issue**: Reclassified `primary` and `secondary` button variants from the dark-background group to the light-background group, ensuring the spinner dot color has proper contrast against the button background (fixes `#835`)
- **Fixed dot-bounce placement**: Updated spinner rendering logic to position the dot-bounce spinner after the button text with left margin (`ml-2`) instead of before the text, resolving the misalignment issue (fixes `#836`)

## Docs / Storybook updates
- Updated `ButtonWithSpinner` code samples in documentation and Storybook to reflect the new spinner positioning logic and variant classification
- Documented the conditional spinner rendering behavior: non-`dots-bounce` variants render spinner before text with right margin; `dots-bounce` variant renders spinner after text with left margin

## Breaking changes
None

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindfiredigital/ignix-ui/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->