### PR TITLE
fix(component): fix default autoclose, date range select order, and adjust preview widths

### DIFF
--- a/apps/docs/src/components/Demo/DatePickerDemo.tsx
+++ b/apps/docs/src/components/Demo/DatePickerDemo.tsx
@@ -219,7 +219,7 @@ export const SizeVariantsDemo = () => {
             description=""
             code={codeString}
         >
-            <div className="grid grid-cols-2 gap-6 max-w-3xl">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-3xl">
                 <DatePicker
                     themeMode={colorMode as 'light' | 'dark'}
                     size="sm"
@@ -278,7 +278,7 @@ export const ColorSchemesDemo = () => {
             code={codeString}
         >
             <div className="space-y-4 max-w-4xl">
-                <div className="grid grid-cols-3 gap-4 p-4 ">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 p-4 w-full">
                     {colorSchemeOptions.map((color) => (
                         <DatePicker
                             key={color.value}
@@ -317,7 +317,7 @@ export const PopupPositionsDemo = () => {
             code={codeString}
         >
             <div className="space-y-6 max-w-4xl">
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 w-full">
                     {popupPositionOptions.map((position) => (
                         <DatePicker
                             key={position.value}
@@ -514,7 +514,7 @@ export const ValidationExamplesDemo = () => {
             title=""
             description=""
         >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-3xl">
                 <DatePicker
                     themeMode={colorMode as 'light' | 'dark'}
                     required

--- a/apps/docs/src/components/Demo/DatePickerDemo.tsx
+++ b/apps/docs/src/components/Demo/DatePickerDemo.tsx
@@ -183,10 +183,9 @@ function MyComponent() {
                     <div className="mt-4 p-3 border border-border/60 bg-muted/20 rounded-xl">
                         <Typography variant="body-small" color="muted">
                             Selected: {range.start.toLocaleDateString()} – {range.end.toLocaleDateString()}
-                            <br />
-                            <Typography variant="caption" color="muted" className="block mt-1">
-                                Duration: {Math.ceil((range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24))} days
-                            </Typography>
+                        </Typography>
+                        <Typography variant="caption" color="muted" className="block mt-1">
+                            Duration: {Math.ceil((range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24))} days
                         </Typography>
                     </div>
                 )}
@@ -607,7 +606,7 @@ export const DatePickerPlayground = () => {
             title=""
             description=""
         >
-            <div className="space-y-8 w-max-4xl">
+            <div className="space-y-8 max-w-4xl">
                 {/* Controls */}
                 <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 p-6 rounded-2xl border-border/60 ">
                     <div className="space-y-2">

--- a/apps/docs/src/components/Demo/DatePickerDemo.tsx
+++ b/apps/docs/src/components/Demo/DatePickerDemo.tsx
@@ -3,8 +3,7 @@ import { DatePicker, type DateRange } from '@site/src/components/UI/date-picker'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { Button } from '@site/src/components/UI/button';
-import { Moon, Sun } from 'lucide-react';
+import { Button } from '@site/src/components/UI/button'
 import { Typography } from '@site/src/components/UI/typography';
 import { useColorMode } from '@docusaurus/theme-common';
 
@@ -19,7 +18,7 @@ const DemoSection = ({ title, description, children, code }: {
     <div className="space-y-4 mb-8">
         <div>
             <Typography variant="h4" weight="semibold">{title}</Typography>
-            <Typography variant="body-small" color="muted">{description}</Typography>
+            <Typography variant="body-small" color='muted'>{description}</Typography>
         </div>
         <Tabs>
             <TabItem value="preview" label="Preview">
@@ -98,7 +97,7 @@ function MyComponent() {
             description=""
             code={codeString}
         >
-            <div className="max-w-lg">
+            <div className="max-w-md">
                 <DatePicker
                     value={date || undefined}
                     onChange={handleSingleDateChange}
@@ -108,8 +107,8 @@ function MyComponent() {
                     themeMode={colorMode as 'light' | 'dark'}
                 />
                 {date && (
-                    <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded">
-                        <Typography variant="body-small">
+                    <div className="mt-4 p-3 border border-border/60 bg-muted/20 rounded-xl">
+                        <Typography variant="body-small" color="muted">
                             Selected: {date.toLocaleDateString('en-US', {
                                 weekday: 'long',
                                 year: 'numeric',
@@ -181,11 +180,11 @@ function MyComponent() {
                     clearButton
                 />
                 {range.start && range.end && (
-                    <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded">
-                        <Typography variant="body-small">
+                    <div className="mt-4 p-3 border border-border/60 bg-muted/20 rounded-xl">
+                        <Typography variant="body-small" color="muted">
                             Selected: {range.start.toLocaleDateString()} – {range.end.toLocaleDateString()}
                             <br />
-                            <Typography variant="caption" className="text-green-600 dark:text-green-400">
+                            <Typography variant="caption" color="muted" className="block mt-1">
                                 Duration: {Math.ceil((range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24))} days
                             </Typography>
                         </Typography>
@@ -220,47 +219,39 @@ export const SizeVariantsDemo = () => {
             description=""
             code={codeString}
         >
-            <div className="space-y-6 max-w-2xl">
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Small</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        size="sm"
-                        placeholder="Small date picker"
-                        value={dates.sm || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, sm: date as Date | null }))}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Medium (Default)</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        size="md"
-                        placeholder="Medium date picker"
-                        value={dates.md || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, md: date as Date | null }))}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Large</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        size="lg"
-                        placeholder="Large date picker"
-                        value={dates.lg || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, lg: date as Date | null }))}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Extra Large</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        size="xl"
-                        placeholder="Extra large date picker"
-                        value={dates.xl || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, xl: date as Date | null }))}
-                    />
-                </div>
+            <div className="grid grid-cols-2 gap-6 max-w-3xl">
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    size="sm"
+                    label="Small"
+                    placeholder="Small date picker"
+                    value={dates.sm || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, sm: date as Date | null }))}
+                />
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    size="md"
+                    label="Medium (Default)"
+                    placeholder="Medium date picker"
+                    value={dates.md || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, md: date as Date | null }))}
+                />
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    size="lg"
+                    label="Large"
+                    placeholder="Large date picker"
+                    value={dates.lg || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, lg: date as Date | null }))}
+                />
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    size="xl"
+                    label="Extra Large"
+                    placeholder="Extra large date picker"
+                    value={dates.xl || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, xl: date as Date | null }))}
+                />
             </div>
         </DemoSection>
     );
@@ -268,7 +259,7 @@ export const SizeVariantsDemo = () => {
 
 // Demo 4: Color Schemes
 export const ColorSchemesDemo = () => {
-    const [themeMode, setThemeMode] = useState<'light' | 'dark'>('dark');
+    const { colorMode } = useColorMode();
 
     const codeString = `
 // Different color schemes
@@ -286,33 +277,17 @@ export const ColorSchemesDemo = () => {
             description=""
             code={codeString}
         >
-            <div className="space-y-4">
-                <div className="flex items-center justify-between mb-4">
-                    <Typography variant="body" weight="medium">Theme Mode</Typography>
-                    <Button
-                        onClick={() => setThemeMode(themeMode === 'light' ? 'dark' : 'light')}
-                        variant="outline"
-                        size="sm"
-                        className="flex items-center gap-2"
-                    >
-                        {themeMode === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-                        {themeMode === 'dark' ? 'Light Mode' : 'Dark Mode'}
-                    </Button>
-                </div>
-
-                <div className={`grid grid-cols-2 gap-4 p-4 rounded-lg ${themeMode === 'dark' ? 'bg-gray-900' : 'bg-gray-50'}`}>
+            <div className="space-y-4 max-w-4xl">
+                <div className="grid grid-cols-3 gap-4 p-4 ">
                     {colorSchemeOptions.map((color) => (
-                        <div key={color.value} className="space-y-2">
-                            <Typography variant="label" className={themeMode === 'dark' ? 'text-gray-300' : 'text-gray-700'}>
-                                {color.label}
-                            </Typography>
-                            <DatePicker
-                                themeMode={themeMode}
-                                colorScheme={color.value as any}
-                                placeholder={`${color.label} theme`}
-                                size="sm"
-                            />
-                        </div>
+                        <DatePicker
+                            key={color.value}
+                            themeMode={colorMode as 'light' | 'dark'}
+                            colorScheme={color.value as any}
+                            label={color.label}
+                            placeholder={`${color.label} theme`}
+                            size="sm"
+                        />
                     ))}
                 </div>
             </div>
@@ -341,31 +316,28 @@ export const PopupPositionsDemo = () => {
             description=""
             code={codeString}
         >
-            <div className="space-y-6">
+            <div className="space-y-6 max-w-4xl">
                 <div className="grid grid-cols-3 gap-4">
                     {popupPositionOptions.map((position) => (
-                        <div key={position.value} className="space-y-2">
-                            <Typography variant="label" className="text-gray-700 dark:text-gray-300">
-                                {position.label}
-                            </Typography>
-                            <DatePicker
-                                themeMode={colorMode as 'light' | 'dark'}
-                                popupPosition={position.value as any}
-                                placeholder={position.label}
-                                size="sm"
-                                value={selectedPositions[position.value] || undefined}
-                                onChange={(date) => setSelectedPositions(prev => ({
-                                    ...prev,
-                                    [position.value]: date as Date | null
-                                }))}
-                            />
-                        </div>
+                        <DatePicker
+                            key={position.value}
+                            themeMode={colorMode as 'light' | 'dark'}
+                            popupPosition={position.value as any}
+                            label={position.label}
+                            placeholder={position.label}
+                            size="sm"
+                            value={selectedPositions[position.value] || undefined}
+                            onChange={(date) => setSelectedPositions(prev => ({
+                                ...prev,
+                                [position.value]: date as Date | null
+                            }))}
+                        />
                     ))}
                 </div>
 
                 <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded">
                     <Typography variant="body-small" className="text-amber-800 dark:text-amber-300">
-                        💡 Tip: The popup position automatically adjusts on small screens to ensure calendar visibility
+                        Tip: The popup position automatically adjusts on small screens to ensure calendar visibility
                     </Typography>
                 </div>
             </div>
@@ -542,60 +514,52 @@ export const ValidationExamplesDemo = () => {
             title=""
             description=""
         >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Required Field</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        required
-                        placeholder="Select a date (required)"
-                        value={dates.required || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, required: date as Date | null }))}
-                        helperText="This field must be filled"
-                        colorScheme="blue"
-                    />
-                </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl">
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    required
+                    placeholder="Select a date (required)"
+                    value={dates.required || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, required: date as Date | null }))}
+                    helperText="This field must be filled"
+                    colorScheme="blue"
+                    label="Required Field"
+                />
 
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Min/Max Date Constraints</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        minDate={today}
-                        maxDate={nextWeek}
-                        placeholder={`Select date within next week`}
-                        value={dates.minMax || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, minMax: date as Date | null }))}
-                        helperText={`Dates between ${today.toLocaleDateString()} and ${nextWeek.toLocaleDateString()}`}
-                        colorScheme="green"
-                    />
-                </div>
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    minDate={today}
+                    maxDate={nextWeek}
+                    placeholder="Select date within next week"
+                    value={dates.minMax || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, minMax: date as Date | null }))}
+                    helperText={`Dates between ${today.toLocaleDateString()} and ${nextWeek.toLocaleDateString()}`}
+                    colorScheme="green"
+                    label="Min/Max Date Constraints"
+                />
 
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Disabled Dates</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        disabledDates={disabledDates}
-                        placeholder="Select date (some dates disabled)"
-                        value={dates.disabled || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, disabled: date as Date | null }))}
-                        helperText="2nd and 4th from today are unavailable"
-                        colorScheme="orange"
-                    />
-                </div>
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    disabledDates={disabledDates}
+                    placeholder="Select date (some dates disabled)"
+                    value={dates.disabled || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, disabled: date as Date | null }))}
+                    helperText="2nd and 4th from today are unavailable"
+                    colorScheme="orange"
+                    label="Disabled Dates"
+                />
 
-                <div className="space-y-2">
-                    <Typography variant="label" className="text-gray-700 dark:text-gray-300">Error State</Typography>
-                    <DatePicker
-                        themeMode={colorMode as 'light' | 'dark'}
-                        error
-                        errorMessage="Invalid date selected"
-                        placeholder="This field has an error"
-                        value={dates.error || undefined}
-                        onChange={(date) => setDates(prev => ({ ...prev, error: date as Date | null }))}
-                        helperText="Showing error state"
-                        colorScheme="rose"
-                    />
-                </div>
+                <DatePicker
+                    themeMode={colorMode as 'light' | 'dark'}
+                    error
+                    errorMessage="Invalid date selected"
+                    placeholder="This field has an error"
+                    value={dates.error || undefined}
+                    onChange={(date) => setDates(prev => ({ ...prev, error: date as Date | null }))}
+                    helperText="Showing error state"
+                    colorScheme="rose"
+                    label="Error State"
+                />
             </div>
         </DemoSection>
     );
@@ -606,7 +570,6 @@ export const DatePickerPlayground = () => {
     const [config, setConfig] = useState<PlaygroundConfig>({
         variant: 'single',
         size: 'md',
-        themeMode: 'dark',
         colorScheme: 'blue',
         popupPosition: 'bottom-left',
         showIcon: true,
@@ -644,15 +607,15 @@ export const DatePickerPlayground = () => {
             title=""
             description=""
         >
-            <div className="space-y-8">
+            <div className="space-y-8 w-max-4xl">
                 {/* Controls */}
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4 border rounded-lg">
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 p-6 rounded-2xl border-border/60 ">
                     <div className="space-y-2">
-                        <Typography variant="caption" weight="medium">Variant</Typography>
+                        <Typography variant="caption" weight="bold" color="muted" className='pb-1'>Variant</Typography>
                         <select
                             value={config.variant}
                             onChange={(e) => handleConfigChange('variant', e.target.value as 'single' | 'range')}
-                            className="w-full px-3 py-1.5 text-sm border rounded"
+                            className="w-full px-3 py-2 text-sm rounded-xl border border-border/60 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-all duration-200 cursor-pointer"
                         >
                             <option value="single">Single Date</option>
                             <option value="range">Date Range</option>
@@ -660,11 +623,11 @@ export const DatePickerPlayground = () => {
                     </div>
 
                     <div className="space-y-2">
-                        <Typography variant="caption" weight="medium">Size</Typography>
+                        <Typography variant="caption" weight="bold" color="muted" className='pb-1'>Size</Typography>
                         <select
                             value={config.size}
                             onChange={(e) => handleConfigChange('size', e.target.value as 'sm' | 'md' | 'lg' | 'xl')}
-                            className="w-full px-3 py-1.5 text-sm border rounded"
+                            className="w-full px-3 py-2 text-sm rounded-xl border border-border/60 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-all duration-200 cursor-pointer"
                         >
                             {sizeOptions.map(option => (
                                 <option key={option.value} value={option.value}>{option.label}</option>
@@ -673,11 +636,11 @@ export const DatePickerPlayground = () => {
                     </div>
 
                     <div className="space-y-2">
-                        <Typography variant="caption" weight="medium">Color Scheme</Typography>
+                        <Typography variant="caption" weight="bold" color="muted" className='pb-1'>Color Scheme</Typography>
                         <select
                             value={config.colorScheme}
                             onChange={(e) => handleConfigChange('colorScheme', e.target.value as 'blue' | 'green' | 'purple' | 'orange' | 'slate' | 'rose')}
-                            className="w-full px-3 py-1.5 text-sm border rounded"
+                            className="w-full px-3 py-2 text-sm rounded-xl border border-border/60 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-all duration-200 cursor-pointer"
                         >
                             {colorSchemeOptions.map(option => (
                                 <option key={option.value} value={option.value}>{option.label}</option>
@@ -686,11 +649,11 @@ export const DatePickerPlayground = () => {
                     </div>
 
                     <div className="space-y-2">
-                        <Typography variant="caption" weight="medium">Popup Position</Typography>
+                        <Typography variant="caption" weight="bold" color="muted" className='pb-1'>Popup Position</Typography>
                         <select
                             value={config.popupPosition}
                             onChange={(e) => handleConfigChange('popupPosition', e.target.value as 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right' | 'left' | 'right')}
-                            className="w-full px-3 py-1.5 text-sm border rounded"
+                            className="w-full px-3 py-2 text-sm rounded-xl border border-border/60 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-all duration-200 cursor-pointer"
                         >
                             {popupPositionOptions.map(option => (
                                 <option key={option.value} value={option.value}>{option.label}</option>
@@ -698,44 +661,48 @@ export const DatePickerPlayground = () => {
                         </select>
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 mt-2">
                         <input
                             type="checkbox"
                             id="showIcon"
                             checked={config.showIcon}
                             onChange={(e) => handleConfigChange('showIcon', e.target.checked)}
+                            className="rounded border-border/60 text-primary focus:ring-ring cursor-pointer h-4 w-4 bg-background"
                         />
-                        <label htmlFor="showIcon" className="text-sm">Show Icon</label>
+                        <label htmlFor="showIcon" className="text-sm text-muted-foreground cursor-pointer font-medium select-none">Show Icon</label>
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 mt-2">
                         <input
                             type="checkbox"
                             id="todayButton"
                             checked={config.todayButton}
                             onChange={(e) => handleConfigChange('todayButton', e.target.checked)}
+                            className="rounded border-border/60 text-primary focus:ring-ring cursor-pointer h-4 w-4 bg-background"
                         />
-                        <label htmlFor="todayButton" className="text-sm">Today Button</label>
+                        <label htmlFor="todayButton" className="text-sm text-muted-foreground cursor-pointer font-medium select-none">Today Button</label>
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 mt-2">
                         <input
                             type="checkbox"
                             id="clearButton"
                             checked={config.clearButton}
                             onChange={(e) => handleConfigChange('clearButton', e.target.checked)}
+                            className="rounded border-border/60 text-primary focus:ring-ring cursor-pointer h-4 w-4 bg-background"
                         />
-                        <label htmlFor="clearButton" className="text-sm">Clear Button</label>
+                        <label htmlFor="clearButton" className="text-sm text-muted-foreground cursor-pointer font-medium select-none">Clear Button</label>
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 mt-2">
                         <input
                             type="checkbox"
                             id="required"
                             checked={config.required}
                             onChange={(e) => handleConfigChange('required', e.target.checked)}
+                            className="rounded border-border/60 text-primary focus:ring-ring cursor-pointer h-4 w-4 bg-background"
                         />
-                        <label htmlFor="required" className="text-sm">Required</label>
+                        <label htmlFor="required" className="text-sm text-muted-foreground cursor-pointer font-medium select-none">Required</label>
                     </div>
 
                     <div className="flex items-center gap-2">
@@ -744,44 +711,30 @@ export const DatePickerPlayground = () => {
                             id="disabled"
                             checked={config.disabled}
                             onChange={(e) => handleConfigChange('disabled', e.target.checked)}
+                            className="rounded border-border/60 text-primary focus:ring-ring cursor-pointer h-4 w-4 bg-background"
                         />
-                        <label htmlFor="disabled" className="text-sm">Disabled</label>
-                    </div>
-
-                    <div className="col-span-2 md:col-span-3 lg:col-span-4">
-                        <Button
-                            onClick={() => handleConfigChange('themeMode', config.themeMode === 'light' ? 'dark' : 'light')}
-                            variant="outline"
-                            size="sm"
-                            className="flex items-center gap-2"
-                        >
-                            {config.themeMode === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-                            Switch to {config.themeMode === 'light' ? 'Dark' : 'Light'} Theme
-                        </Button>
+                        <label htmlFor="disabled" className="text-sm text-muted-foreground cursor-pointer font-medium select-none">Disabled</label>
                     </div>
                 </div>
 
                 {/* Preview */}
-                <div className={`p-6 rounded-lg ${config.themeMode === 'dark' ? 'bg-gray-900' : 'bg-gray-50'}`}>
-                    <div className="max-w-md mx-auto">
-                        <DatePicker
-                            variant={config.variant}
-                            size={config.size}
-                            themeMode={config.themeMode}
-                            colorScheme={config.colorScheme as any}
-                            popupPosition={config.popupPosition as any}
-                            showIcon={config.showIcon}
-                            todayButton={config.todayButton}
-                            clearButton={config.clearButton}
-                            required={config.required}
-                            disabled={config.disabled}
-                            label={`${config.variant === 'single' ? 'Select Date' : 'Select Date Range'}`}
-                            placeholder={config.variant === 'single' ? 'Choose a date' : ['Start date', 'End date']}
-                            helperText="Interactive playground - customize using controls above"
-                            value={config.variant === 'single' ? date || undefined : range}
-                            onChange={config.variant === 'single' ? handleSingleDateChange : handleRangeDateChange}
-                        />
-                    </div>
+                <div className="max-w-md mx-auto">
+                    <DatePicker
+                        variant={config.variant}
+                        size={config.size}
+                        colorScheme={config.colorScheme as any}
+                        popupPosition={config.popupPosition as any}
+                        showIcon={config.showIcon}
+                        todayButton={config.todayButton}
+                        clearButton={config.clearButton}
+                        required={config.required}
+                        disabled={config.disabled}
+                        label={`${config.variant === 'single' ? 'Select Date' : 'Select Date Range'}`}
+                        placeholder={config.variant === 'single' ? 'Choose a date' : ['Start date', 'End date']}
+                        helperText="Interactive playground - customize using controls above"
+                        value={config.variant === 'single' ? date || undefined : range}
+                        onChange={config.variant === 'single' ? handleSingleDateChange : handleRangeDateChange}
+                    />
                 </div>
             </div>
         </DemoSection>
@@ -791,7 +744,6 @@ export const DatePickerPlayground = () => {
 type PlaygroundConfig = {
     variant: 'single' | 'range';
     size: 'sm' | 'md' | 'lg' | 'xl';
-    themeMode: 'light' | 'dark';
     colorScheme: string;
     popupPosition: string;
     showIcon: boolean;
@@ -916,7 +868,7 @@ function RangeDateExample() {
                         <Typography variant="body-small">
                             Selected Range:
                         </Typography>
-                        <Typography variant="caption" className="block">
+                        <Typography variant="caption" className="block pb-1">
                             Start: {rangeDate.start ? rangeDate.start.toLocaleDateString() : 'Not selected'}
                         </Typography>
                         <Typography variant="caption" className="block">

--- a/apps/docs/src/components/Demo/DatePickerDemo.tsx
+++ b/apps/docs/src/components/Demo/DatePickerDemo.tsx
@@ -417,7 +417,7 @@ function HotelBooking() {
       colorScheme="blue"
       todayButton
       clearButton
-      format="MMM DD, YYYY"
+      format="MM/DD/YYYY"
     />
   );
 }
@@ -446,7 +446,7 @@ function HotelBooking() {
                     colorScheme="blue"
                     todayButton
                     clearButton
-                    format="MMM DD, YYYY"
+                    format="MM/DD/YYYY"
                 />
 
                 {booking.start && booking.end && (

--- a/apps/docs/src/components/Demo/DatePickerDemo.tsx
+++ b/apps/docs/src/components/Demo/DatePickerDemo.tsx
@@ -364,10 +364,6 @@ export const HotelBookingDemo = () => {
         if (date.getDay() === 0 || date.getDay() === 6) {
             return date;
         }
-        // Randomly disable some weekdays for demo
-        if (Math.random() < 0.1) {
-            return date;
-        }
         return null;
     }).filter(Boolean) as Date[];
 

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -1259,7 +1259,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDate(value)) {
                     setSelectedDate(value);
                     setCurrentMonth(value);
-                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                    const dateChanged = !selectedDate !== !value || (!!selectedDate && !!value && !isSameDay(selectedDate, value));
+                    if (dateChanged) {
                         setInputValue(formatDate(value, format));
                     }
                 } else if (value === null || value === undefined) {
@@ -1270,8 +1271,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDateRange(value)) {
                     setSelectedRange(value);
                     if (value.start) setCurrentMonth(value.start);
-                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
-                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    const startChanged = !selectedRange.start !== !value.start || (!!selectedRange.start && !!value.start && !isSameDay(selectedRange.start, value.start));
+                    const endChanged = !selectedRange.end !== !value.end || (!!selectedRange.end && !!value.end && !isSameDay(selectedRange.end, value.end));
                     if (startChanged || endChanged) {
                         setRangeInputValue([
                             formatDate(value.start, format),

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -504,34 +504,60 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
 
     try {
         let day, month, year;
+        let yearStr = '';
 
         switch (format) {
-            case 'MM/DD/YYYY':
-                [month, day, year] = str.split('/').map(Number);
+            case 'MM/DD/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [month, day, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'DD/MM/YYYY':
-                [day, month, year] = str.split('/').map(Number);
+            }
+            case 'DD/MM/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [day, month, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'YYYY-MM-DD':
-                [year, month, day] = str.split('-').map(Number);
+            }
+            case 'YYYY-MM-DD': {
+                const parts = str.split('-');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
-            case 'YYYY/MM/DD':
-                [year, month, day] = str.split('/').map(Number);
+            }
+            case 'YYYY/MM/DD': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
+            }
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
+                if (parts.length < 3) return null;
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
+                yearStr = parts[2] || '';
                 break;
             }
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
+                if (parts2.length < 3) return null;
                 day = parseInt(parts2[0]);
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
                 year = parseInt(parts2[2]);
+                yearStr = parts2[2] || '';
                 break;
             }
+        }
+
+        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+        if (cleanYearStr.length !== 4) {
+            return null;
         }
 
         const date = new Date(year!, month! - 1, day!);
@@ -1050,7 +1076,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 {/* Today indicator dot */}
                                 {isToday && !isSelected && !isInRange && (
                                     <div className={cn(
-                                        "absolute -top-1 right-1 w-1.5 h-1.5 rounded-full opacity-60",
+                                        "absolute -top-1 right-0.5 w-1.5 h-1.5 rounded-full opacity-60",
                                         themeMode === 'dark' ? 'bg-blue-300' : 'bg-blue-500'
                                     )} />
                                 )}

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -499,73 +499,104 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
-    try {
-        let day, month, year;
-        let yearStr = '';
+    const parseWithFormat = (s: string, fmt: DateFormat): Date | null => {
+        try {
+            let day, month, year;
+            let yearStr = '';
+            const cleaned = s.trim();
 
-        switch (format) {
-            case 'MM/DD/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [month, day, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
+            switch (fmt) {
+                case 'MM/DD/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [month, day, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD/MM/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [day, month, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'YYYY-MM-DD': {
+                    const parts = cleaned.split('-');
+                    if (parts.length < 3) return null;
+                    [year, month, day] = parts.map(Number);
+                    yearStr = parts[0] || '';
+                    break;
+                }
+                case 'YYYY/MM/DD': {
+                    const communicativeParts = cleaned.split('/');
+                    if (communicativeParts.length < 3) return null;
+                    [year, month, day] = communicativeParts.map(Number);
+                    yearStr = communicativeParts[0] || '';
+                    break;
+                }
+                case 'MMM DD, YYYY': {
+                    const parts = cleaned.split(/[\s,]+/);
+                    if (parts.length < 3) return null;
+                    const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                    if (mIndex === -1) return null;
+                    month = mIndex + 1;
+                    day = parseInt(parts[1]);
+                    year = parseInt(parts[2]);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD MMM YYYY': {
+                    const parts2 = cleaned.split(/[\s,]+/);
+                    if (parts2.length < 3) return null;
+                    const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                    if (mIndex2 === -1) return null;
+                    day = parseInt(parts2[0]);
+                    month = mIndex2 + 1;
+                    year = parseInt(parts2[2]);
+                    yearStr = parts2[2] || '';
+                    break;
+                }
             }
-            case 'DD/MM/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [day, month, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'YYYY-MM-DD': {
-                const parts = str.split('-');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'YYYY/MM/DD': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'MMM DD, YYYY': {
-                const parts = str.split(' ');
-                if (parts.length < 3) return null;
-                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
-                if (mIndex === -1) return null;
-                month = mIndex + 1;
-                day = parseInt(parts[1]);
-                year = parseInt(parts[2]);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'DD MMM YYYY': {
-                const parts2 = str.split(' ');
-                if (parts2.length < 3) return null;
-                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
-                if (mIndex2 === -1) return null;
-                day = parseInt(parts2[0]);
-                month = mIndex2 + 1;
-                year = parseInt(parts2[2]);
-                yearStr = parts2[2] || '';
-                break;
-            }
-        }
 
-        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
-        if (cleanYearStr.length !== 4) {
+            const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+            if (cleanYearStr.length !== 4) {
+                return null;
+            }
+
+            const date = new Date(year!, month! - 1, day!);
+            return date.toString() !== 'Invalid Date' ? date : null;
+        } catch {
             return null;
         }
+    };
 
-        const date = new Date(year!, month! - 1, day!);
-        return date.toString() !== 'Invalid Date' ? date : null;
-    } catch {
-        return null;
+    const primaryResult = parseWithFormat(str, format);
+    if (primaryResult) return primaryResult;
+
+    const allFormats: DateFormat[] = [
+        'MM/DD/YYYY',
+        'DD/MM/YYYY',
+        'YYYY-MM-DD',
+        'YYYY/MM/DD',
+        'MMM DD, YYYY',
+        'DD MMM YYYY'
+    ];
+
+    for (const fmt of allFormats) {
+        if (fmt === format) continue;
+        const result = parseWithFormat(str, fmt);
+        if (result) return result;
     }
+
+    if (str.includes('-')) {
+        const slashed = str.replace(/-/g, '/');
+        for (const fmt of ['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD'] as DateFormat[]) {
+            const result = parseWithFormat(slashed, fmt);
+            if (result) return result;
+        }
+    }
+
+    return null;
 };
 
 /**
@@ -1352,16 +1383,43 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             newValues[index] = value;
             setRangeInputValue(newValues);
 
-            const date = parseDate(value, format);
-            const newRange = { ...selectedRange };
+            if (!value) {
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
 
+                setSelectedRange(newRange);
+                setInternalError(null);
+                onError?.(null);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
+                return;
+            }
+
+            const date = parseDate(value, format);
+            if (!date) {
+                setInternalError('Invalid date format');
+                onError?.('Invalid date format');
+                
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
+                setSelectedRange(newRange);
+                return;
+            }
+
+            const newRange = { ...selectedRange };
             if (index === 0) {
                 newRange.start = date;
             } else {
                 newRange.end = date;
             }
 
-            // Validate if both dates are set
+            setInternalError(null);
+            onError?.(null);
+            setCurrentMonth(date);
+
             if (newRange.start && newRange.end) {
                 const error = validateOnChange ? validateDate(newRange.start) || validateDate(newRange.end) : null;
                 setInternalError(error);
@@ -1385,6 +1443,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                     onChange?.(newRange);
                 }
             } else {
+                const singleDate = newRange.start || newRange.end;
+                const error = validateOnChange ? validateDate(singleDate) : null;
+                setInternalError(error);
+                onError?.(error);
+
                 setSelectedRange(newRange);
                 if (allowEmpty || !newRange.end) {
                     onChange?.(newRange);

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -1294,7 +1294,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             } else if (newRange.start && !newRange.end) {
                 // Complete the range
                 if (date < newRange.start) {
-                    newRange = { start: date, end: newRange.start };
+                    newRange = { start: date, end: null };
                 } else {
                     newRange = { start: newRange.start, end: date };
                 }
@@ -1311,7 +1311,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (autoClose) {
                     setTimeout(() => setIsOpen(false), 100);
                 }
-            } else if (onChange && allowEmpty) {
+            } else if (onChange && (allowEmpty || !newRange.end)) {
                 onChange(newRange);
             }
         };
@@ -1367,12 +1367,27 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 onError?.(error);
 
                 if (!error) {
+                    if (newRange.end < newRange.start) {
+                        if (index === 1) {
+                            newRange.start = newRange.end;
+                            newRange.end = null;
+                            newValues[0] = value;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        } else {
+                            newRange.end = null;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        }
+                    }
                     setSelectedRange(newRange);
                     onChange?.(newRange);
                 }
-            } else if (allowEmpty) {
+            } else {
                 setSelectedRange(newRange);
-                onChange?.(newRange);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
             }
         };
 

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -564,7 +564,17 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             }
 
             const date = new Date(year!, month! - 1, day!);
-            return date.toString() !== 'Invalid Date' ? date : null;
+            if (date.toString() === 'Invalid Date') return null;
+
+            if (
+                date.getFullYear() !== year ||
+                date.getMonth() !== month! - 1 ||
+                date.getDate() !== day
+            ) {
+                return null;
+            }
+
+            return date;
         } catch {
             return null;
         }
@@ -1245,29 +1255,48 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const colorStyles = getColorStyles(colorScheme);
 
         useEffect(() => {
-            if (variant === 'single' && isDate(value)) {
-                setSelectedDate(value);
-                setInputValue(formatDate(value, format));
-                setCurrentMonth(value);
-            } else if (variant === 'range' && isDateRange(value)) {
-                setSelectedRange(value);
-                setRangeInputValue([
-                    formatDate(value.start, format),
-                    formatDate(value.end, format)
-                ]);
-                if (value.start) setCurrentMonth(value.start);
-
-            } else if (value === null || value === undefined) {
-                // Handle null/undefined values
-                if (variant === 'single') {
+            if (variant === 'single') {
+                if (isDate(value)) {
+                    setSelectedDate(value);
+                    setCurrentMonth(value);
+                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                        setInputValue(formatDate(value, format));
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedDate(null);
                     setInputValue('');
-                } else {
+                }
+            } else if (variant === 'range') {
+                if (isDateRange(value)) {
+                    setSelectedRange(value);
+                    if (value.start) setCurrentMonth(value.start);
+                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
+                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    if (startChanged || endChanged) {
+                        setRangeInputValue([
+                            formatDate(value.start, format),
+                            formatDate(value.end, format)
+                        ]);
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedRange({ start: null, end: null });
                     setRangeInputValue(['', '']);
                 }
             }
         }, [value, variant, format]);
+
+        useEffect(() => {
+            if (!isOpen) {
+                if (variant === 'single' && selectedDate) {
+                    setInputValue(formatDate(selectedDate, format));
+                } else if (variant === 'range') {
+                    setRangeInputValue([
+                        formatDate(selectedRange.start, format),
+                        formatDate(selectedRange.end, format)
+                    ]);
+                }
+            }
+        }, [isOpen, variant, format, selectedDate, selectedRange]);
 
         // Handle click outside
         useEffect(() => {
@@ -1401,7 +1430,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             if (!date) {
                 setInternalError('Invalid date format');
                 onError?.('Invalid date format');
-                
+
                 const newRange = { ...selectedRange };
                 if (index === 0) newRange.start = null;
                 else newRange.end = null;

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -636,10 +636,10 @@ const getInRangeStyle = (themeMode: ThemeMode, colorScheme: ColorScheme): string
  */
 const getPopupPositionClasses = (position: string): string => {
     const positions: Record<string, string> = {
-        'bottom-left': 'top-full left-0 mt-2',
-        'bottom-right': 'top-full right-0 mt-2',
-        'top-left': 'bottom-full left-0 mb-2',
-        'top-right': 'bottom-full right-0 mb-2',
+        'bottom-left': 'top-full right-0 mt-2',
+        'bottom-right': 'top-full left-0 mt-2',
+        'top-left': 'bottom-full right-0 mb-2',
+        'top-right': 'bottom-full left-0 mb-2',
         'left': 'right-full top-0 mr-2',
         'right': 'left-full top-0 ml-2',
     };

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -12,15 +12,43 @@ function useDocusaurusTheme(): ThemeMode {
     const [theme, setTheme] = useState<ThemeMode>('light');
 
     useEffect(() => {
-        if (typeof document === 'undefined') return;
+        if (typeof window === 'undefined') return;
 
         const root = document.documentElement;
-        const read = () => (root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light') as ThemeMode;
+        const body = document.body;
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const read = (): ThemeMode => {
+            const hasDarkClass = root.classList.contains('dark') || body.classList.contains('dark');
+            const hasDarkThemeAttr = root.getAttribute('data-theme') === 'dark';
+
+            if (hasDarkClass || hasDarkThemeAttr) {
+                return 'dark';
+            }
+            if (
+                root.classList.contains('light') ||
+                body.classList.contains('light') ||
+                root.getAttribute('data-theme') === 'light'
+            ) {
+                return 'light';
+            }
+
+            return mediaQuery.matches ? 'dark' : 'light';
+        };
+
         setTheme(read());
 
         const observer = new MutationObserver(() => setTheme(read()));
-        observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-        return () => observer.disconnect();
+        observer.observe(root, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+        observer.observe(body, { attributes: true, attributeFilter: ['class'] });
+
+        const listener = () => setTheme(read());
+        mediaQuery.addEventListener('change', listener);
+
+        return () => {
+            observer.disconnect();
+            mediaQuery.removeEventListener('change', listener);
+        };
     }, []);
 
     return theme;
@@ -690,6 +718,7 @@ const InputField: React.FC<InputFieldProps> = ({
                 placeholder={placeholder}
                 className={cn(
                     "w-full bg-transparent outline-none font-medium tracking-wide",
+                    showIcon && "pr-8",
                     themeStyles.text.primary,
                     themeStyles.placeholder,
                     disabled && "cursor-not-allowed",
@@ -771,6 +800,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
 
             <Typography
                 variant="body"
+                color="inherit"
                 className={themeStyles.text.muted}
             >
                 –
@@ -785,6 +815,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
                     placeholder={Array.isArray(placeholder) ? placeholder[1] : 'End date'}
                     className={cn(
                         "w-full bg-transparent outline-none font-medium tracking-wide",
+                        showIcon && "pr-8",
                         themeStyles.text.primary,
                         themeStyles.placeholder,
                         disabled && "cursor-not-allowed",
@@ -887,6 +918,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                     <Typography
                         variant="h6"
                         weight="bold"
+                        color="inherit"
                         className={cn("tracking-tight", themeStyles.header)}
                     >
                         {monthNames[currentMonthIndex]} {currentYear}
@@ -917,6 +949,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                         variant="caption"
                         weight="semibold"
                         align="center"
+                        color="inherit"
                         className={cn("py-2 tracking-wide", themeStyles.weekday)}
                     >
                         {getDayName(index)}
@@ -986,6 +1019,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 <Typography
                                     variant="body-small"
                                     weight={(isSelected || isStart || isEnd) ? "bold" : "normal"}
+                                    color="inherit"
                                     className={cn(
                                         "relative z-10",
                                         (isSelected || isStart || isEnd) && "!text-white",
@@ -1038,28 +1072,23 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                             variant="outline"
                             size="sm"
                             onClick={onTodayClick}
-                            className="flex-1 rounded-xl shadow-sm hover:shadow text-slate-500 cursor-pointer"
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer border-border/60 hover:bg-muted/50 bg-background text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {todayText}
                             </Typography>
                         </Button>
                     )}
                     {clearButton && (
                         <Button
-                            variant="ghost"
+                            variant="secondary"
                             size="sm"
                             onClick={onClearClick}
-                            className={cn(
-                                "flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer",
-                                themeMode === 'dark'
-                                    ? "bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-700 hover:to-gray-800 text-gray-300"
-                                    : "bg-gradient-to-r from-gray-50 to-gray-100 hover:from-gray-100 hover:to-gray-200 text-gray-600"
-                            )}
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {clearText}
                             </Typography>
                         </Button>
@@ -1356,16 +1385,17 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const hasError = Boolean(error) || !!internalError;
 
         return (
-            <div ref={containerRef} className={cn("relative", className)}>
+            <div ref={containerRef} className={cn("relative text-foreground space-y-3", themeMode, className)}>
                 {label && (
                     <motion.label
                         initial={{ opacity: 0, y: -5 }}
                         animate={{ opacity: 1, y: 0 }}
-                        className="block mb-2"
+                        className="block mb-1"
                     >
                         <Typography
                             variant="label"
                             weight="semibold"
+                            color="inherit"
                             className={cn("tracking-wide", themeStyles.text.primary)}
                         >
                             {label}

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -1156,7 +1156,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             allowEmpty = false,
             todayButton = true,
             clearButton = true,
-            autoClose = false,
+            autoClose = true,
             className,
             inputClassName,
             calendarClassName,

--- a/apps/docs/src/components/UI/date-picker/index.tsx
+++ b/apps/docs/src/components/UI/date-picker/index.tsx
@@ -496,9 +496,6 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
     }
 };
 
-/**
- * Parses a date string into a Date object based on specified format
- */
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
@@ -538,7 +535,9 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
                 if (parts.length < 3) return null;
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
+                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                if (mIndex === -1) return null;
+                month = mIndex + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
                 yearStr = parts[2] || '';
@@ -547,8 +546,10 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
                 if (parts2.length < 3) return null;
+                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                if (mIndex2 === -1) return null;
                 day = parseInt(parts2[0]);
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
+                month = mIndex2 + 1;
                 year = parseInt(parts2[2]);
                 yearStr = parts2[2] || '';
                 break;

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -1298,7 +1298,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDate(value)) {
                     setSelectedDate(value);
                     setCurrentMonth(value);
-                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                    const dateChanged = !selectedDate !== !value || (!!selectedDate && !!value && !isSameDay(selectedDate, value));
+                    if (dateChanged) {
                         setInputValue(formatDate(value, format));
                     }
                 } else if (value === null || value === undefined) {
@@ -1309,8 +1310,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDateRange(value)) {
                     setSelectedRange(value);
                     if (value.start) setCurrentMonth(value.start);
-                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
-                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    const startChanged = !selectedRange.start !== !value.start || (!!selectedRange.start && !!value.start && !isSameDay(selectedRange.start, value.start));
+                    const endChanged = !selectedRange.end !== !value.end || (!!selectedRange.end && !!value.end && !isSameDay(selectedRange.end, value.end));
                     if (startChanged || endChanged) {
                         setRangeInputValue([
                             formatDate(value.start, format),

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -1195,7 +1195,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             allowEmpty = false,
             todayButton = true,
             clearButton = true,
-            autoClose = false,
+            autoClose = true,
             className,
             inputClassName,
             calendarClassName,

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -1333,7 +1333,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             } else if (newRange.start && !newRange.end) {
                 // Complete the range
                 if (date < newRange.start) {
-                    newRange = { start: date, end: newRange.start };
+                    newRange = { start: date, end: null };
                 } else {
                     newRange = { start: newRange.start, end: date };
                 }
@@ -1350,7 +1350,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (autoClose) {
                     setTimeout(() => setIsOpen(false), 100);
                 }
-            } else if (onChange && allowEmpty) {
+            } else if (onChange && (allowEmpty || !newRange.end)) {
                 onChange(newRange);
             }
         };
@@ -1406,12 +1406,27 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 onError?.(error);
 
                 if (!error) {
+                    if (newRange.end < newRange.start) {
+                        if (index === 1) {
+                            newRange.start = newRange.end;
+                            newRange.end = null;
+                            newValues[0] = value;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        } else {
+                            newRange.end = null;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        }
+                    }
                     setSelectedRange(newRange);
                     onChange?.(newRange);
                 }
-            } else if (allowEmpty) {
+            } else {
                 setSelectedRange(newRange);
-                onChange?.(newRange);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
             }
         };
 

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -8,15 +8,15 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { DatePicker } from '@site/src/components/UI/date-picker';
 import {
-  BasicDatePickerDemo,
-  RangeDatePickerDemo,
-  SizeVariantsDemo,
-  ColorSchemesDemo,
-  PopupPositionsDemo,
-  HotelBookingDemo,
-  EventRegistrationDemo,
-  ValidationExamplesDemo,
-  DatePickerPlayground, SimpleControlledDemo, ControlledDatePickerDemo
+    BasicDatePickerDemo,
+    RangeDatePickerDemo,
+    SizeVariantsDemo,
+    ColorSchemesDemo,
+    PopupPositionsDemo,
+    HotelBookingDemo,
+    EventRegistrationDemo,
+    ValidationExamplesDemo,
+    DatePickerPlayground, SimpleControlledDemo, ControlledDatePickerDemo
 } from '@site/src/components/Demo/DatePickerDemo';
 import { Calender } from 'lucide-react';
 
@@ -543,34 +543,60 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
 
     try {
         let day, month, year;
+        let yearStr = '';
 
         switch (format) {
-            case 'MM/DD/YYYY':
-                [month, day, year] = str.split('/').map(Number);
+            case 'MM/DD/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [month, day, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'DD/MM/YYYY':
-                [day, month, year] = str.split('/').map(Number);
+            }
+            case 'DD/MM/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [day, month, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'YYYY-MM-DD':
-                [year, month, day] = str.split('-').map(Number);
+            }
+            case 'YYYY-MM-DD': {
+                const parts = str.split('-');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
-            case 'YYYY/MM/DD':
-                [year, month, day] = str.split('/').map(Number);
+            }
+            case 'YYYY/MM/DD': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
+            }
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
+                if (parts.length < 3) return null;
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
+                yearStr = parts[2] || '';
                 break;
             }
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
+                if (parts2.length < 3) return null;
                 day = parseInt(parts2[0]);
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
                 year = parseInt(parts2[2]);
+                yearStr = parts2[2] || '';
                 break;
             }
+        }
+
+        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+        if (cleanYearStr.length !== 4) {
+            return null;
         }
 
         const date = new Date(year!, month! - 1, day!);

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -603,7 +603,17 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             }
 
             const date = new Date(year!, month! - 1, day!);
-            return date.toString() !== 'Invalid Date' ? date : null;
+            if (date.toString() === 'Invalid Date') return null;
+
+            if (
+                date.getFullYear() !== year ||
+                date.getMonth() !== month! - 1 ||
+                date.getDate() !== day
+            ) {
+                return null;
+            }
+
+            return date;
         } catch {
             return null;
         }
@@ -1284,29 +1294,48 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const colorStyles = getColorStyles(colorScheme);
 
         useEffect(() => {
-            if (variant === 'single' && isDate(value)) {
-                setSelectedDate(value);
-                setInputValue(formatDate(value, format));
-                setCurrentMonth(value);
-            } else if (variant === 'range' && isDateRange(value)) {
-                setSelectedRange(value);
-                setRangeInputValue([
-                    formatDate(value.start, format),
-                    formatDate(value.end, format)
-                ]);
-                if (value.start) setCurrentMonth(value.start);
-
-            } else if (value === null || value === undefined) {
-                // Handle null/undefined values
-                if (variant === 'single') {
+            if (variant === 'single') {
+                if (isDate(value)) {
+                    setSelectedDate(value);
+                    setCurrentMonth(value);
+                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                        setInputValue(formatDate(value, format));
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedDate(null);
                     setInputValue('');
-                } else {
+                }
+            } else if (variant === 'range') {
+                if (isDateRange(value)) {
+                    setSelectedRange(value);
+                    if (value.start) setCurrentMonth(value.start);
+                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
+                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    if (startChanged || endChanged) {
+                        setRangeInputValue([
+                            formatDate(value.start, format),
+                            formatDate(value.end, format)
+                        ]);
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedRange({ start: null, end: null });
                     setRangeInputValue(['', '']);
                 }
             }
         }, [value, variant, format]);
+
+        useEffect(() => {
+            if (!isOpen) {
+                if (variant === 'single' && selectedDate) {
+                    setInputValue(formatDate(selectedDate, format));
+                } else if (variant === 'range') {
+                    setRangeInputValue([
+                        formatDate(selectedRange.start, format),
+                        formatDate(selectedRange.end, format)
+                    ]);
+                }
+            }
+        }, [isOpen, variant, format, selectedDate, selectedRange]);
 
         // Handle click outside
         useEffect(() => {

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -538,73 +538,104 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
-    try {
-        let day, month, year;
-        let yearStr = '';
+    const parseWithFormat = (s: string, fmt: DateFormat): Date | null => {
+        try {
+            let day, month, year;
+            let yearStr = '';
+            const cleaned = s.trim();
 
-        switch (format) {
-            case 'MM/DD/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [month, day, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
+            switch (fmt) {
+                case 'MM/DD/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [month, day, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD/MM/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [day, month, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'YYYY-MM-DD': {
+                    const parts = cleaned.split('-');
+                    if (parts.length < 3) return null;
+                    [year, month, day] = parts.map(Number);
+                    yearStr = parts[0] || '';
+                    break;
+                }
+                case 'YYYY/MM/DD': {
+                    const communicativeParts = cleaned.split('/');
+                    if (communicativeParts.length < 3) return null;
+                    [year, month, day] = communicativeParts.map(Number);
+                    yearStr = communicativeParts[0] || '';
+                    break;
+                }
+                case 'MMM DD, YYYY': {
+                    const parts = cleaned.split(/[\s,]+/);
+                    if (parts.length < 3) return null;
+                    const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                    if (mIndex === -1) return null;
+                    month = mIndex + 1;
+                    day = parseInt(parts[1]);
+                    year = parseInt(parts[2]);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD MMM YYYY': {
+                    const parts2 = cleaned.split(/[\s,]+/);
+                    if (parts2.length < 3) return null;
+                    const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                    if (mIndex2 === -1) return null;
+                    day = parseInt(parts2[0]);
+                    month = mIndex2 + 1;
+                    year = parseInt(parts2[2]);
+                    yearStr = parts2[2] || '';
+                    break;
+                }
             }
-            case 'DD/MM/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [day, month, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'YYYY-MM-DD': {
-                const parts = str.split('-');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'YYYY/MM/DD': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'MMM DD, YYYY': {
-                const parts = str.split(' ');
-                if (parts.length < 3) return null;
-                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
-                if (mIndex === -1) return null;
-                month = mIndex + 1;
-                day = parseInt(parts[1]);
-                year = parseInt(parts[2]);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'DD MMM YYYY': {
-                const parts2 = str.split(' ');
-                if (parts2.length < 3) return null;
-                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
-                if (mIndex2 === -1) return null;
-                day = parseInt(parts2[0]);
-                month = mIndex2 + 1;
-                year = parseInt(parts2[2]);
-                yearStr = parts2[2] || '';
-                break;
-            }
-        }
 
-        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
-        if (cleanYearStr.length !== 4) {
+            const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+            if (cleanYearStr.length !== 4) {
+                return null;
+            }
+
+            const date = new Date(year!, month! - 1, day!);
+            return date.toString() !== 'Invalid Date' ? date : null;
+        } catch {
             return null;
         }
+    };
 
-        const date = new Date(year!, month! - 1, day!);
-        return date.toString() !== 'Invalid Date' ? date : null;
-    } catch {
-        return null;
+    const primaryResult = parseWithFormat(str, format);
+    if (primaryResult) return primaryResult;
+
+    const allFormats: DateFormat[] = [
+        'MM/DD/YYYY',
+        'DD/MM/YYYY',
+        'YYYY-MM-DD',
+        'YYYY/MM/DD',
+        'MMM DD, YYYY',
+        'DD MMM YYYY'
+    ];
+
+    for (const fmt of allFormats) {
+        if (fmt === format) continue;
+        const result = parseWithFormat(str, fmt);
+        if (result) return result;
     }
+
+    if (str.includes('-')) {
+        const slashed = str.replace(/-/g, '/');
+        for (const fmt of ['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD'] as DateFormat[]) {
+            const result = parseWithFormat(slashed, fmt);
+            if (result) return result;
+        }
+    }
+
+    return null;
 };
 
 /**
@@ -1391,16 +1422,43 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             newValues[index] = value;
             setRangeInputValue(newValues);
 
-            const date = parseDate(value, format);
-            const newRange = { ...selectedRange };
+            if (!value) {
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
 
+                setSelectedRange(newRange);
+                setInternalError(null);
+                onError?.(null);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
+                return;
+            }
+
+            const date = parseDate(value, format);
+            if (!date) {
+                setInternalError('Invalid date format');
+                onError?.('Invalid date format');
+                
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
+                setSelectedRange(newRange);
+                return;
+            }
+
+            const newRange = { ...selectedRange };
             if (index === 0) {
                 newRange.start = date;
             } else {
                 newRange.end = date;
             }
 
-            // Validate if both dates are set
+            setInternalError(null);
+            onError?.(null);
+            setCurrentMonth(date);
+
             if (newRange.start && newRange.end) {
                 const error = validateOnChange ? validateDate(newRange.start) || validateDate(newRange.end) : null;
                 setInternalError(error);
@@ -1424,6 +1482,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                     onChange?.(newRange);
                 }
             } else {
+                const singleDate = newRange.start || newRange.end;
+                const error = validateOnChange ? validateDate(singleDate) : null;
+                setInternalError(error);
+                onError?.(error);
+
                 setSelectedRange(newRange);
                 if (allowEmpty || !newRange.end) {
                     onChange?.(newRange);

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -535,9 +535,6 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
     }
 };
 
-/**
- * Parses a date string into a Date object based on specified format
- */
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
@@ -577,7 +574,9 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
                 if (parts.length < 3) return null;
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
+                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                if (mIndex === -1) return null;
+                month = mIndex + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
                 yearStr = parts[2] || '';
@@ -586,8 +585,10 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
                 if (parts2.length < 3) return null;
+                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                if (mIndex2 === -1) return null;
                 day = parseInt(parts2[0]);
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
+                month = mIndex2 + 1;
                 year = parseInt(parts2[2]);
                 yearStr = parts2[2] || '';
                 break;

--- a/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/date-picker.mdx
@@ -36,6 +36,7 @@ The DatePicker component is a flexible and feature-rich date selection component
 ``` tsx
 
 
+
 'use client';
 
 import React, { useState, useEffect, useRef, forwardRef } from 'react';
@@ -50,15 +51,43 @@ function useDocusaurusTheme(): ThemeMode {
     const [theme, setTheme] = useState<ThemeMode>('light');
 
     useEffect(() => {
-        if (typeof document === 'undefined') return;
+        if (typeof window === 'undefined') return;
 
         const root = document.documentElement;
-        const read = () => (root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light') as ThemeMode;
+        const body = document.body;
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const read = (): ThemeMode => {
+            const hasDarkClass = root.classList.contains('dark') || body.classList.contains('dark');
+            const hasDarkThemeAttr = root.getAttribute('data-theme') === 'dark';
+
+            if (hasDarkClass || hasDarkThemeAttr) {
+                return 'dark';
+            }
+            if (
+                root.classList.contains('light') ||
+                body.classList.contains('light') ||
+                root.getAttribute('data-theme') === 'light'
+            ) {
+                return 'light';
+            }
+
+            return mediaQuery.matches ? 'dark' : 'light';
+        };
+
         setTheme(read());
 
         const observer = new MutationObserver(() => setTheme(read()));
-        observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-        return () => observer.disconnect();
+        observer.observe(root, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+        observer.observe(body, { attributes: true, attributeFilter: ['class'] });
+
+        const listener = () => setTheme(read());
+        mediaQuery.addEventListener('change', listener);
+
+        return () => {
+            observer.disconnect();
+            mediaQuery.removeEventListener('change', listener);
+        };
     }, []);
 
     return theme;
@@ -728,6 +757,7 @@ const InputField: React.FC<InputFieldProps> = ({
                 placeholder={placeholder}
                 className={cn(
                     "w-full bg-transparent outline-none font-medium tracking-wide",
+                    showIcon && "pr-8",
                     themeStyles.text.primary,
                     themeStyles.placeholder,
                     disabled && "cursor-not-allowed",
@@ -809,6 +839,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
 
             <Typography
                 variant="body"
+                color="inherit"
                 className={themeStyles.text.muted}
             >
                 –
@@ -823,6 +854,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
                     placeholder={Array.isArray(placeholder) ? placeholder[1] : 'End date'}
                     className={cn(
                         "w-full bg-transparent outline-none font-medium tracking-wide",
+                        showIcon && "pr-8",
                         themeStyles.text.primary,
                         themeStyles.placeholder,
                         disabled && "cursor-not-allowed",
@@ -925,6 +957,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                     <Typography
                         variant="h6"
                         weight="bold"
+                        color="inherit"
                         className={cn("tracking-tight", themeStyles.header)}
                     >
                         {monthNames[currentMonthIndex]} {currentYear}
@@ -955,6 +988,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                         variant="caption"
                         weight="semibold"
                         align="center"
+                        color="inherit"
                         className={cn("py-2 tracking-wide", themeStyles.weekday)}
                     >
                         {getDayName(index)}
@@ -1024,6 +1058,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 <Typography
                                     variant="body-small"
                                     weight={(isSelected || isStart || isEnd) ? "bold" : "normal"}
+                                    color="inherit"
                                     className={cn(
                                         "relative z-10",
                                         (isSelected || isStart || isEnd) && "!text-white",
@@ -1076,28 +1111,23 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                             variant="outline"
                             size="sm"
                             onClick={onTodayClick}
-                            className="flex-1 rounded-xl shadow-sm hover:shadow text-slate-500 cursor-pointer"
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer border-border/60 hover:bg-muted/50 bg-background text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {todayText}
                             </Typography>
                         </Button>
                     )}
                     {clearButton && (
                         <Button
-                            variant="ghost"
+                            variant="secondary"
                             size="sm"
                             onClick={onClearClick}
-                            className={cn(
-                                "flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer",
-                                themeMode === 'dark'
-                                    ? "bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-700 hover:to-gray-800 text-gray-300"
-                                    : "bg-gradient-to-r from-gray-50 to-gray-100 hover:from-gray-100 hover:to-gray-200 text-gray-600"
-                            )}
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {clearText}
                             </Typography>
                         </Button>
@@ -1394,16 +1424,17 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const hasError = Boolean(error) || !!internalError;
 
         return (
-            <div ref={containerRef} className={cn("relative", className)}>
+            <div ref={containerRef} className={cn("relative text-foreground space-y-3", themeMode, className)}>
                 {label && (
                     <motion.label
                         initial={{ opacity: 0, y: -5 }}
                         animate={{ opacity: 1, y: 0 }}
-                        className="block mb-2"
+                        className="block mb-1"
                     >
                         <Typography
                             variant="label"
                             weight="semibold"
+                            color="inherit"
                             className={cn("tracking-wide", themeStyles.text.primary)}
                         >
                             {label}
@@ -1540,6 +1571,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
 DatePicker.displayName = 'DatePicker';
 
 export { DatePicker };
+
   ```
     </TabItem>
 </Tabs>

--- a/apps/storybook/src/components/date-picker/date-picker.stories.tsx
+++ b/apps/storybook/src/components/date-picker/date-picker.stories.tsx
@@ -118,7 +118,6 @@ export const SingleDatePicker = () => {
                 placeholder="Pick a date"
                 label="Select Date"
                 helperText="Choose any date from the calendar"
-                themeMode="light"
                 colorScheme="blue"
             />
             {date && (
@@ -142,7 +141,6 @@ export const RangeDatePicker = () => {
                 placeholder={['Start date', 'End date']}
                 label="Select Date Range"
                 helperText="Choose start and end dates"
-                themeMode="light"
                 colorScheme="green"
             />
             {range.start && range.end && (
@@ -155,91 +153,69 @@ export const RangeDatePicker = () => {
 };
 
 export const DifferentSizes = () => (
-    <div className="space-y-6 p-6 border rounded-lg dark:border-gray-700">
+    <div className="space-y-6 p-6 border rounded-lg border-slate-200 dark:border-slate-800">
         <div className="space-y-2">
             <Typography variant="label" color="muted">Small</Typography>
-            <DatePicker size="sm" placeholder="Small picker" themeMode="light" colorScheme="blue" />
+            <DatePicker size="sm" placeholder="Small picker" colorScheme="blue" />
         </div>
         <div className="space-y-2">
             <Typography variant="label" color="muted">Medium (Default)</Typography>
-            <DatePicker size="md" placeholder="Medium picker" themeMode="light" colorScheme="green" />
+            <DatePicker size="md" placeholder="Medium picker" colorScheme="green" />
         </div>
         <div className="space-y-2">
             <Typography variant="label" color="muted">Large</Typography>
-            <DatePicker size="lg" placeholder="Large picker" themeMode="light" colorScheme="purple" />
+            <DatePicker size="lg" placeholder="Large picker" colorScheme="purple" />
         </div>
         <div className="space-y-2">
             <Typography variant="label" color="muted">Extra Large</Typography>
-            <DatePicker size="xl" placeholder="Extra large picker" themeMode="light" colorScheme="orange" />
+            <DatePicker size="xl" placeholder="Extra large picker" colorScheme="orange" />
         </div>
     </div>
 );
 
 export const AllColorSchemes = () => {
-    const [themeMode, setThemeMode] = useState<ThemeMode>('light');
-
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between">
                 <Typography variant="h3" weight="semibold">
                     All Color Schemes - Solid Backgrounds
                 </Typography>
-                <Button
-                    onClick={() => setThemeMode(themeMode === 'light' ? 'dark' : 'light')}
-                    variant="outline"
-                    className="flex items-center gap-2"
-                    animationVariant="press3DSoft"
-                >
-                    {themeMode === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-                    <Typography variant="body-small" weight="medium">
-                        Switch to {themeMode === 'light' ? 'Dark' : 'Light'}
-                    </Typography>
-                </Button>
             </div>
 
-            <div className={cn(
-                "p-6 border rounded-2xl space-y-6",
-                themeMode === 'dark'
-                    ? "bg-gray-950 border-gray-800"
-                    : "bg-white border-gray-200"
-            )}>
+            <div className="p-6 border rounded-2xl space-y-6 border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
                 {(['blue', 'green', 'purple', 'orange', 'slate', 'rose'] as ColorScheme[]).map((colorScheme) => (
                     <div key={colorScheme} className="space-y-2">
                         <Typography
                             variant="label"
-                            className={themeMode === 'dark' ? "text-gray-300" : "text-gray-700"}
+                            className="text-slate-700 dark:text-slate-300"
                             transform="capitalize"
                         >
                             {colorScheme} Color Scheme
                         </Typography>
                         <DatePicker
-                            themeMode={themeMode}
                             colorScheme={colorScheme}
                             placeholder={`${colorScheme} theme`}
-                            helperText={`${themeMode === 'light' ? 'Light' : 'Dark'} theme with ${colorScheme} colors`}
+                            helperText={`Theme with ${colorScheme} colors`}
                         />
                     </div>
                 ))}
             </div>
 
-            <div className={cn(
-                "p-4 rounded-lg",
-                themeMode === 'dark' ? "bg-gray-800" : "bg-gray-100"
-            )}>
-                <Typography variant="body-small" weight="medium" className={themeMode === 'dark' ? "text-gray-300" : "text-gray-700"}>
+            <div className="p-4 rounded-lg bg-slate-100 dark:bg-slate-850">
+                <Typography variant="body-small" weight="medium" className="text-slate-700 dark:text-slate-300">
                     Note: All backgrounds are now solid:
                 </Typography>
                 <ul className="mt-2 space-y-1">
-                    <Typography variant="body-small" className={themeMode === 'dark' ? "text-gray-400" : "text-gray-600"} as="li">
+                    <Typography variant="body-small" className="text-slate-600 dark:text-slate-400" as="li">
                         • Light theme: Pure white backgrounds
                     </Typography>
-                    <Typography variant="body-small" className={themeMode === 'dark' ? "text-gray-400" : "text-gray-600"} as="li">
+                    <Typography variant="body-small" className="text-slate-600 dark:text-slate-400" as="li">
                         • Dark theme: Solid black/gray-900 backgrounds
                     </Typography>
-                    <Typography variant="body-small" className={themeMode === 'dark' ? "text-gray-400" : "text-gray-600"} as="li">
+                    <Typography variant="body-small" className="text-slate-600 dark:text-slate-400" as="li">
                         • No transparency or blur effects
                     </Typography>
-                    <Typography variant="body-small" className={themeMode === 'dark' ? "text-gray-400" : "text-gray-600"} as="li">
+                    <Typography variant="body-small" className="text-slate-600 dark:text-slate-400" as="li">
                         • Better contrast and readability
                     </Typography>
                 </ul>

--- a/apps/storybook/src/components/date-picker/date-picker.stories.tsx
+++ b/apps/storybook/src/components/date-picker/date-picker.stories.tsx
@@ -201,11 +201,11 @@ export const AllColorSchemes = () => {
                 ))}
             </div>
 
-            <div className="p-4 rounded-lg bg-slate-100 dark:bg-slate-850">
+            <div className="p-4 rounded-lg bg-slate-100 dark:bg-slate-900">
                 <Typography variant="body-small" weight="medium" className="text-slate-700 dark:text-slate-300">
                     Note: All backgrounds are now solid:
                 </Typography>
-                <ul className="mt-2 space-y-1">
+                <ul className="mt-2 space-y-1 list-none">
                     <Typography variant="body-small" className="text-slate-600 dark:text-slate-400" as="li">
                         • Light theme: Pure white backgrounds
                     </Typography>

--- a/apps/storybook/src/components/date-picker/date-picker.stories.tsx
+++ b/apps/storybook/src/components/date-picker/date-picker.stories.tsx
@@ -52,9 +52,9 @@ export const CombinedThemes = () => (
             Combined Theme & Color Schemes
         </Typography>
 
-        <div className="grid grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl">
             {/* Light theme with different colors */}
-            <div className="space-y-4 p-4 bg-gray-100 rounded-lg">
+            <div className="space-y-4 p-4 bg-gray-100 dark:bg-gray-900 rounded-lg">
                 <Typography variant="h4" weight="medium" className="text-gray-900">Light Theme</Typography>
                 <DatePicker themeMode="light" colorScheme="blue" placeholder="Light Blue" />
                 <DatePicker themeMode="light" colorScheme="green" placeholder="Light Green" />
@@ -79,7 +79,7 @@ export const CustomCombinations = () => (
             Custom Theme Combinations
         </Typography>
 
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 w-full max-w-5xl">
             <DatePicker
                 themeMode="light"
                 colorScheme="rose"
@@ -111,7 +111,7 @@ export const SingleDatePicker = () => {
     const [date, setDate] = useState<Date | null>(null);
 
     return (
-        <div className="space-y-4">
+        <div className="w-[350px] space-y-4">
             <DatePicker
                 value={date || undefined}
                 onChange={(val) => setDate(val as Date | null)}
@@ -133,7 +133,7 @@ export const RangeDatePicker = () => {
     const [range, setRange] = useState<DateRange>({ start: null, end: null });
 
     return (
-        <div className="space-y-4">
+        <div className="w-[450px] space-y-4">
             <DatePicker
                 variant="range"
                 value={range}
@@ -153,7 +153,7 @@ export const RangeDatePicker = () => {
 };
 
 export const DifferentSizes = () => (
-    <div className="space-y-6 p-6 border rounded-lg border-slate-200 dark:border-slate-800">
+    <div className="w-[350px] space-y-6 p-6 border rounded-lg border-slate-200 dark:border-slate-800">
         <div className="space-y-2">
             <Typography variant="label" color="muted">Small</Typography>
             <DatePicker size="sm" placeholder="Small picker" colorScheme="blue" />
@@ -229,7 +229,7 @@ export const WithMinMaxDates = () => {
     nextWeek.setDate(today.getDate() + 7);
 
     return (
-        <div className="space-y-4">
+        <div className="w-[350px] space-y-4">
             <DatePicker
                 minDate={today}
                 maxDate={nextWeek}
@@ -260,7 +260,7 @@ export const WithDisabledDates = () => {
     ];
 
     return (
-        <div className="space-y-4">
+        <div className="w-[350px] space-y-4">
             <DatePicker
                 disabledDates={disabledDates}
                 placeholder="Select date (some dates disabled)"
@@ -294,7 +294,7 @@ export const WithHighlightedDates = () => {
     ];
 
     return (
-        <div className="space-y-4">
+        <div className="w-[350px] space-y-4">
             <DatePicker
                 highlightDates={highlightDates}
                 placeholder="Select date (some dates highlighted)"
@@ -308,7 +308,7 @@ export const WithHighlightedDates = () => {
 };
 
 export const ErrorStates = () => (
-    <div className="space-y-6 p-6 border rounded-lg dark:border-gray-700">
+    <div className="w-[350px] space-y-6 p-6 border rounded-lg dark:border-gray-700">
         <div className="space-y-2">
             <Typography variant="label" color="muted">Required Field (Empty)</Typography>
             <DatePicker
@@ -345,7 +345,7 @@ export const ErrorStates = () => (
 );
 
 export const DifferentPopupPositions = () => (
-    <div className="grid grid-cols-2 gap-6 p-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-6 w-full max-w-3xl">
         <div className="space-y-2">
             <Typography variant="label" color="muted">Bottom Left (Default)</Typography>
             <DatePicker popupPosition="bottom-left" placeholder="Bottom left" themeMode="light" colorScheme="blue" />

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -1259,7 +1259,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDate(value)) {
                     setSelectedDate(value);
                     setCurrentMonth(value);
-                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                    const dateChanged = !selectedDate !== !value || (!!selectedDate && !!value && !isSameDay(selectedDate, value));
+                    if (dateChanged) {
                         setInputValue(formatDate(value, format));
                     }
                 } else if (value === null || value === undefined) {
@@ -1270,8 +1271,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDateRange(value)) {
                     setSelectedRange(value);
                     if (value.start) setCurrentMonth(value.start);
-                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
-                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    const startChanged = !selectedRange.start !== !value.start || (!!selectedRange.start && !!value.start && !isSameDay(selectedRange.start, value.start));
+                    const endChanged = !selectedRange.end !== !value.end || (!!selectedRange.end && !!value.end && !isSameDay(selectedRange.end, value.end));
                     if (startChanged || endChanged) {
                         setRangeInputValue([
                             formatDate(value.start, format),

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -504,34 +504,60 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
 
     try {
         let day, month, year;
+        let yearStr = '';
 
         switch (format) {
-            case 'MM/DD/YYYY':
-                [month, day, year] = str.split('/').map(Number);
+            case 'MM/DD/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [month, day, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'DD/MM/YYYY':
-                [day, month, year] = str.split('/').map(Number);
+            }
+            case 'DD/MM/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [day, month, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'YYYY-MM-DD':
-                [year, month, day] = str.split('-').map(Number);
+            }
+            case 'YYYY-MM-DD': {
+                const parts = str.split('-');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
-            case 'YYYY/MM/DD':
-                [year, month, day] = str.split('/').map(Number);
+            }
+            case 'YYYY/MM/DD': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
+            }
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
+                if (parts.length < 3) return null;
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
+                yearStr = parts[2] || '';
                 break;
             }
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
+                if (parts2.length < 3) return null;
                 day = parseInt(parts2[0]);
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
                 year = parseInt(parts2[2]);
+                yearStr = parts2[2] || '';
                 break;
             }
+        }
+
+        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+        if (cleanYearStr.length !== 4) {
+            return null;
         }
 
         const date = new Date(year!, month! - 1, day!);
@@ -1050,7 +1076,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 {/* Today indicator dot */}
                                 {isToday && !isSelected && !isInRange && (
                                     <div className={cn(
-                                        "absolute -top-1 right-1 w-1.5 h-1.5 rounded-full opacity-60",
+                                        "absolute -top-1 right-0.5 w-1.5 h-1.5 rounded-full opacity-60",
                                         themeMode === 'dark' ? 'bg-blue-300' : 'bg-blue-500'
                                     )} />
                                 )}

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -499,73 +499,104 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
-    try {
-        let day, month, year;
-        let yearStr = '';
+    const parseWithFormat = (s: string, fmt: DateFormat): Date | null => {
+        try {
+            let day, month, year;
+            let yearStr = '';
+            const cleaned = s.trim();
 
-        switch (format) {
-            case 'MM/DD/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [month, day, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
+            switch (fmt) {
+                case 'MM/DD/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [month, day, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD/MM/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [day, month, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'YYYY-MM-DD': {
+                    const parts = cleaned.split('-');
+                    if (parts.length < 3) return null;
+                    [year, month, day] = parts.map(Number);
+                    yearStr = parts[0] || '';
+                    break;
+                }
+                case 'YYYY/MM/DD': {
+                    const communicativeParts = cleaned.split('/');
+                    if (communicativeParts.length < 3) return null;
+                    [year, month, day] = communicativeParts.map(Number);
+                    yearStr = communicativeParts[0] || '';
+                    break;
+                }
+                case 'MMM DD, YYYY': {
+                    const parts = cleaned.split(/[\s,]+/);
+                    if (parts.length < 3) return null;
+                    const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                    if (mIndex === -1) return null;
+                    month = mIndex + 1;
+                    day = parseInt(parts[1]);
+                    year = parseInt(parts[2]);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD MMM YYYY': {
+                    const parts2 = cleaned.split(/[\s,]+/);
+                    if (parts2.length < 3) return null;
+                    const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                    if (mIndex2 === -1) return null;
+                    day = parseInt(parts2[0]);
+                    month = mIndex2 + 1;
+                    year = parseInt(parts2[2]);
+                    yearStr = parts2[2] || '';
+                    break;
+                }
             }
-            case 'DD/MM/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [day, month, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'YYYY-MM-DD': {
-                const parts = str.split('-');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'YYYY/MM/DD': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'MMM DD, YYYY': {
-                const parts = str.split(' ');
-                if (parts.length < 3) return null;
-                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
-                if (mIndex === -1) return null;
-                month = mIndex + 1;
-                day = parseInt(parts[1]);
-                year = parseInt(parts[2]);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'DD MMM YYYY': {
-                const parts2 = str.split(' ');
-                if (parts2.length < 3) return null;
-                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
-                if (mIndex2 === -1) return null;
-                day = parseInt(parts2[0]);
-                month = mIndex2 + 1;
-                year = parseInt(parts2[2]);
-                yearStr = parts2[2] || '';
-                break;
-            }
-        }
 
-        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
-        if (cleanYearStr.length !== 4) {
+            const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+            if (cleanYearStr.length !== 4) {
+                return null;
+            }
+
+            const date = new Date(year!, month! - 1, day!);
+            return date.toString() !== 'Invalid Date' ? date : null;
+        } catch {
             return null;
         }
+    };
 
-        const date = new Date(year!, month! - 1, day!);
-        return date.toString() !== 'Invalid Date' ? date : null;
-    } catch {
-        return null;
+    const primaryResult = parseWithFormat(str, format);
+    if (primaryResult) return primaryResult;
+
+    const allFormats: DateFormat[] = [
+        'MM/DD/YYYY',
+        'DD/MM/YYYY',
+        'YYYY-MM-DD',
+        'YYYY/MM/DD',
+        'MMM DD, YYYY',
+        'DD MMM YYYY'
+    ];
+
+    for (const fmt of allFormats) {
+        if (fmt === format) continue;
+        const result = parseWithFormat(str, fmt);
+        if (result) return result;
     }
+
+    if (str.includes('-')) {
+        const slashed = str.replace(/-/g, '/');
+        for (const fmt of ['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD'] as DateFormat[]) {
+            const result = parseWithFormat(slashed, fmt);
+            if (result) return result;
+        }
+    }
+
+    return null;
 };
 
 /**
@@ -1352,16 +1383,43 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             newValues[index] = value;
             setRangeInputValue(newValues);
 
-            const date = parseDate(value, format);
-            const newRange = { ...selectedRange };
+            if (!value) {
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
 
+                setSelectedRange(newRange);
+                setInternalError(null);
+                onError?.(null);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
+                return;
+            }
+
+            const date = parseDate(value, format);
+            if (!date) {
+                setInternalError('Invalid date format');
+                onError?.('Invalid date format');
+                
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
+                setSelectedRange(newRange);
+                return;
+            }
+
+            const newRange = { ...selectedRange };
             if (index === 0) {
                 newRange.start = date;
             } else {
                 newRange.end = date;
             }
 
-            // Validate if both dates are set
+            setInternalError(null);
+            onError?.(null);
+            setCurrentMonth(date);
+
             if (newRange.start && newRange.end) {
                 const error = validateOnChange ? validateDate(newRange.start) || validateDate(newRange.end) : null;
                 setInternalError(error);
@@ -1385,6 +1443,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                     onChange?.(newRange);
                 }
             } else {
+                const singleDate = newRange.start || newRange.end;
+                const error = validateOnChange ? validateDate(singleDate) : null;
+                setInternalError(error);
+                onError?.(error);
+
                 setSelectedRange(newRange);
                 if (allowEmpty || !newRange.end) {
                     onChange?.(newRange);

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -1294,7 +1294,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             } else if (newRange.start && !newRange.end) {
                 // Complete the range
                 if (date < newRange.start) {
-                    newRange = { start: date, end: newRange.start };
+                    newRange = { start: date, end: null };
                 } else {
                     newRange = { start: newRange.start, end: date };
                 }
@@ -1311,7 +1311,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (autoClose) {
                     setTimeout(() => setIsOpen(false), 100);
                 }
-            } else if (onChange && allowEmpty) {
+            } else if (onChange && (allowEmpty || !newRange.end)) {
                 onChange(newRange);
             }
         };
@@ -1367,12 +1367,27 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 onError?.(error);
 
                 if (!error) {
+                    if (newRange.end < newRange.start) {
+                        if (index === 1) {
+                            newRange.start = newRange.end;
+                            newRange.end = null;
+                            newValues[0] = value;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        } else {
+                            newRange.end = null;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        }
+                    }
                     setSelectedRange(newRange);
                     onChange?.(newRange);
                 }
-            } else if (allowEmpty) {
+            } else {
                 setSelectedRange(newRange);
-                onChange?.(newRange);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
             }
         };
 

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import React, { useState, useEffect, useRef, forwardRef } from 'react';
@@ -13,15 +12,43 @@ function useDocusaurusTheme(): ThemeMode {
     const [theme, setTheme] = useState<ThemeMode>('light');
 
     useEffect(() => {
-        if (typeof document === 'undefined') return;
+        if (typeof window === 'undefined') return;
 
         const root = document.documentElement;
-        const read = () => (root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light') as ThemeMode;
+        const body = document.body;
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const read = (): ThemeMode => {
+            const hasDarkClass = root.classList.contains('dark') || body.classList.contains('dark');
+            const hasDarkThemeAttr = root.getAttribute('data-theme') === 'dark';
+
+            if (hasDarkClass || hasDarkThemeAttr) {
+                return 'dark';
+            }
+            if (
+                root.classList.contains('light') ||
+                body.classList.contains('light') ||
+                root.getAttribute('data-theme') === 'light'
+            ) {
+                return 'light';
+            }
+
+            return mediaQuery.matches ? 'dark' : 'light';
+        };
+
         setTheme(read());
 
         const observer = new MutationObserver(() => setTheme(read()));
-        observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-        return () => observer.disconnect();
+        observer.observe(root, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+        observer.observe(body, { attributes: true, attributeFilter: ['class'] });
+
+        const listener = () => setTheme(read());
+        mediaQuery.addEventListener('change', listener);
+
+        return () => {
+            observer.disconnect();
+            mediaQuery.removeEventListener('change', listener);
+        };
     }, []);
 
     return theme;
@@ -691,6 +718,7 @@ const InputField: React.FC<InputFieldProps> = ({
                 placeholder={placeholder}
                 className={cn(
                     "w-full bg-transparent outline-none font-medium tracking-wide",
+                    showIcon && "pr-8",
                     themeStyles.text.primary,
                     themeStyles.placeholder,
                     disabled && "cursor-not-allowed",
@@ -772,6 +800,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
 
             <Typography
                 variant="body"
+                color="inherit"
                 className={themeStyles.text.muted}
             >
                 –
@@ -786,6 +815,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
                     placeholder={Array.isArray(placeholder) ? placeholder[1] : 'End date'}
                     className={cn(
                         "w-full bg-transparent outline-none font-medium tracking-wide",
+                        showIcon && "pr-8",
                         themeStyles.text.primary,
                         themeStyles.placeholder,
                         disabled && "cursor-not-allowed",
@@ -888,6 +918,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                     <Typography
                         variant="h6"
                         weight="bold"
+                        color="inherit"
                         className={cn("tracking-tight", themeStyles.header)}
                     >
                         {monthNames[currentMonthIndex]} {currentYear}
@@ -918,6 +949,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                         variant="caption"
                         weight="semibold"
                         align="center"
+                        color="inherit"
                         className={cn("py-2 tracking-wide", themeStyles.weekday)}
                     >
                         {getDayName(index)}
@@ -987,6 +1019,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 <Typography
                                     variant="body-small"
                                     weight={(isSelected || isStart || isEnd) ? "bold" : "normal"}
+                                    color="inherit"
                                     className={cn(
                                         "relative z-10",
                                         (isSelected || isStart || isEnd) && "!text-white",
@@ -1039,28 +1072,23 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                             variant="outline"
                             size="sm"
                             onClick={onTodayClick}
-                            className="flex-1 rounded-xl shadow-sm hover:shadow text-slate-500 cursor-pointer"
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer border-border/60 hover:bg-muted/50 bg-background text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {todayText}
                             </Typography>
                         </Button>
                     )}
                     {clearButton && (
                         <Button
-                            variant="ghost"
+                            variant="secondary"
                             size="sm"
                             onClick={onClearClick}
-                            className={cn(
-                                "flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer",
-                                themeMode === 'dark'
-                                    ? "bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-700 hover:to-gray-800 text-gray-300"
-                                    : "bg-gradient-to-r from-gray-50 to-gray-100 hover:from-gray-100 hover:to-gray-200 text-gray-600"
-                            )}
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {clearText}
                             </Typography>
                         </Button>
@@ -1357,16 +1385,17 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const hasError = Boolean(error) || !!internalError;
 
         return (
-            <div ref={containerRef} className={cn("relative", className)}>
+            <div ref={containerRef} className={cn("relative text-foreground space-y-3", themeMode, className)}>
                 {label && (
                     <motion.label
                         initial={{ opacity: 0, y: -5 }}
                         animate={{ opacity: 1, y: 0 }}
-                        className="block mb-2"
+                        className="block mb-1"
                     >
                         <Typography
                             variant="label"
                             weight="semibold"
+                            color="inherit"
                             className={cn("tracking-wide", themeStyles.text.primary)}
                         >
                             {label}

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -564,7 +564,17 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             }
 
             const date = new Date(year!, month! - 1, day!);
-            return date.toString() !== 'Invalid Date' ? date : null;
+            if (date.toString() === 'Invalid Date') return null;
+
+            if (
+                date.getFullYear() !== year ||
+                date.getMonth() !== month! - 1 ||
+                date.getDate() !== day
+            ) {
+                return null;
+            }
+
+            return date;
         } catch {
             return null;
         }
@@ -1245,29 +1255,48 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const colorStyles = getColorStyles(colorScheme);
 
         useEffect(() => {
-            if (variant === 'single' && isDate(value)) {
-                setSelectedDate(value);
-                setInputValue(formatDate(value, format));
-                setCurrentMonth(value);
-            } else if (variant === 'range' && isDateRange(value)) {
-                setSelectedRange(value);
-                setRangeInputValue([
-                    formatDate(value.start, format),
-                    formatDate(value.end, format)
-                ]);
-                if (value.start) setCurrentMonth(value.start);
-
-            } else if (value === null || value === undefined) {
-                // Handle null/undefined values
-                if (variant === 'single') {
+            if (variant === 'single') {
+                if (isDate(value)) {
+                    setSelectedDate(value);
+                    setCurrentMonth(value);
+                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                        setInputValue(formatDate(value, format));
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedDate(null);
                     setInputValue('');
-                } else {
+                }
+            } else if (variant === 'range') {
+                if (isDateRange(value)) {
+                    setSelectedRange(value);
+                    if (value.start) setCurrentMonth(value.start);
+                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
+                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    if (startChanged || endChanged) {
+                        setRangeInputValue([
+                            formatDate(value.start, format),
+                            formatDate(value.end, format)
+                        ]);
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedRange({ start: null, end: null });
                     setRangeInputValue(['', '']);
                 }
             }
         }, [value, variant, format]);
+
+        useEffect(() => {
+            if (!isOpen) {
+                if (variant === 'single' && selectedDate) {
+                    setInputValue(formatDate(selectedDate, format));
+                } else if (variant === 'range') {
+                    setRangeInputValue([
+                        formatDate(selectedRange.start, format),
+                        formatDate(selectedRange.end, format)
+                    ]);
+                }
+            }
+        }, [isOpen, variant, format, selectedDate, selectedRange]);
 
         // Handle click outside
         useEffect(() => {
@@ -1401,7 +1430,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             if (!date) {
                 setInternalError('Invalid date format');
                 onError?.('Invalid date format');
-                
+
                 const newRange = { ...selectedRange };
                 if (index === 0) newRange.start = null;
                 else newRange.end = null;

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -636,10 +636,10 @@ const getInRangeStyle = (themeMode: ThemeMode, colorScheme: ColorScheme): string
  */
 const getPopupPositionClasses = (position: string): string => {
     const positions: Record<string, string> = {
-        'bottom-left': 'top-full left-0 mt-2',
-        'bottom-right': 'top-full right-0 mt-2',
-        'top-left': 'bottom-full left-0 mb-2',
-        'top-right': 'bottom-full right-0 mb-2',
+        'bottom-left': 'top-full right-0 mt-2',
+        'bottom-right': 'top-full left-0 mt-2',
+        'top-left': 'bottom-full right-0 mb-2',
+        'top-right': 'bottom-full left-0 mb-2',
         'left': 'right-full top-0 mr-2',
         'right': 'left-full top-0 ml-2',
     };

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -1156,7 +1156,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             allowEmpty = false,
             todayButton = true,
             clearButton = true,
-            autoClose = false,
+            autoClose = true,
             className,
             inputClassName,
             calendarClassName,

--- a/apps/storybook/src/components/date-picker/index.tsx
+++ b/apps/storybook/src/components/date-picker/index.tsx
@@ -496,9 +496,6 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
     }
 };
 
-/**
- * Parses a date string into a Date object based on specified format
- */
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
@@ -538,7 +535,9 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
                 if (parts.length < 3) return null;
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
+                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                if (mIndex === -1) return null;
+                month = mIndex + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
                 yearStr = parts[2] || '';
@@ -547,8 +546,10 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
                 if (parts2.length < 3) return null;
+                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                if (mIndex2 === -1) return null;
                 day = parseInt(parts2[0]);
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
+                month = mIndex2 + 1;
                 year = parseInt(parts2[2]);
                 yearStr = parts2[2] || '';
                 break;

--- a/packages/cli-tool/tests/commands/mcpCommand.test.ts
+++ b/packages/cli-tool/tests/commands/mcpCommand.test.ts
@@ -61,7 +61,7 @@ describe('mcp commands', () => {
       await runCommand(createMcpInitCommand, ['--client', 'cursor']);
 
       expect(fs.writeJSON).toHaveBeenCalledWith(
-        expect.stringContaining('.cursor/mcp.json'),
+        expect.stringMatching(/[\\/]\.cursor[\\/]mcp\.json/),
         expect.objectContaining({ mcpServers: expect.anything() }),
         expect.anything()
       );
@@ -82,7 +82,8 @@ describe('mcp commands', () => {
   describe('status', () => {
     it('reports status as JSON', async () => {
       vi.mocked(fs.pathExists).mockImplementation((path: any) => {
-        if (path.toString().includes('.cursor/mcp.json')) return Promise.resolve(true);
+        if (path.toString().replace(/\\/g, '/').includes('.cursor/mcp.json'))
+          return Promise.resolve(true);
         return Promise.resolve(false);
       });
       vi.mocked(fs.readJSON).mockResolvedValue({
@@ -115,18 +116,21 @@ describe('mcp commands', () => {
       const { consoleOutput } = await import('../helpers');
 
       vi.mocked(fs.pathExists).mockImplementation((path: any) => {
-        if (path.toString().includes('.cursor/mcp.json')) return Promise.resolve(true);
-        if (path.toString().includes('.vscode/mcp.json')) return Promise.resolve(true);
+        if (path.toString().replace(/\\/g, '/').includes('.cursor/mcp.json'))
+          return Promise.resolve(true);
+        if (path.toString().replace(/\\/g, '/').includes('.vscode/mcp.json'))
+          return Promise.resolve(true);
         return Promise.resolve(false);
       });
 
       vi.mocked(fs.readJSON).mockImplementation((path: any) => {
-        if (path.toString().includes('.cursor/mcp.json')) {
+        const normalizedPath = path.toString().replace(/\\/g, '/');
+        if (normalizedPath.includes('.cursor/mcp.json')) {
           return Promise.resolve({
             mcpServers: { ignix: { args: ['@mindfiredigital/ignix-mcp-server@1.0.0'] } },
           });
         }
-        if (path.toString().includes('.vscode/mcp.json')) {
+        if (normalizedPath.includes('.vscode/mcp.json')) {
           return Promise.resolve({
             mcpServers: { ignix: { args: ['@mindfiredigital/ignix-mcp-server@1.1.0'] } },
           });

--- a/packages/cli-tool/tests/services/templateService.test.ts
+++ b/packages/cli-tool/tests/services/templateService.test.ts
@@ -60,7 +60,7 @@ describe('TemplateService', () => {
       expect(mockRegistry.getTemplateConfig).toHaveBeenCalledWith('landing');
 
       expect(fs.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining('landing/landing.tsx'),
+        expect.stringMatching(/landing[\\/]landing\.tsx/),
         'template content'
       );
     });

--- a/packages/registry/components/date-picker/date-picker.test.tsx
+++ b/packages/registry/components/date-picker/date-picker.test.tsx
@@ -6,6 +6,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom';
 import { DatePicker } from './';
 
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});
+
 // Mock for framer-motion
 vi.mock('framer-motion', () => ({
     motion: {

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -1259,7 +1259,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDate(value)) {
                     setSelectedDate(value);
                     setCurrentMonth(value);
-                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                    const dateChanged = !selectedDate !== !value || (!!selectedDate && !!value && !isSameDay(selectedDate, value));
+                    if (dateChanged) {
                         setInputValue(formatDate(value, format));
                     }
                 } else if (value === null || value === undefined) {
@@ -1270,8 +1271,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (isDateRange(value)) {
                     setSelectedRange(value);
                     if (value.start) setCurrentMonth(value.start);
-                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
-                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    const startChanged = !selectedRange.start !== !value.start || (!!selectedRange.start && !!value.start && !isSameDay(selectedRange.start, value.start));
+                    const endChanged = !selectedRange.end !== !value.end || (!!selectedRange.end && !!value.end && !isSameDay(selectedRange.end, value.end));
                     if (startChanged || endChanged) {
                         setRangeInputValue([
                             formatDate(value.start, format),

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -504,34 +504,60 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
 
     try {
         let day, month, year;
+        let yearStr = '';
 
         switch (format) {
-            case 'MM/DD/YYYY':
-                [month, day, year] = str.split('/').map(Number);
+            case 'MM/DD/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [month, day, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'DD/MM/YYYY':
-                [day, month, year] = str.split('/').map(Number);
+            }
+            case 'DD/MM/YYYY': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [day, month, year] = parts.map(Number);
+                yearStr = parts[2] || '';
                 break;
-            case 'YYYY-MM-DD':
-                [year, month, day] = str.split('-').map(Number);
+            }
+            case 'YYYY-MM-DD': {
+                const parts = str.split('-');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
-            case 'YYYY/MM/DD':
-                [year, month, day] = str.split('/').map(Number);
+            }
+            case 'YYYY/MM/DD': {
+                const parts = str.split('/');
+                if (parts.length < 3) return null;
+                [year, month, day] = parts.map(Number);
+                yearStr = parts[0] || '';
                 break;
+            }
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
+                if (parts.length < 3) return null;
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
+                yearStr = parts[2] || '';
                 break;
             }
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
+                if (parts2.length < 3) return null;
                 day = parseInt(parts2[0]);
                 month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
                 year = parseInt(parts2[2]);
+                yearStr = parts2[2] || '';
                 break;
             }
+        }
+
+        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+        if (cleanYearStr.length !== 4) {
+            return null;
         }
 
         const date = new Date(year!, month! - 1, day!);
@@ -1050,7 +1076,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 {/* Today indicator dot */}
                                 {isToday && !isSelected && !isInRange && (
                                     <div className={cn(
-                                        "absolute -top-1 right-1 w-1.5 h-1.5 rounded-full opacity-60",
+                                        "absolute -top-1 right-0.5 w-1.5 h-1.5 rounded-full opacity-60",
                                         themeMode === 'dark' ? 'bg-blue-300' : 'bg-blue-500'
                                     )} />
                                 )}

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -499,73 +499,104 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
-    try {
-        let day, month, year;
-        let yearStr = '';
+    const parseWithFormat = (s: string, fmt: DateFormat): Date | null => {
+        try {
+            let day, month, year;
+            let yearStr = '';
+            const cleaned = s.trim();
 
-        switch (format) {
-            case 'MM/DD/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [month, day, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
+            switch (fmt) {
+                case 'MM/DD/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [month, day, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD/MM/YYYY': {
+                    const parts = cleaned.split('/');
+                    if (parts.length < 3) return null;
+                    [day, month, year] = parts.map(Number);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'YYYY-MM-DD': {
+                    const parts = cleaned.split('-');
+                    if (parts.length < 3) return null;
+                    [year, month, day] = parts.map(Number);
+                    yearStr = parts[0] || '';
+                    break;
+                }
+                case 'YYYY/MM/DD': {
+                    const communicativeParts = cleaned.split('/');
+                    if (communicativeParts.length < 3) return null;
+                    [year, month, day] = communicativeParts.map(Number);
+                    yearStr = communicativeParts[0] || '';
+                    break;
+                }
+                case 'MMM DD, YYYY': {
+                    const parts = cleaned.split(/[\s,]+/);
+                    if (parts.length < 3) return null;
+                    const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                    if (mIndex === -1) return null;
+                    month = mIndex + 1;
+                    day = parseInt(parts[1]);
+                    year = parseInt(parts[2]);
+                    yearStr = parts[2] || '';
+                    break;
+                }
+                case 'DD MMM YYYY': {
+                    const parts2 = cleaned.split(/[\s,]+/);
+                    if (parts2.length < 3) return null;
+                    const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                    if (mIndex2 === -1) return null;
+                    day = parseInt(parts2[0]);
+                    month = mIndex2 + 1;
+                    year = parseInt(parts2[2]);
+                    yearStr = parts2[2] || '';
+                    break;
+                }
             }
-            case 'DD/MM/YYYY': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [day, month, year] = parts.map(Number);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'YYYY-MM-DD': {
-                const parts = str.split('-');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'YYYY/MM/DD': {
-                const parts = str.split('/');
-                if (parts.length < 3) return null;
-                [year, month, day] = parts.map(Number);
-                yearStr = parts[0] || '';
-                break;
-            }
-            case 'MMM DD, YYYY': {
-                const parts = str.split(' ');
-                if (parts.length < 3) return null;
-                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
-                if (mIndex === -1) return null;
-                month = mIndex + 1;
-                day = parseInt(parts[1]);
-                year = parseInt(parts[2]);
-                yearStr = parts[2] || '';
-                break;
-            }
-            case 'DD MMM YYYY': {
-                const parts2 = str.split(' ');
-                if (parts2.length < 3) return null;
-                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
-                if (mIndex2 === -1) return null;
-                day = parseInt(parts2[0]);
-                month = mIndex2 + 1;
-                year = parseInt(parts2[2]);
-                yearStr = parts2[2] || '';
-                break;
-            }
-        }
 
-        const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
-        if (cleanYearStr.length !== 4) {
+            const cleanYearStr = yearStr.replace(/[^0-9]/g, '');
+            if (cleanYearStr.length !== 4) {
+                return null;
+            }
+
+            const date = new Date(year!, month! - 1, day!);
+            return date.toString() !== 'Invalid Date' ? date : null;
+        } catch {
             return null;
         }
+    };
 
-        const date = new Date(year!, month! - 1, day!);
-        return date.toString() !== 'Invalid Date' ? date : null;
-    } catch {
-        return null;
+    const primaryResult = parseWithFormat(str, format);
+    if (primaryResult) return primaryResult;
+
+    const allFormats: DateFormat[] = [
+        'MM/DD/YYYY',
+        'DD/MM/YYYY',
+        'YYYY-MM-DD',
+        'YYYY/MM/DD',
+        'MMM DD, YYYY',
+        'DD MMM YYYY'
+    ];
+
+    for (const fmt of allFormats) {
+        if (fmt === format) continue;
+        const result = parseWithFormat(str, fmt);
+        if (result) return result;
     }
+
+    if (str.includes('-')) {
+        const slashed = str.replace(/-/g, '/');
+        for (const fmt of ['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD'] as DateFormat[]) {
+            const result = parseWithFormat(slashed, fmt);
+            if (result) return result;
+        }
+    }
+
+    return null;
 };
 
 /**
@@ -1352,16 +1383,43 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             newValues[index] = value;
             setRangeInputValue(newValues);
 
-            const date = parseDate(value, format);
-            const newRange = { ...selectedRange };
+            if (!value) {
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
 
+                setSelectedRange(newRange);
+                setInternalError(null);
+                onError?.(null);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
+                return;
+            }
+
+            const date = parseDate(value, format);
+            if (!date) {
+                setInternalError('Invalid date format');
+                onError?.('Invalid date format');
+                
+                const newRange = { ...selectedRange };
+                if (index === 0) newRange.start = null;
+                else newRange.end = null;
+                setSelectedRange(newRange);
+                return;
+            }
+
+            const newRange = { ...selectedRange };
             if (index === 0) {
                 newRange.start = date;
             } else {
                 newRange.end = date;
             }
 
-            // Validate if both dates are set
+            setInternalError(null);
+            onError?.(null);
+            setCurrentMonth(date);
+
             if (newRange.start && newRange.end) {
                 const error = validateOnChange ? validateDate(newRange.start) || validateDate(newRange.end) : null;
                 setInternalError(error);
@@ -1385,6 +1443,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                     onChange?.(newRange);
                 }
             } else {
+                const singleDate = newRange.start || newRange.end;
+                const error = validateOnChange ? validateDate(singleDate) : null;
+                setInternalError(error);
+                onError?.(error);
+
                 setSelectedRange(newRange);
                 if (allowEmpty || !newRange.end) {
                     onChange?.(newRange);

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -1294,7 +1294,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             } else if (newRange.start && !newRange.end) {
                 // Complete the range
                 if (date < newRange.start) {
-                    newRange = { start: date, end: newRange.start };
+                    newRange = { start: date, end: null };
                 } else {
                     newRange = { start: newRange.start, end: date };
                 }
@@ -1311,7 +1311,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 if (autoClose) {
                     setTimeout(() => setIsOpen(false), 100);
                 }
-            } else if (onChange && allowEmpty) {
+            } else if (onChange && (allowEmpty || !newRange.end)) {
                 onChange(newRange);
             }
         };
@@ -1367,12 +1367,27 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 onError?.(error);
 
                 if (!error) {
+                    if (newRange.end < newRange.start) {
+                        if (index === 1) {
+                            newRange.start = newRange.end;
+                            newRange.end = null;
+                            newValues[0] = value;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        } else {
+                            newRange.end = null;
+                            newValues[1] = '';
+                            setRangeInputValue(newValues);
+                        }
+                    }
                     setSelectedRange(newRange);
                     onChange?.(newRange);
                 }
-            } else if (allowEmpty) {
+            } else {
                 setSelectedRange(newRange);
-                onChange?.(newRange);
+                if (allowEmpty || !newRange.end) {
+                    onChange?.(newRange);
+                }
             }
         };
 

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -564,7 +564,17 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             }
 
             const date = new Date(year!, month! - 1, day!);
-            return date.toString() !== 'Invalid Date' ? date : null;
+            if (date.toString() === 'Invalid Date') return null;
+
+            if (
+                date.getFullYear() !== year ||
+                date.getMonth() !== month! - 1 ||
+                date.getDate() !== day
+            ) {
+                return null;
+            }
+
+            return date;
         } catch {
             return null;
         }
@@ -1245,29 +1255,48 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const colorStyles = getColorStyles(colorScheme);
 
         useEffect(() => {
-            if (variant === 'single' && isDate(value)) {
-                setSelectedDate(value);
-                setInputValue(formatDate(value, format));
-                setCurrentMonth(value);
-            } else if (variant === 'range' && isDateRange(value)) {
-                setSelectedRange(value);
-                setRangeInputValue([
-                    formatDate(value.start, format),
-                    formatDate(value.end, format)
-                ]);
-                if (value.start) setCurrentMonth(value.start);
-
-            } else if (value === null || value === undefined) {
-                // Handle null/undefined values
-                if (variant === 'single') {
+            if (variant === 'single') {
+                if (isDate(value)) {
+                    setSelectedDate(value);
+                    setCurrentMonth(value);
+                    if (!selectedDate || !isSameDay(selectedDate, value)) {
+                        setInputValue(formatDate(value, format));
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedDate(null);
                     setInputValue('');
-                } else {
+                }
+            } else if (variant === 'range') {
+                if (isDateRange(value)) {
+                    setSelectedRange(value);
+                    if (value.start) setCurrentMonth(value.start);
+                    const startChanged = !selectedRange.start || !isSameDay(selectedRange.start, value.start);
+                    const endChanged = !selectedRange.end || !isSameDay(selectedRange.end, value.end);
+                    if (startChanged || endChanged) {
+                        setRangeInputValue([
+                            formatDate(value.start, format),
+                            formatDate(value.end, format)
+                        ]);
+                    }
+                } else if (value === null || value === undefined) {
                     setSelectedRange({ start: null, end: null });
                     setRangeInputValue(['', '']);
                 }
             }
         }, [value, variant, format]);
+
+        useEffect(() => {
+            if (!isOpen) {
+                if (variant === 'single' && selectedDate) {
+                    setInputValue(formatDate(selectedDate, format));
+                } else if (variant === 'range') {
+                    setRangeInputValue([
+                        formatDate(selectedRange.start, format),
+                        formatDate(selectedRange.end, format)
+                    ]);
+                }
+            }
+        }, [isOpen, variant, format, selectedDate, selectedRange]);
 
         // Handle click outside
         useEffect(() => {
@@ -1401,7 +1430,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             if (!date) {
                 setInternalError('Invalid date format');
                 onError?.('Invalid date format');
-                
+
                 const newRange = { ...selectedRange };
                 if (index === 0) newRange.start = null;
                 else newRange.end = null;

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -636,10 +636,10 @@ const getInRangeStyle = (themeMode: ThemeMode, colorScheme: ColorScheme): string
  */
 const getPopupPositionClasses = (position: string): string => {
     const positions: Record<string, string> = {
-        'bottom-left': 'top-full left-0 mt-2',
-        'bottom-right': 'top-full right-0 mt-2',
-        'top-left': 'bottom-full left-0 mb-2',
-        'top-right': 'bottom-full right-0 mb-2',
+        'bottom-left': 'top-full right-0 mt-2',
+        'bottom-right': 'top-full left-0 mt-2',
+        'top-left': 'bottom-full right-0 mb-2',
+        'top-right': 'bottom-full left-0 mb-2',
         'left': 'right-full top-0 mr-2',
         'right': 'left-full top-0 ml-2',
     };

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -12,15 +12,43 @@ function useDocusaurusTheme(): ThemeMode {
     const [theme, setTheme] = useState<ThemeMode>('light');
 
     useEffect(() => {
-        if (typeof document === 'undefined') return;
+        if (typeof window === 'undefined') return;
 
         const root = document.documentElement;
-        const read = () => (root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light') as ThemeMode;
+        const body = document.body;
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const read = (): ThemeMode => {
+            const hasDarkClass = root.classList.contains('dark') || body.classList.contains('dark');
+            const hasDarkThemeAttr = root.getAttribute('data-theme') === 'dark';
+
+            if (hasDarkClass || hasDarkThemeAttr) {
+                return 'dark';
+            }
+            if (
+                root.classList.contains('light') ||
+                body.classList.contains('light') ||
+                root.getAttribute('data-theme') === 'light'
+            ) {
+                return 'light';
+            }
+
+            return mediaQuery.matches ? 'dark' : 'light';
+        };
+
         setTheme(read());
 
         const observer = new MutationObserver(() => setTheme(read()));
-        observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-        return () => observer.disconnect();
+        observer.observe(root, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+        observer.observe(body, { attributes: true, attributeFilter: ['class'] });
+
+        const listener = () => setTheme(read());
+        mediaQuery.addEventListener('change', listener);
+
+        return () => {
+            observer.disconnect();
+            mediaQuery.removeEventListener('change', listener);
+        };
     }, []);
 
     return theme;
@@ -690,6 +718,7 @@ const InputField: React.FC<InputFieldProps> = ({
                 placeholder={placeholder}
                 className={cn(
                     "w-full bg-transparent outline-none font-medium tracking-wide",
+                    showIcon && "pr-8",
                     themeStyles.text.primary,
                     themeStyles.placeholder,
                     disabled && "cursor-not-allowed",
@@ -771,6 +800,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
 
             <Typography
                 variant="body"
+                color="inherit"
                 className={themeStyles.text.muted}
             >
                 –
@@ -785,6 +815,7 @@ const RangeInputField: React.FC<RangeInputFieldProps> = ({
                     placeholder={Array.isArray(placeholder) ? placeholder[1] : 'End date'}
                     className={cn(
                         "w-full bg-transparent outline-none font-medium tracking-wide",
+                        showIcon && "pr-8",
                         themeStyles.text.primary,
                         themeStyles.placeholder,
                         disabled && "cursor-not-allowed",
@@ -887,6 +918,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                     <Typography
                         variant="h6"
                         weight="bold"
+                        color="inherit"
                         className={cn("tracking-tight", themeStyles.header)}
                     >
                         {monthNames[currentMonthIndex]} {currentYear}
@@ -917,6 +949,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                         variant="caption"
                         weight="semibold"
                         align="center"
+                        color="inherit"
                         className={cn("py-2 tracking-wide", themeStyles.weekday)}
                     >
                         {getDayName(index)}
@@ -986,6 +1019,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                                 <Typography
                                     variant="body-small"
                                     weight={(isSelected || isStart || isEnd) ? "bold" : "normal"}
+                                    color="inherit"
                                     className={cn(
                                         "relative z-10",
                                         (isSelected || isStart || isEnd) && "!text-white",
@@ -1038,28 +1072,23 @@ const CalendarView: React.FC<CalendarViewProps> = ({
                             variant="outline"
                             size="sm"
                             onClick={onTodayClick}
-                            className="flex-1 rounded-xl shadow-sm hover:shadow text-slate-500 cursor-pointer"
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer border-border/60 hover:bg-muted/50 bg-background text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {todayText}
                             </Typography>
                         </Button>
                     )}
                     {clearButton && (
                         <Button
-                            variant="ghost"
+                            variant="secondary"
                             size="sm"
                             onClick={onClearClick}
-                            className={cn(
-                                "flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer",
-                                themeMode === 'dark'
-                                    ? "bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-700 hover:to-gray-800 text-gray-300"
-                                    : "bg-gradient-to-r from-gray-50 to-gray-100 hover:from-gray-100 hover:to-gray-200 text-gray-600"
-                            )}
+                            className="flex-1 rounded-xl shadow-sm hover:shadow cursor-pointer bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground"
                             animationVariant="press3DSoft"
                         >
-                            <Typography variant="body-small" weight="medium">
+                            <Typography variant="body-small" weight="medium" color="inherit">
                                 {clearText}
                             </Typography>
                         </Button>
@@ -1356,16 +1385,17 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         const hasError = Boolean(error) || !!internalError;
 
         return (
-            <div ref={containerRef} className={cn("relative", className)}>
+            <div ref={containerRef} className={cn("relative text-foreground space-y-3", themeMode, className)}>
                 {label && (
                     <motion.label
                         initial={{ opacity: 0, y: -5 }}
                         animate={{ opacity: 1, y: 0 }}
-                        className="block mb-2"
+                        className="block mb-1"
                     >
                         <Typography
                             variant="label"
                             weight="semibold"
+                            color="inherit"
                             className={cn("tracking-wide", themeStyles.text.primary)}
                         >
                             {label}

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -1156,7 +1156,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             allowEmpty = false,
             todayButton = true,
             clearButton = true,
-            autoClose = false,
+            autoClose = true,
             className,
             inputClassName,
             calendarClassName,

--- a/packages/registry/components/date-picker/index.tsx
+++ b/packages/registry/components/date-picker/index.tsx
@@ -496,9 +496,6 @@ const formatDate = (date: Date | null, format: DateFormat): string => {
     }
 };
 
-/**
- * Parses a date string into a Date object based on specified format
- */
 const parseDate = (str: string, format: DateFormat): Date | null => {
     if (!str) return null;
 
@@ -538,7 +535,9 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'MMM DD, YYYY': {
                 const parts = str.split(' ');
                 if (parts.length < 3) return null;
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts[0])) + 1;
+                const mIndex = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts[0].toLowerCase()));
+                if (mIndex === -1) return null;
+                month = mIndex + 1;
                 day = parseInt(parts[1]);
                 year = parseInt(parts[2]);
                 yearStr = parts[2] || '';
@@ -547,8 +546,10 @@ const parseDate = (str: string, format: DateFormat): Date | null => {
             case 'DD MMM YYYY': {
                 const parts2 = str.split(' ');
                 if (parts2.length < 3) return null;
+                const mIndex2 = MONTH_NAMES.findIndex(m => m.toLowerCase().startsWith(parts2[1].toLowerCase()));
+                if (mIndex2 === -1) return null;
                 day = parseInt(parts2[0]);
-                month = MONTH_NAMES.findIndex(m => m.startsWith(parts2[1])) + 1;
+                month = mIndex2 + 1;
                 year = parseInt(parts2[2]);
                 yearStr = parts2[2] || '';
                 break;

--- a/packages/registry/templates/pages/sign-in/signin.test.tsx
+++ b/packages/registry/templates/pages/sign-in/signin.test.tsx
@@ -157,6 +157,7 @@ describe("SignIn Component", () => {
     });
 
     it("handles social login button clicks", async () => {
+        vi.useFakeTimers();
         render(
             <SignIn
                 onSubmit={mockOnSubmit}
@@ -181,6 +182,9 @@ describe("SignIn Component", () => {
         const microsoftButton = screen.getByLabelText("Sign in with Microsoft");
         fireEvent.click(microsoftButton);
         expect(mockOnMicrosoftSignIn).toHaveBeenCalled();
+
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
     });
 
     it("shows loading state when social sign-in is in progress", () => {


### PR DESCRIPTION
## Pull Request Title

fix(component): default autoclose to true, fix date range select order, and adjust preview widths

---

## Description

### What does this PR do?

This PR addresses several visual and functional issues in the DatePicker component and its test/preview setups:
* Auto-Close
* Range Selection Ordering 
* Year Input Handling
* Visual Spacing & Alignment
* Preview Containment
* Dark Theme Context

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #855 #857 #859 #865 #867 #868  #878 #880 #881 #882 

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [X] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Defaulted `DatePicker` `autoClose` to `true`.
  - Updated range selection so when the second (end) date is earlier than the start, the selection resets to `{ start: <new date>, end: null }`.
  - Broadened range `onChange` to fire for incomplete/empty ranges (e.g., when `allowEmpty` is enabled or when `end` is unset).
  - Hardened date parsing for year input: strict format-specific parsing, sanitizing extracted year digits, requiring exactly 4-digit years, validating the constructed date, and retrying across supported formats (including dash-to-slash normalization).

- **Bug fixes**
  - Fixed dark-mode rendering during range selection by ensuring relevant UI text inherits correct color (`Typography` switched to `color="inherit"`) and applying related spacing/alignment adjustments.
  - Improved theme auto-detection/sync for demos and Storybook/registry usage by deriving mode from `documentElement`/`body` classes and `data-theme`, falling back to `prefers-color-scheme`, and keeping React state updated via `MutationObserver` + `matchMedia` listener (with cleanup).
  - Corrected range text input handling: clearing/invalid inputs now clear the corresponding boundary, ordering is enforced when `end < start`, and displayed endpoint strings stay consistent with internal range state.
  - UI alignment/placement fixes: added right padding (`pr-8`) when `showIcon` to prevent overlap, adjusted the “today” indicator dot position, updated footer Today/Clear button classes/typography colors, corrected popup diagonal anchoring swaps for `bottom-left`/`bottom-right`, and refined label/wrapper spacing.

- **Tooling / config changes**
  - Added a global `window.matchMedia` mock for DatePicker tests.
  - Updated CLI/template tests to tolerate Windows vs POSIX path separators (regex/normalization).
  - Updated sign-in social-login test to use Vitest fake timers and advance timers before assertions.

- **Docs / Storybook updates**
  - Refactored DatePicker docs demos and Storybook stories (grid/map-based rendering, responsive sizing/layout, updated typography styling).
  - Removed interactive theme-mode toggle wiring in demos/playground so previews rely on theme context/CSS instead of passing a `themeMode` prop (improving dark-mode behavior and preview containment).
  - Updated the Hotel Booking demo date format to `MM/DD/YYYY`.
  - Reshaped multiple demos (size variants, color schemes, popup positions, validation examples) and adjusted controlled range captions/panels accordingly.

- **Breaking changes**
  - None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->