### PR TITLE
fix(dropdown): resolve visibility of dark bg of dropwdown menu issue

### DIFF
--- a/apps/docs/src/components/UI/dropdown/index.tsx
+++ b/apps/docs/src/components/UI/dropdown/index.tsx
@@ -21,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--ifm-color-emphasis-300:var(--color-dark-dropdown-border)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",

--- a/apps/docs/src/components/UI/dropdown/index.tsx
+++ b/apps/docs/src/components/UI/dropdown/index.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
+import { Check } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
 import type { ReactNode } from "react";
@@ -20,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -118,7 +119,7 @@ export const DropdownItem = ({
 } & React.ComponentProps<typeof DropdownMenu.Item>) => (
   <DropdownMenu.Item
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground",
+      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground text-foreground",
       className
     )}
     {...props}
@@ -136,27 +137,14 @@ export const DropdownCheckboxItem = ({
 } & React.ComponentProps<typeof DropdownMenu.CheckboxItem>) => (
   <DropdownMenu.CheckboxItem
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-foreground",
       className
     )}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenu.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        <Check className="h-4 w-4" />
       </DropdownMenu.ItemIndicator>
     </span>
     {children}
@@ -182,4 +170,3 @@ export const DropdownSeparator = ({
     {...props}
   />
 );
-

--- a/apps/docs/src/components/UI/dropdown/index.tsx
+++ b/apps/docs/src/components/UI/dropdown/index.tsx
@@ -1,12 +1,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
-import { Check } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
 import type { ReactNode } from "react";
 
 // Styling variants using CVA
-const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
+const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-none", {
   variants: {
     size: {
       sm: "text-sm",
@@ -21,7 +20,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-card text-card-foreground",
+      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -98,6 +97,7 @@ export const Dropdown = ({
             initial="initial"
             animate="animate"
             exit="exit"
+            data-theme={bg === "dark" ? "dark" : undefined}
             className={cn(dropdownVariants({ size, rounded, bg }), className)}
           >
             {children}
@@ -126,25 +126,6 @@ export const DropdownItem = ({
     {children}
   </DropdownMenu.Item>
 );
-
-export const DropdownLabel = ({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) => (
-  <DropdownMenu.Label
-    className={cn("px-3 py-1.5 text-sm font-semibold", className)}
-  >
-    {children}
-  </DropdownMenu.Label>
-);
-
-export const DropdownSeparator = ({ className }: { className?: string }) => (
-  <DropdownMenu.Separator className={cn("-mx-1 my-1 h-px bg-border", className)} />
-);
-
 export const DropdownCheckboxItem = ({
   children,
   className,
@@ -162,9 +143,43 @@ export const DropdownCheckboxItem = ({
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenu.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
       </DropdownMenu.ItemIndicator>
     </span>
     {children}
   </DropdownMenu.CheckboxItem>
 );
+
+export const DropdownLabel = ({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenu.Label>) => (
+  <DropdownMenu.Label
+    className={cn("px-3 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground", className)}
+    {...props}
+  />
+);
+
+export const DropdownSeparator = ({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenu.Separator>) => (
+  <DropdownMenu.Separator
+    className={cn("-mx-2 my-2 h-px bg-border/50", className)}
+    {...props}
+  />
+);
+

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -14,6 +14,9 @@
 :root {
   --color-gradient-from-dropdown: #a855f7;
   --color-gradient-to-dropdown: #ec4899;
+  --color-dark-dropdown-bg: #121212;
+  --color-dark-dropdown-text: #ffffff;
+  --color-dark-dropdown-border: #2a2a2a;
   --ifm-color-primary: #ff0000;
   --ifm-color-primary-dark: #cc0511;
   --ifm-color-primary-darker: #b70510;

--- a/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
@@ -46,7 +46,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] 
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--ifm-color-emphasis-300:var(--color-dark-dropdown-border)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",

--- a/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
@@ -29,9 +29,9 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
-const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] mt-[12px]", {
+const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] mt-[12px] outline-none", {
   variants: {
     size: {
       sm: "text-sm",
@@ -46,7 +46,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] 
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-card text-card-foreground",
+      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
       transparent: "bg-transparent.",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -120,6 +120,7 @@ export const Dropdown = ({
             initial="initial"
             animate="animate"
             exit="exit"
+            data-theme={bg === "dark" ? "dark" : undefined}
             className={cn(dropdownVariants({ size, rounded, bg }), className)}
           >
             {children}

--- a/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
@@ -47,7 +47,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] 
     bg: {
       default: "bg-background text-foreground",
       dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
-      transparent: "bg-transparent.",
+      transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
       primary: "bg-primary text-primary-foreground",

--- a/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/dropdown.mdx
@@ -46,7 +46,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg ml-[10px] 
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -141,7 +141,7 @@ export const DropdownItem = ({
 } & React.ComponentProps<typeof DropdownMenu.Item>) => (
   <DropdownMenu.Item
     className={cn(
-      "cursor-pointer select-none rounded-md px-3 py-2 text-sm outline-transparent",
+      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground text-foreground",
       className
     )}
     {...props}

--- a/apps/storybook/src/components/dropdown/index.tsx
+++ b/apps/storybook/src/components/dropdown/index.tsx
@@ -21,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--ifm-color-emphasis-300:var(--color-dark-dropdown-border)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",

--- a/apps/storybook/src/components/dropdown/index.tsx
+++ b/apps/storybook/src/components/dropdown/index.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
+import { Check } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
 import type { ReactNode } from "react";
@@ -20,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -118,7 +119,7 @@ export const DropdownItem = ({
 } & React.ComponentProps<typeof DropdownMenu.Item>) => (
   <DropdownMenu.Item
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground",
+      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground text-foreground",
       className
     )}
     {...props}
@@ -136,27 +137,14 @@ export const DropdownCheckboxItem = ({
 } & React.ComponentProps<typeof DropdownMenu.CheckboxItem>) => (
   <DropdownMenu.CheckboxItem
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-foreground",
       className
     )}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenu.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        <Check className="h-4 w-4" />
       </DropdownMenu.ItemIndicator>
     </span>
     {children}
@@ -182,4 +170,3 @@ export const DropdownSeparator = ({
     {...props}
   />
 );
-

--- a/apps/storybook/src/components/dropdown/index.tsx
+++ b/apps/storybook/src/components/dropdown/index.tsx
@@ -1,12 +1,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
-import { Check } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
 import type { ReactNode } from "react";
 
 // Styling variants using CVA
-const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
+const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-none", {
   variants: {
     size: {
       sm: "text-sm",
@@ -21,7 +20,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-card text-card-foreground",
+      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -98,6 +97,7 @@ export const Dropdown = ({
             initial="initial"
             animate="animate"
             exit="exit"
+            data-theme={bg === "dark" ? "dark" : undefined}
             className={cn(dropdownVariants({ size, rounded, bg }), className)}
           >
             {children}
@@ -126,25 +126,6 @@ export const DropdownItem = ({
     {children}
   </DropdownMenu.Item>
 );
-
-export const DropdownLabel = ({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) => (
-  <DropdownMenu.Label
-    className={cn("px-3 py-1.5 text-sm font-semibold", className)}
-  >
-    {children}
-  </DropdownMenu.Label>
-);
-
-export const DropdownSeparator = ({ className }: { className?: string }) => (
-  <DropdownMenu.Separator className={cn("-mx-1 my-1 h-px bg-border", className)} />
-);
-
 export const DropdownCheckboxItem = ({
   children,
   className,
@@ -162,9 +143,43 @@ export const DropdownCheckboxItem = ({
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenu.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
       </DropdownMenu.ItemIndicator>
     </span>
     {children}
   </DropdownMenu.CheckboxItem>
 );
+
+export const DropdownLabel = ({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenu.Label>) => (
+  <DropdownMenu.Label
+    className={cn("px-3 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground", className)}
+    {...props}
+  />
+);
+
+export const DropdownSeparator = ({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenu.Separator>) => (
+  <DropdownMenu.Separator
+    className={cn("-mx-2 my-2 h-px bg-border/50", className)}
+    {...props}
+  />
+);
+

--- a/apps/storybook/src/index.css
+++ b/apps/storybook/src/index.css
@@ -4,6 +4,9 @@
   :root {
     --color-gradient-from-dropdown: #a855f7;
     --color-gradient-to-dropdown: #ec4899;
+    --color-dark-dropdown-bg: #121212;
+    --color-dark-dropdown-text: #ffffff;
+    --color-dark-dropdown-border: #2a2a2a;
     --background: #ffffff;
     --foreground: #0f172a;
     --card: #ffffff;

--- a/packages/registry/components/dropdown/index.tsx
+++ b/packages/registry/components/dropdown/index.tsx
@@ -21,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--ifm-color-emphasis-300:var(--color-dark-dropdown-border)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",

--- a/packages/registry/components/dropdown/index.tsx
+++ b/packages/registry/components/dropdown/index.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
+import { Check } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
 import type { ReactNode } from "react";
@@ -20,7 +21,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-no
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
+      dark: "bg-[var(--color-dark-dropdown-bg)] text-[var(--color-dark-dropdown-text)] border-[var(--color-dark-dropdown-border)] [--foreground:var(--color-dark-dropdown-text)] [--ifm-font-color-base:var(--color-dark-dropdown-text)] [--border:var(--color-dark-dropdown-border)]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -118,7 +119,7 @@ export const DropdownItem = ({
 } & React.ComponentProps<typeof DropdownMenu.Item>) => (
   <DropdownMenu.Item
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground",
+      "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-transparent focus:bg-accent focus:text-accent-foreground text-foreground",
       className
     )}
     {...props}
@@ -136,27 +137,14 @@ export const DropdownCheckboxItem = ({
 } & React.ComponentProps<typeof DropdownMenu.CheckboxItem>) => (
   <DropdownMenu.CheckboxItem
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-foreground",
       className
     )}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenu.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        <Check className="h-4 w-4" />
       </DropdownMenu.ItemIndicator>
     </span>
     {children}
@@ -182,4 +170,3 @@ export const DropdownSeparator = ({
     {...props}
   />
 );
-

--- a/packages/registry/components/dropdown/index.tsx
+++ b/packages/registry/components/dropdown/index.tsx
@@ -2,10 +2,10 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { motion } from "framer-motion";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 // Styling variants using CVA
-const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
+const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg outline-none", {
   variants: {
     size: {
       sm: "text-sm",
@@ -20,7 +20,7 @@ const dropdownVariants = cva("z-50 min-w-[10rem] border p-2 shadow-lg", {
     },
     bg: {
       default: "bg-background text-foreground",
-      dark: "bg-card text-card-foreground",
+      dark: "bg-background text-foreground border-border [--foreground:#ffffff] [--ifm-font-color-base:#ffffff] [--border:#2a2a2a]",
       transparent: "bg-transparent",
       glass: "bg-white/10 backdrop-blur-lg text-[var(--color-glass-text)]",
       gradient: "bg-gradient-to-r from-[var(--color-gradient-from-dropdown)] to-[var(--color-gradient-to-dropdown)] text-white",
@@ -97,6 +97,7 @@ export const Dropdown = ({
             initial="initial"
             animate="animate"
             exit="exit"
+            data-theme={bg === "dark" ? "dark" : undefined}
             className={cn(dropdownVariants({ size, rounded, bg }), className)}
           >
             {children}


### PR DESCRIPTION
### Description

Resolves the background colour visibility issue on selecting black background colour in light mode.

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #864 

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Updated `DropdownLabel` and `DropdownSeparator` to accept and forward full Radix `DropdownMenu.Label`/`Separator` props (`React.ComponentPropsWithoutRef`) to the underlying components.
  - Added theme handling so the dropdown’s animated content wrapper sets `data-theme="dark"` when `bg === "dark"`.
  - Updated dropdown item styling to explicitly apply `text-foreground`, and adjusted checkbox item indicator rendering to align with the new theming/styling.

- **Bug fixes**
  - Fixed the dropdown background not appearing when selecting the “black” (`bg="dark"`) option while in light mode by switching dark dropdown styling to CSS-variable-driven colors and ensuring proper foreground/border styling after the menu opens.

- **Tooling / config changes**
  - Added dark dropdown CSS custom properties (`--color-dark-dropdown-bg`, `--color-dark-dropdown-text`, `--color-dark-dropdown-border`) and updated styling to rely on these variables instead of hardcoded colors.

- **Docs / Storybook updates**
  - Updated the versioned Dropdown documentation snippet to reflect the corrected dark (`bg="dark"`) styling and the conditional `data-theme="dark"` behavior.
  - Synced Storybook dropdown theming/styling (including `data-theme` handling and checkbox indicator/text-foreground styling).

### Breaking changes
None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->