### PR TITLE
Release from Development

### DIFF
--- a/apps/docs/src/components/UI/button/index.tsx
+++ b/apps/docs/src/components/UI/button/index.tsx
@@ -6,6 +6,14 @@ import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../../utils/cn';
 
+export interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onDrag'>,
+  VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+  animationVariant?: string;
+  children?: React.ReactNode;
+}
+
 const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
@@ -46,16 +54,6 @@ const buttonVariants = cva(
     },
   }
 );
-
-export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
-
-export interface ButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onDrag'>,
-  VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-  animationVariant?: string;
-  children?: React.ReactNode;
-}
 
 const animations = {
   bounce: {
@@ -296,11 +294,7 @@ const ninaTextVariants = {
   hover: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: {
-      delay: i * 0.045,
-      duration: 0.3,
-      ease: [0.75, 0, 0.125, 1] as [number, number, number, number],
-    },
+    transition: { delay: i * 0.045, duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   }),
 };
 
@@ -309,16 +303,13 @@ const ninaBeforeVariants = {
   hover: {
     opacity: 0,
     y: 20,
-    transition: {
-      duration: 0.3,
-      ease: [0.75, 0, 0.125, 1] as [number, number, number, number],
-    },
+    transition: { duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   },
-} as const;
+};
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, animationVariant, children, ...props }, ref) => {
-    const animationProps = animationVariant ? animations[animationVariant] || {} : {};
+    const animationProps = animationVariant ? animations[animationVariant as keyof typeof animations] || {} : {};
 
     const slotProps = asChild ? { ...props } : {};
     const motionProps = !asChild ? { ...props, ...animationProps } : {};
@@ -348,7 +339,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         <motion.button
           className={cn(buttonVariants({ variant, size }), className, 'relative overflow-hidden')}
           ref={ref}
-          {...(motionProps as any)}
+          {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
           initial="initial"
           whileHover="hover"
         >
@@ -373,7 +364,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <motion.button
         className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
-        {...(motionProps as any)}
+        {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
       >
         {children}
       </motion.button>

--- a/apps/poc/package.json
+++ b/apps/poc/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/apps/poc/package.json
+++ b/apps/poc/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -21,7 +21,7 @@
     "@tailwindcss/vite": "^4.1.14",
     "autoprefixer": "^10.4.20",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.4.10",
+    "framer-motion": "^12.23.24",
     "lucide-react": "^0.477.0",
     "postcss": "^8.5.3",
     "react": "^19.0.0",

--- a/apps/poc/src/components/input/AnimatedInput.tsx
+++ b/apps/poc/src/components/input/AnimatedInput.tsx
@@ -17,7 +17,7 @@ interface InputVariant {
   extra?: Variants;
 }
 
-const borderBeamVariants = {
+const borderBeamVariants: Variants = {
   initial: {
     pathLength: 0,
     opacity: 0,
@@ -480,17 +480,17 @@ const inputVariants: Record<string, InputVariant> = {
   },
   glitch: {
     label: {
-      initial: { skew: 0, y: 0 },
+      initial: { skewX: 0, y: 0 },
       animate: {
-        skew: [-5, 5, -2, 2, 0],
+        skewX: [-5, 5, -2, 2, 0],
         y: -25,
         transition: { repeat: Number.POSITIVE_INFINITY, duration: 0.5 },
       },
     },
     input: {
-      initial: { skew: 0 },
+      initial: { skewX: 0 },
       animate: {
-        skew: [0, -2, 2, -1, 1, 0],
+        skewX: [0, -2, 2, -1, 1, 0],
         transition: { repeat: Number.POSITIVE_INFINITY, duration: 0.5 },
       },
     },

--- a/apps/poc/src/components/navigation/Breadcrumbs/index.tsx
+++ b/apps/poc/src/components/navigation/Breadcrumbs/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, type Variants } from 'framer-motion';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import { Link } from 'react-router-dom';
@@ -46,7 +46,7 @@ export const Breadcrumbs = ({ variant = 'default', items, className, style }: Br
     bordered: 'mx-2 text-[var(--text)]',
   };
 
-  const containerVariants = {
+  const containerVariants: Variants = {
     hidden: { opacity: 0, y: -10 },
     visible: {
       opacity: 1,
@@ -60,7 +60,7 @@ export const Breadcrumbs = ({ variant = 'default', items, className, style }: Br
     },
   };
 
-  const itemAnimationVariants = {
+  const itemAnimationVariants: Variants = {
     hidden: {
       opacity: 0,
       x: -10,
@@ -97,7 +97,7 @@ export const Breadcrumbs = ({ variant = 'default', items, className, style }: Br
     },
   };
 
-  const iconVariants = {
+  const iconVariants: Variants = {
     hidden: {
       opacity: 0,
       scale: 0,
@@ -130,7 +130,7 @@ export const Breadcrumbs = ({ variant = 'default', items, className, style }: Br
     },
   };
 
-  const separatorAnimationVariants = {
+  const separatorAnimationVariants: Variants = {
     hidden: {
       opacity: 0,
       scale: 0.5,

--- a/apps/poc/src/components/navigation/Navbar/index.tsx
+++ b/apps/poc/src/components/navigation/Navbar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { ChevronDown, Menu, X } from 'lucide-react';
 import { cn } from '../../../lib/utils';
@@ -36,7 +36,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     accent: 'bg-[var(--button-red)] text-white rounded-lg',
   };
 
-  const navVariants = {
+  const navVariants: Variants = {
     hidden: {
       y: -20,
       opacity: 0,
@@ -53,7 +53,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     },
   };
 
-  const itemVariants = {
+  const itemVariants: Variants = {
     hidden: { opacity: 0, y: -10 },
     visible: {
       opacity: 1,
@@ -81,7 +81,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     },
   };
 
-  const dropdownVariants = {
+  const dropdownVariants: Variants = {
     hidden: {
       opacity: 0,
       scale: 0.95,
@@ -114,7 +114,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     },
   };
 
-  const mobileMenuVariants = {
+  const mobileMenuVariants: Variants = {
     hidden: {
       opacity: 0,
       x: '100%',
@@ -144,7 +144,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     },
   };
 
-  const iconVariants = {
+  const iconVariants: Variants = {
     hover: {
       rotate: 10,
       scale: 1.1,
@@ -156,7 +156,7 @@ export const Navbar = ({ variant = 'modern', items, logo, className, style }: Na
     },
   };
 
-  const backdropVariants = {
+  const backdropVariants: Variants = {
     hidden: {
       opacity: 0,
       transition: {

--- a/apps/poc/src/components/navigation/Sidebar/index.tsx
+++ b/apps/poc/src/components/navigation/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { ChevronRight, X } from 'lucide-react';
 import { cn } from '../../../lib/utils';
@@ -45,7 +45,7 @@ export const Sidebar = ({
     elevated: 'shadow-lg',
   };
 
-  const sidebarVariants = {
+  const sidebarVariants: Variants = {
     open: {
       width: isCollapsed ? 64 : 256,
       transition: {
@@ -67,7 +67,7 @@ export const Sidebar = ({
     },
   };
 
-  const itemVariants = {
+  const itemVariants: Variants = {
     open: {
       x: 0,
       opacity: 1,
@@ -99,7 +99,7 @@ export const Sidebar = ({
     },
   };
 
-  const iconVariants = {
+  const iconVariants: Variants = {
     hover: {
       rotate: 10,
       scale: 1.1,
@@ -119,7 +119,7 @@ export const Sidebar = ({
     },
   };
 
-  const badgeVariants = {
+  const badgeVariants: Variants = {
     hover: {
       scale: 1.1,
       transition: {
@@ -130,7 +130,7 @@ export const Sidebar = ({
     },
   };
 
-  const tooltipVariants = {
+  const tooltipVariants: Variants = {
     hidden: {
       opacity: 0,
       x: -20,

--- a/apps/poc/src/components/navigation/Tabs/index.tsx
+++ b/apps/poc/src/components/navigation/Tabs/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import { cn } from '../../../lib/utils';
 
 interface Tab {
@@ -55,7 +55,7 @@ export const Tabs = ({ variant = 'default', tabs, defaultValue, className, style
     },
   };
 
-  const tabListVariants = {
+  const tabListVariants: Variants = {
     hidden: {
       opacity: 0,
       y: -10,
@@ -74,7 +74,7 @@ export const Tabs = ({ variant = 'default', tabs, defaultValue, className, style
     },
   };
 
-  const tabContentVariants = {
+  const tabContentVariants: Variants = {
     hidden: {
       opacity: 0,
       x: 20,
@@ -105,7 +105,7 @@ export const Tabs = ({ variant = 'default', tabs, defaultValue, className, style
     },
   };
 
-  const iconVariants = {
+  const iconVariants: Variants = {
     hidden: {
       opacity: 0,
       scale: 0,
@@ -138,7 +138,7 @@ export const Tabs = ({ variant = 'default', tabs, defaultValue, className, style
     },
   };
 
-  const triggerVariants = {
+  const triggerVariants: Variants = {
     hidden: {
       opacity: 0,
       y: -10,
@@ -169,7 +169,7 @@ export const Tabs = ({ variant = 'default', tabs, defaultValue, className, style
     },
   };
 
-  const backgroundVariants = {
+  const backgroundVariants: Variants = {
     hidden: {
       opacity: 0,
       scale: 0.9,

--- a/apps/storybook/src/components/badge/badge.stories.tsx
+++ b/apps/storybook/src/components/badge/badge.stories.tsx
@@ -81,7 +81,7 @@ export const AttachedIcon: Story = {
     mode: "attached",
   },
   render: (args) => (
-    <Badge {...args}>
+    <Badge {...args as any}>
       <Mail className="h-10 w-10" />
     </Badge>
   ),
@@ -97,7 +97,7 @@ export const AttachedButton: Story = {
     mode: "attached",
   },
   render: (args) => (
-    <Badge {...args}>
+    <Badge {...args as any}>
       <button className="px-4 py-2 bg-muted rounded-lg shadow">
         Components
       </button>

--- a/apps/storybook/src/components/badge/badge.stories.tsx
+++ b/apps/storybook/src/components/badge/badge.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Badge } from "./index";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Badge, type AttachedBadgeProps } from "./index";
 import { Mail } from "lucide-react";
 
 const meta: Meta<typeof Badge> = {
@@ -81,7 +81,7 @@ export const AttachedIcon: Story = {
     mode: "attached",
   },
   render: (args) => (
-    <Badge {...args as any}>
+    <Badge {...args as AttachedBadgeProps}>
       <Mail className="h-10 w-10" />
     </Badge>
   ),
@@ -97,7 +97,7 @@ export const AttachedButton: Story = {
     mode: "attached",
   },
   render: (args) => (
-    <Badge {...args as any}>
+    <Badge {...args as AttachedBadgeProps}>
       <button className="px-4 py-2 bg-muted rounded-lg shadow">
         Components
       </button>

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -9,17 +9,17 @@ type BadgeBaseProps = {
   className?: string;
 };
 
-type InlineBadgeProps = BadgeBaseProps & {
+export type InlineBadgeProps = BadgeBaseProps & {
   mode?: "inline";
   children?: never;
 };
 
-type AttachedBadgeProps = BadgeBaseProps & {
+export type AttachedBadgeProps = BadgeBaseProps & {
   mode: "attached";
   children: React.ReactNode;
 };
 
-type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+export type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,

--- a/apps/storybook/src/components/button/index.tsx
+++ b/apps/storybook/src/components/button/index.tsx
@@ -32,6 +32,7 @@ const buttonVariants = cva(
         elevated: 'bg-background shadow-md hover:shadow-lg',
         glass: 'bg-black/10 backdrop-blur-lg text-primary hover:bg-black/20',
         neon: 'bg-pink-500 text-white shadow-lg shadow-pink-500/50 hover:bg-pink-600',
+        pill: 'rounded-full',
         none: '',
       },
       size: {
@@ -293,7 +294,7 @@ const ninaTextVariants = {
   hover: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.045, duration: 0.3, ease: [0.75, 0, 0.125, 1] },
+    transition: { delay: i * 0.045, duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   }),
 };
 
@@ -302,7 +303,7 @@ const ninaBeforeVariants = {
   hover: {
     opacity: 0,
     y: 20,
-    transition: { duration: 0.3, ease: [0.75, 0, 0.125, 1] },
+    transition: { duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   },
 };
 
@@ -338,7 +339,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         <motion.button
           className={cn(buttonVariants({ variant, size }), className, 'relative overflow-hidden')}
           ref={ref}
-          {...(motionProps as any)}
+          {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
           initial="initial"
           whileHover="hover"
         >
@@ -363,7 +364,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <motion.button
         className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
-        {...(motionProps as any)}
+        {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
       >
         {children}
       </motion.button>

--- a/apps/storybook/src/components/card/index.tsx
+++ b/apps/storybook/src/components/card/index.tsx
@@ -3,47 +3,49 @@ import * as React from "react"
 import { type HTMLMotionProps, motion } from "framer-motion"
 import { cva, type VariantProps } from "class-variance-authority"
 
+type AnimationVariant = "none" | "fadeIn" | "slideUp" | "scaleIn" | "flipIn" | "bounceIn" | "floatIn";
+
 // Card Animation Variants
-const cardAnimations = {
+const cardAnimations: Record<AnimationVariant, HTMLMotionProps<"div">> = {
   none: {},
   fadeIn: {
     initial: { opacity: 0, y: 20 },
     animate: { opacity: 1, y: 0 },
-    transition: { duration: 0.6, ease: [0.4, 0, 0.2, 1] }
+    transition: { duration: 0.6, ease: [0.4, 0, 0.2, 1] as [number, number, number, number] }
   },
   slideUp: {
     initial: { opacity: 0, y: 60, scale: 0.95 },
     animate: { opacity: 1, y: 0, scale: 1 },
-    transition: { duration: 0.7, ease: [0.4, 0, 0.2, 1] }
+    transition: { duration: 0.7, ease: [0.4, 0, 0.2, 1] as [number, number, number, number] }
   },
   scaleIn: {
     initial: { opacity: 0, scale: 0.8, rotateX: 15 },
     animate: { opacity: 1, scale: 1, rotateX: 0 },
-    transition: { duration: 0.6, ease: [0.4, 0, 0.2, 1] }
+    transition: { duration: 0.6, ease: [0.4, 0, 0.2, 1] as [number, number, number, number] }
   },
   flipIn: {
     initial: { opacity: 0, rotateY: -90, scale: 0.8 },
     animate: { opacity: 1, rotateY: 0, scale: 1 },
-    transition: { duration: 0.8, ease: [0.4, 0, 0.2, 1] }
+    transition: { duration: 0.8, ease: [0.4, 0, 0.2, 1] as [number, number, number, number] }
   },
   bounceIn: {
     initial: { opacity: 0, scale: 0.3, y: 50 },
     animate: { opacity: 1, scale: 1, y: 0 },
-    transition: { 
-      type: "spring", 
-      stiffness: 300, 
+    transition: {
+      type: "spring",
+      stiffness: 300,
       damping: 20,
-      duration: 0.8 
+      duration: 0.8
     }
   },
   floatIn: {
     initial: { opacity: 0, y: 100, rotateX: 45 },
     animate: { opacity: 1, y: 0, rotateX: 0 },
-    transition: { duration: 0.8, ease: [0.68, -0.55, 0.265, 1.55] }
+    transition: { duration: 0.8, ease: [0.68, -0.55, 0.265, 1.55] as [number, number, number, number] }
   }
 };
 
-type AnimationVariant = keyof typeof cardAnimations;
+
 
 // CVA Variants for Card
 const cardVariants = cva(

--- a/apps/storybook/src/components/dialog-box/index.tsx
+++ b/apps/storybook/src/components/dialog-box/index.tsx
@@ -1,5 +1,5 @@
-import { motion, AnimatePresence } from 'framer-motion';
-import { createContext, CSSProperties, useState } from 'react';
+import { motion, AnimatePresence, type TargetAndTransition } from 'framer-motion';
+import { createContext, type CSSProperties, useState } from 'react';
 import { X, Check, AlertTriangle, Info, XCircle } from 'lucide-react';
 
 // types/dialog.ts
@@ -24,7 +24,13 @@ export type DialogAnimationTypes =
 
 export type DialogTypes = 'success' | 'confirm' | 'error' | 'alert' | 'info' | 'warning';
 
-export const animations = {
+interface AnimationConfig {
+  initial: TargetAndTransition;
+  animate: TargetAndTransition;
+  exit: TargetAndTransition;
+}
+
+export const animations: Record<DialogAnimationTypes, AnimationConfig> = {
   popIn: {
     initial: {
       scale: 0.95,

--- a/apps/storybook/src/components/layouts/breakpoint/breakpoint.stories.tsx
+++ b/apps/storybook/src/components/layouts/breakpoint/breakpoint.stories.tsx
@@ -1,9 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import { Breakpoint } from "./index";
 
-export default {
+const meta: Meta<typeof Breakpoint> = {
   title: "Layouts/Breakpoint",
   component: Breakpoint,
-   tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
     show: {
       control: { type: "select" },
@@ -24,31 +25,51 @@ export default {
   },
 };
 
+export default meta;
+type Story = StoryObj<typeof Breakpoint>;
 
-const Template: ComponentStory<typeof Breakpoint> = (args) => (
-  <Breakpoint {...args}>
-    <p>This content is conditionally rendered based on the viewport size.</p>
-  </Breakpoint>
-);
-
-export const ShowMobile = Template.bind({});
-ShowMobile.args = {
-  show: "mobile",
+export const ShowMobile: Story = {
+  args: {
+    show: "mobile",
+  },
+  render: (args) => (
+    <Breakpoint {...args}>
+      <p>This content is conditionally rendered based on the viewport size.</p>
+    </Breakpoint>
+  ),
 };
 
-export const HideDesktop = Template.bind({});
-HideDesktop.args = {
-  hide: "desktop",
+export const HideDesktop: Story = {
+  args: {
+    hide: "desktop",
+  },
+  render: (args) => (
+    <Breakpoint {...args}>
+      <p>This content is conditionally rendered based on the viewport size.</p>
+    </Breakpoint>
+  ),
 };
 
-export const FromTabletToDesktop = Template.bind({});
-FromTabletToDesktop.args = {
-  from: "tablet",
-  to: "desktop",
+export const FromTabletToDesktop: Story = {
+  args: {
+    from: "tablet",
+    to: "desktop",
+  },
+  render: (args) => (
+    <Breakpoint {...args}>
+      <p>This content is conditionally rendered based on the viewport size.</p>
+    </Breakpoint>
+  ),
 };
 
-export const CustomRange = Template.bind({});
-CustomRange.args = {
-  from: "mobile",
-  to: "tablet",
+export const CustomRange: Story = {
+  args: {
+    from: "mobile",
+    to: "tablet",
+  },
+  render: (args) => (
+    <Breakpoint {...args}>
+      <p>This content is conditionally rendered based on the viewport size.</p>
+    </Breakpoint>
+  ),
 };

--- a/apps/storybook/src/components/layouts/breakpoint/breakpoint.stories.tsx
+++ b/apps/storybook/src/components/layouts/breakpoint/breakpoint.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Breakpoint } from "./index";
 
 const meta: Meta<typeof Breakpoint> = {

--- a/apps/storybook/src/components/layouts/lazyload/lazyload.stories.tsx
+++ b/apps/storybook/src/components/layouts/lazyload/lazyload.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { LazyLoad } from "./index";
 
 const meta: Meta<typeof LazyLoad> = {
@@ -32,13 +32,13 @@ type Story = StoryObj<typeof LazyLoad>;
 export const Default: Story = {
   args: {
     threshold: "100px",
-    placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
+    placeholder: <div className="h-[200px] bg-neutral-100 flex items-center justify-center text-sm text-neutral-500">Loading...</div>,
     once: true,
     animation: "fade",
   },
   render: (args) => (
     <LazyLoad {...args}>
-      <div style={{ height: "200px", background: "#ccc", display: "flex", justifyContent: "center", alignItems: "center" }}>
+      <div className="h-[200px] bg-neutral-300 flex items-center justify-center">
         Loaded Content
       </div>
     </LazyLoad>
@@ -48,13 +48,13 @@ export const Default: Story = {
 export const SlideAnimation: Story = {
   args: {
     threshold: "50px",
-    placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
+    placeholder: <div className="h-[200px] bg-neutral-100 flex items-center justify-center text-sm text-neutral-500">Loading...</div>,
     once: false,
     animation: "slide",
   },
   render: (args) => (
     <LazyLoad {...args}>
-      <div style={{ height: "200px", background: "#ccc", display: "flex", justifyContent: "center", alignItems: "center" }}>
+      <div className="h-[200px] bg-neutral-300 flex items-center justify-center">
         Loaded Content
       </div>
     </LazyLoad>

--- a/apps/storybook/src/components/layouts/lazyload/lazyload.stories.tsx
+++ b/apps/storybook/src/components/layouts/lazyload/lazyload.stories.tsx
@@ -1,9 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import { LazyLoad } from "./index";
 
-export default {
+const meta: Meta<typeof LazyLoad> = {
   title: "Layouts/LazyLoad",
   component: LazyLoad,
-   tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
     threshold: {
       control: { type: "text" },
@@ -25,26 +26,37 @@ export default {
   },
 };
 
-const Template = (args) => (
-  <LazyLoad {...args}>
-    <div style={{ height: "200px", background: "#ccc" ,display: "flex", 
-    justifyContent: "center", 
-    alignItems: "center" }}>Loaded Content</div>
-  </LazyLoad>
-);
+export default meta;
+type Story = StoryObj<typeof LazyLoad>;
 
-export const Default = Template.bind({});
-Default.args = {
-  threshold: "100px",
-  placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
-  once: true,
-  animation: "fade",
+export const Default: Story = {
+  args: {
+    threshold: "100px",
+    placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
+    once: true,
+    animation: "fade",
+  },
+  render: (args) => (
+    <LazyLoad {...args}>
+      <div style={{ height: "200px", background: "#ccc", display: "flex", justifyContent: "center", alignItems: "center" }}>
+        Loaded Content
+      </div>
+    </LazyLoad>
+  ),
 };
 
-export const SlideAnimation = Template.bind({});
-SlideAnimation.args = {
-  threshold: "50px",
-  placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
-  once: false,
-  animation: "slide",
+export const SlideAnimation: Story = {
+  args: {
+    threshold: "50px",
+    placeholder: <div style={{ height: "200px", background: "#eee" }}>Loading...</div>,
+    once: false,
+    animation: "slide",
+  },
+  render: (args) => (
+    <LazyLoad {...args}>
+      <div style={{ height: "200px", background: "#ccc", display: "flex", justifyContent: "center", alignItems: "center" }}>
+        Loaded Content
+      </div>
+    </LazyLoad>
+  ),
 };

--- a/apps/storybook/src/templates/layouts/single-column-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/single-column-layout/index.tsx
@@ -433,7 +433,7 @@ const SingleColumnLayout: React.FC<SingleColumnLayoutProps> = ({
     navLinks: DesktopNav,
     authControls: AuthControls,
     mobileMenuButton: MobileMenuButton,
-    variant,
+    variant: variant || "default",
     isMobileMenuOpen: menuOpen,
     toggleMobileMenu: () => setMenuOpen(!menuOpen),
   }) : (
@@ -528,7 +528,7 @@ const SingleColumnLayout: React.FC<SingleColumnLayoutProps> = ({
 
   /* ─────────────── Default Footer ─────────────── */
   const DefaultFooter = renderFooter ? renderFooter({
-    variant,
+    variant: variant || "default",
     content: footerContent || (
       <div className="text-center text-sm">
         © 2025 My Application. All rights reserved.

--- a/apps/storybook/src/templates/layouts/single-column-layout/single-column-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/single-column-layout/single-column-layout.stories.tsx
@@ -191,7 +191,7 @@ export const RenderFunctionCustomization: Story = {
     args: {
         variant: "glass",
         children: <DemoContent />,
-        renderHeader: ({ logo, navLinks, authControls, mobileMenuButton, _variant }) => (
+        renderHeader: ({ logo, navLinks, authControls, mobileMenuButton, variant: _variant }) => (
             <div className="flex items-center justify-between w-full h-full px-6">
                 {logo}
                 <div className="flex-1 flex justify-center">
@@ -212,7 +212,7 @@ export const RenderFunctionCustomization: Story = {
                 </div>
             </div>
         ),
-        renderFooter: ({ _variant, content }) => (
+        renderFooter: ({ variant: _variant, content }) => (
             <div className="flex flex-col items-center justify-center py-6 space-y-4">
                 {content}
                 <div className="flex space-x-4">

--- a/apps/storybook/src/templates/pages/account-management/api-keys/index.tsx
+++ b/apps/storybook/src/templates/pages/account-management/api-keys/index.tsx
@@ -169,7 +169,7 @@ interface RevokeKeyModalProps {
 interface ViewKeyModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onReveal: (apiKey: ApiKey) => Promise<void>;
+    onReveal: (apiKey: ApiKey) => Promise<string | void>;
     apiKey: ApiKey | null;
     isLoading?: boolean;
     inputVariant?: string;
@@ -2541,7 +2541,7 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
 
                     {filteredKeys.length === 0 ? (
                         customEmptyState || (
-                            <div className={cn(CardVariants({ variant: cardVariant }), "p-12 text-center")}>
+                            <div className={cn(CardVariants({ variant: cardVariant as "default" | "glass" | "border" | "elevated" }), "p-12 text-center")}>
                                 <div className="w-16 h-16 rounded-full bg-secondary flex items-center justify-center mx-auto mb-4">
                                     <Key className="w-8 h-8 text-muted-foreground" />
                                 </div>
@@ -2614,8 +2614,8 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
                             ))}
                         </div>
                     ) : (
-                        <div className={cn(CardVariants({ variant: cardVariant }), "overflow-hidden")}>
-                            <table className={cn("w-full", TableVariants({ variant: cardVariant }))}>
+                        <div className={cn(CardVariants({ variant: cardVariant as "default" | "glass" | "border" | "elevated" }), "overflow-hidden")}>
+                            <table className={cn("w-full", TableVariants({ variant: cardVariant as "default" | "glass" | "border" }))}>
                                 <thead>
                                     <tr className="border-b border-border">
                                         <th className="px-6 py-3 text-left text-sm font-medium text-muted-foreground">

--- a/apps/storybook/src/templates/pages/account-management/api-keys/index.tsx
+++ b/apps/storybook/src/templates/pages/account-management/api-keys/index.tsx
@@ -169,7 +169,7 @@ interface RevokeKeyModalProps {
 interface ViewKeyModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onReveal: (apiKey: ApiKey) => Promise<string | void>;
+    onReveal: (apiKey: ApiKey) => Promise<string>;
     apiKey: ApiKey | null;
     isLoading?: boolean;
     inputVariant?: string;
@@ -223,6 +223,8 @@ interface SearchFilterProps {
     searchPlaceholder?: string;
 }
 
+export type ApiKeysCardVariant = "default" | "glass" | "border" | "elevated";
+
 interface ApiKeysPageProps {
     headerTitle?: string;
     headerIcon?: React.ReactNode;
@@ -248,7 +250,7 @@ interface ApiKeysPageProps {
     | "slideUp"
     | "slideLeft"
     | "slideRight";
-    cardVariant?: string;
+    cardVariant?: ApiKeysCardVariant;
     inputVariant?: string;
     buttonVariant?: ButtonVariant;
     buttonAnimationVariant?: string;
@@ -1935,9 +1937,8 @@ const ViewKeyModal = ({
         }
 
         try {
-            const fullKey = `sk_live_${Math.random().toString(36).substring(2, 42)}`;
+            const fullKey = await onReveal(apiKey);
             setRevealedKey(fullKey);
-            await onReveal(apiKey);
             setError('');
         } catch (error) {
             setError('Failed to reveal API key');
@@ -2175,6 +2176,11 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
     autoHideDelay = 30,
     darkMode = false
 }) => {
+    const getTableVariant = (variant: ApiKeysCardVariant): "default" | "glass" | "border" => {
+        if (variant === "elevated") return "default";
+        return variant;
+    };
+
     const [apiKeys, setApiKeys] = useState<ApiKey[]>(initialApiKeys.length > 0 ? initialApiKeys : generateMockApiKeys());
     const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
     const [searchQuery, setSearchQuery] = useState('');
@@ -2615,7 +2621,7 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
                         </div>
                     ) : (
                         <div className={cn(CardVariants({ variant: cardVariant as "default" | "glass" | "border" | "elevated" }), "overflow-hidden")}>
-                            <table className={cn("w-full", TableVariants({ variant: cardVariant as "default" | "glass" | "border" }))}>
+                            <table className={cn("w-full", TableVariants({ variant: getTableVariant(cardVariant) }))}>
                                 <thead>
                                     <tr className="border-b border-border">
                                         <th className="px-6 py-3 text-left text-sm font-medium text-muted-foreground">

--- a/apps/storybook/src/templates/pages/account-management/profile/index.tsx
+++ b/apps/storybook/src/templates/pages/account-management/profile/index.tsx
@@ -117,7 +117,7 @@ interface ProfileProps {
     avatarShape?: 'circle' | 'square' | 'rounded' | 'hexagon' | 'star';
     avatarSize?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl' | '8xl' | '9xl';
     inputVariant?: string;
-    buttonVariant?: string;
+    buttonVariant?: ButtonVariantType;
     buttonAnimationVariant?: string;
 
     // Custom content
@@ -521,7 +521,7 @@ const SaveCancelBar = ({
             "border-t border-border animate-fade-in cursor-pointer"
         )}>
             <Button
-                variant={cancelButtonVariant}
+                variant={cancelButtonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                 onClick={onCancel}
                 disabled={isSaving}
                 className="min-w-[100px] cursor-pointer"
@@ -531,7 +531,7 @@ const SaveCancelBar = ({
                 Cancel
             </Button>
             <Button
-                variant={saveButtonVariant}
+                variant={saveButtonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                 onClick={onSave}
                 disabled={isSaving}
                 className="min-w-[100px] cursor-pointer"
@@ -799,7 +799,7 @@ export const ProfilePage: React.FC<ProfileProps> = ({
                             {!isEditing && (
                                 <Button
                                     onClick={handleEdit}
-                                    variant={buttonVariant}
+                                    variant={buttonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                                     animationVariant={buttonAnimationVariant}
                                     className='cursor-pointer'
                                 >

--- a/apps/storybook/src/templates/pages/account-management/profile/profile.stories.tsx
+++ b/apps/storybook/src/templates/pages/account-management/profile/profile.stories.tsx
@@ -120,20 +120,6 @@ const meta: Meta<typeof ProfilePage> = {
                 defaultValue: { summary: "Edit Profile" },
             },
         },
-        saveButtonLabel: {
-            control: "text",
-            description: "Label for save button",
-            table: {
-                defaultValue: { summary: "Save Changes" },
-            },
-        },
-        cancelButtonLabel: {
-            control: "text",
-            description: "Label for cancel button",
-            table: {
-                defaultValue: { summary: "Cancel" },
-            },
-        },
     },
     decorators: [
         (Story) => (

--- a/apps/storybook/src/templates/pages/authentication/signup/index.tsx
+++ b/apps/storybook/src/templates/pages/authentication/signup/index.tsx
@@ -616,7 +616,7 @@ const SignUp: React.FC<SignUpProps> = ({
             }
             socialTimeoutRef.current = setTimeout(() => {
                 if (isMounted.current) {
-                    setSocialLoading(null);
+                    setSocialLoading(prev => prev === provider ? null : prev);
                 }
             }, 500);
         }

--- a/apps/storybook/src/templates/pages/authentication/signup/index.tsx
+++ b/apps/storybook/src/templates/pages/authentication/signup/index.tsx
@@ -480,10 +480,13 @@ const SignUp: React.FC<SignUpProps> = ({
     const [socialLoading, setSocialLoading] = React.useState<SocialProvider | null>(null);
     const [captchaVerified, setCaptchaVerified] = React.useState(false);
     const socialTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isMounted = React.useRef(true);
 
     // Cleanup timeout on unmount
     React.useEffect(() => {
+        isMounted.current = true;
         return () => {
+            isMounted.current = false;
             if (socialTimeoutRef.current) {
                 clearTimeout(socialTimeoutRef.current);
             }
@@ -608,7 +611,14 @@ const SignUp: React.FC<SignUpProps> = ({
         } catch (error) {
             alert(`Social sign-up failed for ${provider}: ${error}`);
         } finally {
-            socialTimeoutRef.current = setTimeout(() => setSocialLoading(null), 500);
+            if (socialTimeoutRef.current) {
+                clearTimeout(socialTimeoutRef.current);
+            }
+            socialTimeoutRef.current = setTimeout(() => {
+                if (isMounted.current) {
+                    setSocialLoading(null);
+                }
+            }, 500);
         }
     };
 

--- a/apps/storybook/src/templates/pages/data-management/data-table/data-table.stories.tsx
+++ b/apps/storybook/src/templates/pages/data-management/data-table/data-table.stories.tsx
@@ -122,7 +122,7 @@ const employeeColumns: Column<Employee>[] = [
     key: 'name',
     title: 'Name',
     sortable: true,
-    render: (value: any, row: Employee) => (
+    render: (_value: any, row: Employee) => (
       <div className="flex items-center gap-2">
         <Avatar
         size="sm"

--- a/apps/storybook/src/templates/pages/data-management/data-table/data-table.stories.tsx
+++ b/apps/storybook/src/templates/pages/data-management/data-table/data-table.stories.tsx
@@ -122,7 +122,7 @@ const employeeColumns: Column<Employee>[] = [
     key: 'name',
     title: 'Name',
     sortable: true,
-    render: (_value: any, row: Employee) => (
+    render: (_value: unknown, row: Employee) => (
       <div className="flex items-center gap-2">
         <Avatar
         size="sm"
@@ -141,7 +141,7 @@ const employeeColumns: Column<Employee>[] = [
     key: 'status',
     title: 'Status',
     sortable: true,
-    render: (value: any) => {
+    render: (value: unknown) => {
       const statusColors = {
         Active: 'bg-green-100 text-green-800',
         Pending: 'bg-yellow-100 text-yellow-800',
@@ -158,7 +158,7 @@ const employeeColumns: Column<Employee>[] = [
     key: 'salary',
     title: 'Salary',
     sortable: true,
-    render: (value: any) => (
+    render: (value: unknown) => (
       <span className="font-medium text-gray-900">
         ${Number(value).toLocaleString()}
       </span>
@@ -169,7 +169,7 @@ const employeeColumns: Column<Employee>[] = [
     key: 'performance',
     title: 'Rating',
     sortable: true,
-    render: (value: any) => (
+    render: (value: unknown) => (
       <div className="flex items-center gap-1">
         <StarFilledIcon className="w-4 h-4 fill-yellow-400 text-yellow-400" />
         <span className="text-sm font-medium">{Number(value).toFixed(1)}</span>
@@ -186,13 +186,13 @@ const productColumns: Column<Product>[] = [
     key: 'price',
     title: 'Price',
     sortable: true,
-    render: (value: any) => `$${Number(value).toFixed(2)}`
+    render: (value: unknown) => `$${Number(value).toFixed(2)}`
   },
   {
     key: 'stock',
     title: 'Stock',
     sortable: true,
-    render: (value: any) => (
+    render: (value: unknown) => (
       <span className={Number(value) === 0 ? 'text-red-600 font-medium' : 'text-gray-700'}>
         {Number(value)}
       </span>
@@ -202,7 +202,7 @@ const productColumns: Column<Product>[] = [
     key: 'rating',
     title: 'Rating',
     sortable: true,
-    render: (value: any) => (
+    render: (value: unknown) => (
       <div className="flex items-center gap-1">
         <StarFilledIcon className="w-4 h-4 fill-yellow-400 text-yellow-400" />
         <span>{Number(value).toFixed(1)}</span>
@@ -213,7 +213,7 @@ const productColumns: Column<Product>[] = [
     key: 'inStock',
     title: 'Availability',
     sortable: true,
-    render: (value: any) => (
+    render: (value: unknown) => (
       <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${value ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
         {value ? 'In Stock' : 'Out of Stock'}
       </span>

--- a/apps/storybook/src/templates/pages/data-management/data-table/index.tsx
+++ b/apps/storybook/src/templates/pages/data-management/data-table/index.tsx
@@ -1314,7 +1314,7 @@ export function DataTable<T extends Record<string, any>>({
         <table className="w-full min-w-[800px] table-fixed" role="grid" aria-label="Data table">
           <colgroup>
             {enableRowSelection && <col style={{ width: '48px' }} />}
-            {visibleColumnsList.map((col, idx) => (
+            {visibleColumnsList.map((_col, idx) => (
               <col key={idx} style={{ width: `${100 / visibleColumnsList.length}%` }} />
             ))}
           </colgroup>

--- a/apps/storybook/src/templates/pages/error-pages/error-page.stories.tsx
+++ b/apps/storybook/src/templates/pages/error-pages/error-page.stories.tsx
@@ -472,7 +472,7 @@ export const ErrorCodeAnimations: Story = {
  */
 export const ServerVariant: Story = {
   render: () => (
-    <ErrorPage variant="server">
+    <ErrorPage variant="gradient">
       <ErrorPageContent>
         <ErrorPageErrorCode errorCode="500" animationType="glow" />
         <ErrorPageHeading title="Internal Server Error" />
@@ -490,7 +490,7 @@ export const ServerVariant: Story = {
  */
 export const ForbiddenVariant: Story = {
   render: () => (
-    <ErrorPage variant="forbidden" icon={ShieldAlert}>
+    <ErrorPage variant="dark" icon={ShieldAlert}>
       <ErrorPageContent>
         <ErrorPageErrorCode errorCode="403" animationType="glow" />
         <ErrorPageHeading title="Access Denied" />
@@ -803,7 +803,7 @@ export const Forbidden403: Story = {
     };
 
     return (
-      <ErrorPage variant="forbidden" icon={ShieldAlert}>
+      <ErrorPage variant="dark" icon={ShieldAlert}>
         <ErrorPageContent>
           <ErrorPageErrorCode 
             errorCode="403" 

--- a/apps/storybook/src/templates/pages/form-pages/contact-form/index.tsx
+++ b/apps/storybook/src/templates/pages/form-pages/contact-form/index.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import type { Variants } from "framer-motion";
 import AnimatedInput from "../../../../components/input";
 import { Button } from "../../../../components/button";
-import FileUpload from "../../../../components/file-upload";
+import { FileUpload } from "../../../../components/file-upload";
 import AnimatedTextarea from "../../../../components/textarea";
 import { ToastContext } from "../../../../components/toast";
 import { InfoCircledIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
@@ -412,7 +412,7 @@ function FileUploadField() {
   return (
     <FileUpload
       buttonVariant="primary"
-      onFilesChange={(files) => {
+      onFilesChange={(files: File[]) => {
         const file = files?.[0] ?? null;
         updateField("file", file);
       }}

--- a/apps/storybook/src/templates/pages/form-pages/dynamic-form/index.tsx
+++ b/apps/storybook/src/templates/pages/form-pages/dynamic-form/index.tsx
@@ -1885,6 +1885,8 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
 
     return (
         <Button
+            type="button"
+            aria-pressed={theme === 'dark'}
             variant="ghost"
             size="sm"
             onClick={toggleTheme}

--- a/apps/storybook/src/templates/pages/form-pages/dynamic-form/index.tsx
+++ b/apps/storybook/src/templates/pages/form-pages/dynamic-form/index.tsx
@@ -15,6 +15,8 @@ import {
     ChevronDownIcon,
     MagicWandIcon,
     RocketIcon,
+    SunIcon,
+    MoonIcon,
 } from '@radix-ui/react-icons';
 import { cn } from '../../../../../utils/cn';
 import { Button } from '../../../../components/button';
@@ -1862,6 +1864,41 @@ const DynamicDebugger: React.FC<DynamicDebuggerProps> = ({ className }) => {
 export interface ThemeToggleProps {
     className?: string;
 }
+
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+    useEffect(() => {
+        const isDark = document.documentElement.classList.contains('dark');
+        setTheme(isDark ? 'dark' : 'light');
+    }, []);
+
+    const toggleTheme = () => {
+        const nextTheme = theme === 'light' ? 'dark' : 'light';
+        setTheme(nextTheme);
+        if (nextTheme === 'dark') {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    };
+
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleTheme}
+            className={cn("w-9 h-9 p-0", className)}
+        >
+            {theme === 'light' ? (
+                <MoonIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+            ) : (
+                <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            )}
+            <span className="sr-only">Toggle theme</span>
+        </Button>
+    );
+};
 
 /* ============================================
    ASSIGN COMPOUND COMPONENTS

--- a/apps/storybook/src/templates/pages/form-pages/multi-step-form/multi-step-form.stories.tsx
+++ b/apps/storybook/src/templates/pages/form-pages/multi-step-form/multi-step-form.stories.tsx
@@ -340,7 +340,7 @@ const registrationSteps = [
 ];
 
 // Create a Step helper component for cleaner syntax
-const Step = ({ _step, children }: { step: number; children: React.ReactNode }) => {
+const Step = ({ children }: { step: number; children: React.ReactNode }) => {
     return <>{children}</>;
 };
 

--- a/apps/storybook/src/templates/pages/sign-in/index.tsx
+++ b/apps/storybook/src/templates/pages/sign-in/index.tsx
@@ -430,7 +430,7 @@ const SignIn: React.FC<SignInProps> = ({
             }
             socialTimeoutRef.current = setTimeout(() => {
                 if (isMounted.current) {
-                    setSocialLoading(null);
+                    setSocialLoading(prev => prev === provider ? null : prev);
                 }
             }, 500);
         }

--- a/apps/storybook/src/templates/pages/sign-in/index.tsx
+++ b/apps/storybook/src/templates/pages/sign-in/index.tsx
@@ -351,10 +351,13 @@ const SignIn: React.FC<SignInProps> = ({
     const [errors, setErrors] = React.useState<Record<string, string>>({});
     const [socialLoading, setSocialLoading] = React.useState<SocialProvider | null>(null);
     const socialTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isMounted = React.useRef(true);
 
     // Cleanup timeout on unmount
     React.useEffect(() => {
+        isMounted.current = true;
         return () => {
+            isMounted.current = false;
             if (socialTimeoutRef.current) {
                 clearTimeout(socialTimeoutRef.current);
             }
@@ -422,7 +425,14 @@ const SignIn: React.FC<SignInProps> = ({
         } catch (error) {
             alert(`Social sign-in failed for ${provider}: ${error}`);
         } finally {
-            socialTimeoutRef.current = setTimeout(() => setSocialLoading(null), 500);
+            if (socialTimeoutRef.current) {
+                clearTimeout(socialTimeoutRef.current);
+            }
+            socialTimeoutRef.current = setTimeout(() => {
+                if (isMounted.current) {
+                    setSocialLoading(null);
+                }
+            }, 500);
         }
     };
 

--- a/apps/storybook/src/templates/section/content/faq/index.tsx
+++ b/apps/storybook/src/templates/section/content/faq/index.tsx
@@ -390,7 +390,7 @@ interface AccordionItemProps {
  * </AccordionItem>
  * ```
  */
-const AccordionItem = ({ _id, children, className, disabled = false }: AccordionItemProps) => {
+const AccordionItem = ({ children, className, disabled = false }: AccordionItemProps) => {
   const context = useAccordionContext();
   // const isOpen = context.openItems.includes(id);
 

--- a/apps/storybook/src/templates/section/content/stats-grid/index.tsx
+++ b/apps/storybook/src/templates/section/content/stats-grid/index.tsx
@@ -32,8 +32,8 @@ export interface StatItem {
 
 export interface StatsGridProps extends VariantProps<typeof statsGridVariants> {
     // Layout & Variants
-    variant?: "default" | "dark" | "light";
-    columns?: 2 | 3 | 4 | 5 | 6;
+    variant?: "default" | "dark" | "light" | "primary" | "secondary";
+    columns?: 1 | 2 | 3 | 4 | 5 | 6;
     contentAlign?: "left" | "center" | "right";
 
     // Animation
@@ -110,6 +110,8 @@ const statsGridVariants = cva("w-full transition-all duration-300", {
             default: "bg-white text-gray-900",
             dark: "bg-gray-950 text-white", // Solid dark, no gradient
             light: "bg-gray-50 text-gray-900",
+            primary: "bg-primary text-white",
+            secondary: "bg-secondary text-white",
         },
         padding: {
             sm: "py-8 md:py-12",
@@ -148,6 +150,7 @@ const gapClasses: Record<string, string> = {
 };
 
 const columnClasses: Record<number, string> = {
+    1: "grid-cols-1",
     2: "grid-cols-1 sm:grid-cols-2",
     3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
     4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
@@ -525,6 +528,12 @@ export interface StatIconProps {
     bgColor?: string;
     iconColor?: string;
     solid?: boolean; // Use solid vibrant colors instead of light backgrounds
+    // Story compatibility props
+    iconBg?: string;
+    iconFg?: string;
+    darkIconBg?: string;
+    darkIconFg?: string;
+    overrideAccent?: boolean;
 }
 
 /**
@@ -547,6 +556,11 @@ export const StatIcon: React.FC<StatIconProps> = ({
     bgColor,
     iconColor,
     solid = false,
+    iconBg,
+    iconFg,
+    darkIconBg,
+    darkIconFg,
+    overrideAccent = false,
 }) => {
     const context = useStatsGrid();
     const styles = vibrantAccentStyles[accent];
@@ -565,6 +579,9 @@ export const StatIcon: React.FC<StatIconProps> = ({
 
     // Determine background color
     const getBgClass = () => {
+        if (overrideAccent) {
+            return context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor || "";
+        }
         if (bgColor) return bgColor;
         if (solid) return styles.iconBg;
         return context.theme === "dark" ? styles.darkBg : styles.lightBg;
@@ -572,6 +589,9 @@ export const StatIcon: React.FC<StatIconProps> = ({
 
     // Determine icon color
     const getFgClass = () => {
+        if (overrideAccent) {
+            return context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor || "";
+        }
         if (iconColor) return iconColor;
         if (solid) return styles.iconFg;
         return context.theme === "dark" ? "text-gray-200" : `text-${accent}-600`;

--- a/apps/storybook/src/templates/section/content/stats-grid/index.tsx
+++ b/apps/storybook/src/templates/section/content/stats-grid/index.tsx
@@ -580,7 +580,8 @@ export const StatIcon: React.FC<StatIconProps> = ({
     // Determine background color
     const getBgClass = () => {
         if (overrideAccent) {
-            return context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor || "";
+            const overrideVal = context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor;
+            if (overrideVal) return overrideVal;
         }
         if (bgColor) return bgColor;
         if (solid) return styles.iconBg;
@@ -590,7 +591,8 @@ export const StatIcon: React.FC<StatIconProps> = ({
     // Determine icon color
     const getFgClass = () => {
         if (overrideAccent) {
-            return context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor || "";
+            const overrideVal = context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor;
+            if (overrideVal) return overrideVal;
         }
         if (iconColor) return iconColor;
         if (solid) return styles.iconFg;

--- a/apps/storybook/src/templates/section/content/stats-grid/stats-grid.stories.tsx
+++ b/apps/storybook/src/templates/section/content/stats-grid/stats-grid.stories.tsx
@@ -45,6 +45,7 @@ import {
 } from "@radix-ui/react-icons";
 import { cn } from "../../../../../utils/cn";
 import React from "react";
+import { ShoppingCart as ShoppingCartIcon, Flag as FlagIcon } from "lucide-react";
 
 const meta: Meta<typeof StatsGrid> = {
     title: "Templates/Section/Content/StatsGrid",
@@ -1311,10 +1312,10 @@ export const DarkThemeGlassy: Story = {
                 </StatsGridDescription>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 relative z-10">
                     {[
-                        { value: 10000000, label: "Users", icon: PersonIcon, color: "blue" },
-                        { value: 99.99, label: "Uptime", icon: LockClosedIcon, color: "emerald", suffix: "%" },
-                        { value: 2500000000, label: "Revenue", icon: CardStackIcon, color: "amber" },
-                        { value: 50000000, label: "Downloads", icon: DownloadIcon, color: "violet", suffix: "+" },
+                        { value: 10000000, label: "Users", icon: PersonIcon, color: "blue", format: "compact" },
+                        { value: 99.99, label: "Uptime", icon: LockClosedIcon, color: "emerald", suffix: "%", format: "percentage" },
+                        { value: 2500000000, label: "Revenue", icon: CardStackIcon, color: "amber", format: "currency" },
+                        { value: 50000000, label: "Downloads", icon: DownloadIcon, color: "violet", suffix: "+", format: "compact" },
                     ].map((stat, i) => (
                         <div key={i} className="backdrop-blur-xl bg-white/5 rounded-2xl p-6 border border-white/10 shadow-2xl">
                             <div className="flex items-start justify-between">

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -9,17 +9,17 @@ type BadgeBaseProps = {
   className?: string;
 };
 
-type InlineBadgeProps = BadgeBaseProps & {
+export type InlineBadgeProps = BadgeBaseProps & {
   mode?: "inline";
   children?: never;
 };
 
-type AttachedBadgeProps = BadgeBaseProps & {
+export type AttachedBadgeProps = BadgeBaseProps & {
   mode: "attached";
   children: React.ReactNode;
 };
 
-type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+export type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
 
 const Badge: React.FC<BadgeProps> = ({
   text,

--- a/packages/registry/components/button/index.tsx
+++ b/packages/registry/components/button/index.tsx
@@ -32,6 +32,7 @@ const buttonVariants = cva(
         elevated: 'bg-background shadow-md hover:shadow-lg',
         glass: 'bg-black/10 backdrop-blur-lg text-primary hover:bg-black/20',
         neon: 'bg-pink-500 text-white shadow-lg shadow-pink-500/50 hover:bg-pink-600',
+        pill: 'rounded-full',
         none: '',
       },
       size: {
@@ -293,7 +294,7 @@ const ninaTextVariants = {
   hover: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.045, duration: 0.3, ease: [0.75, 0, 0.125, 1] as const },
+    transition: { delay: i * 0.045, duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   }),
 };
 
@@ -302,7 +303,7 @@ const ninaBeforeVariants = {
   hover: {
     opacity: 0,
     y: 20,
-    transition: { duration: 0.3, ease: [0.75, 0, 0.125, 1] as const },
+    transition: { duration: 0.3, ease: [0.75, 0, 0.125, 1] as [number, number, number, number] },
   },
 };
 
@@ -338,7 +339,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         <motion.button
           className={cn(buttonVariants({ variant, size }), className, 'relative overflow-hidden')}
           ref={ref}
-          {...(motionProps as any)}
+          {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
           initial="initial"
           whileHover="hover"
         >
@@ -363,7 +364,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <motion.button
         className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
-        {...(motionProps as any)}
+        {...(motionProps as unknown as React.ComponentPropsWithoutRef<typeof motion.button>)}
       >
         {children}
       </motion.button>

--- a/packages/registry/components/dialogbox/index.tsx
+++ b/packages/registry/components/dialogbox/index.tsx
@@ -1,5 +1,5 @@
-import { motion, AnimatePresence, TargetAndTransition } from 'framer-motion';
-import { createContext, CSSProperties, useState } from 'react';
+import { motion, AnimatePresence, type TargetAndTransition } from 'framer-motion';
+import { createContext, type CSSProperties, useState } from 'react';
 import { X, Check, AlertTriangle, Info, XCircle } from 'lucide-react';
 
 // types/dialog.ts

--- a/packages/registry/components/layouts/responsive-grid/index.tsx
+++ b/packages/registry/components/layouts/responsive-grid/index.tsx
@@ -78,7 +78,7 @@ const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
         className={`${baseClass} ${uniqueClass} ${className}`}
       >
         <AnimatePresence>
-          {React.Children.map(children, (child: any, index: number) => {
+          {React.Children.map(children, (child: React.ReactNode, index: number) => {
             if (animation === "none") return child;
 
             return (

--- a/packages/registry/components/layouts/spacer/index.tsx
+++ b/packages/registry/components/layouts/spacer/index.tsx
@@ -33,6 +33,8 @@ const spacerVariants = cva('', {
   },
 });
 
+type SpacerVariantSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
 const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
   (
     { className, size = 'md', direction = 'vertical', responsive, style, ...props },
@@ -43,16 +45,18 @@ const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
     const responsiveClasses: string[] = [];
     if (responsive) {
       if (responsive.mobile && designTokenSizes.includes(responsive.mobile as string)) {
-        responsiveClasses.push(spacerVariants({ size: responsive.mobile as any, direction }));
+        responsiveClasses.push(
+          spacerVariants({ size: responsive.mobile as SpacerVariantSize, direction })
+        );
       }
       if (responsive.tablet && designTokenSizes.includes(responsive.tablet as string)) {
         responsiveClasses.push(
-          `sm:${spacerVariants({ size: responsive.tablet as any, direction })}`
+          `sm:${spacerVariants({ size: responsive.tablet as SpacerVariantSize, direction })}`
         );
       }
       if (responsive.desktop && designTokenSizes.includes(responsive.desktop as string)) {
         responsiveClasses.push(
-          `md:${spacerVariants({ size: responsive.desktop as any, direction })}`
+          `md:${spacerVariants({ size: responsive.desktop as SpacerVariantSize, direction })}`
         );
       }
     }
@@ -84,7 +88,7 @@ const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
       <div
         ref={ref}
         className={cn(
-          !isCustomSize && spacerVariants({ size: size as any, direction }),
+          !isCustomSize && spacerVariants({ size: size as SpacerVariantSize, direction }),
           responsiveClasses,
           className
         )}

--- a/packages/registry/components/spacer/index.tsx
+++ b/packages/registry/components/spacer/index.tsx
@@ -33,6 +33,8 @@ const spacerVariants = cva('', {
   },
 });
 
+type SpacerVariantSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
 const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
   (
     { className, size = 'md', direction = 'vertical', responsive, style, ...props },
@@ -43,16 +45,18 @@ const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
     const responsiveClasses: string[] = [];
     if (responsive) {
       if (responsive.mobile && designTokenSizes.includes(responsive.mobile as string)) {
-        responsiveClasses.push(spacerVariants({ size: responsive.mobile as any, direction }));
+        responsiveClasses.push(
+          spacerVariants({ size: responsive.mobile as SpacerVariantSize, direction })
+        );
       }
       if (responsive.tablet && designTokenSizes.includes(responsive.tablet as string)) {
         responsiveClasses.push(
-          `sm:${spacerVariants({ size: responsive.tablet as any, direction })}`
+          `sm:${spacerVariants({ size: responsive.tablet as SpacerVariantSize, direction })}`
         );
       }
       if (responsive.desktop && designTokenSizes.includes(responsive.desktop as string)) {
         responsiveClasses.push(
-          `md:${spacerVariants({ size: responsive.desktop as any, direction })}`
+          `md:${spacerVariants({ size: responsive.desktop as SpacerVariantSize, direction })}`
         );
       }
     }
@@ -84,7 +88,7 @@ const Spacer = React.forwardRef<HTMLDivElement, SpacerProps>(
       <div
         ref={ref}
         className={cn(
-          !isCustomSize && spacerVariants({ size: size as any, direction }),
+          !isCustomSize && spacerVariants({ size: size as SpacerVariantSize, direction }),
           responsiveClasses,
           className
         )}

--- a/packages/registry/components/threecolumnsidebar/threecolumnsidebar.test.tsx
+++ b/packages/registry/components/threecolumnsidebar/threecolumnsidebar.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 
 vi.mock("framer-motion", () => {
   const actual = vi.importActual<typeof import("framer-motion")>("framer-motion");
@@ -143,8 +142,7 @@ describe("useSidebar", () => {
     spy.mockRestore();
   });
 
-  it("toggle flips the open state", async () => {
-    const user = userEvent.setup();
+  it("toggle flips the open state", () => {
     const Toggler = () => {
       const { isOpen, toggle } = useSidebar("left");
       return (
@@ -162,14 +160,13 @@ describe("useSidebar", () => {
 
     const btn = screen.getByTestId("btn");
     expect(btn.textContent).toBe("true");
-    await user.click(btn);
+    fireEvent.click(btn);
     expect(btn.textContent).toBe("false");
-    await user.click(btn);
+    fireEvent.click(btn);
     expect(btn.textContent).toBe("true");
   });
 
-  it("onOpen sets the sidebar open", async () => {
-    const user = userEvent.setup();
+  it("onOpen sets the sidebar open", () => {
     const Opener = () => {
       const { isOpen, onOpen } = useSidebar("left");
       return (
@@ -186,12 +183,11 @@ describe("useSidebar", () => {
     );
 
     expect(screen.getByTestId("btn").textContent).toBe("false");
-    await user.click(screen.getByTestId("btn"));
+    fireEvent.click(screen.getByTestId("btn"));
     expect(screen.getByTestId("btn").textContent).toBe("true");
   });
 
-  it("onClose sets the sidebar closed", async () => {
-    const user = userEvent.setup();
+  it("onClose sets the sidebar closed", () => {
     const Closer = () => {
       const { isOpen, onClose } = useSidebar("left");
       return (
@@ -208,7 +204,7 @@ describe("useSidebar", () => {
     );
 
     expect(screen.getByTestId("btn").textContent).toBe("true");
-    await user.click(screen.getByTestId("btn"));
+    fireEvent.click(screen.getByTestId("btn"));
     expect(screen.getByTestId("btn").textContent).toBe("false");
   });
 
@@ -248,8 +244,7 @@ describe("useSidebar", () => {
     expect(screen.getByTestId("result").textContent).toBe("false");
   });
 
-  it("each position is tracked independently", async () => {
-    const user = userEvent.setup();
+  it("each position is tracked independently", () => {
     const MultiProbe = () => {
       const left  = useSidebar("left");
       const right = useSidebar("right");
@@ -267,7 +262,7 @@ describe("useSidebar", () => {
       </SidebarProvider>
     );
 
-    await user.click(screen.getByTestId("toggle-left"));
+    fireEvent.click(screen.getByTestId("toggle-left"));
     expect(screen.getByTestId("toggle-left").textContent).toBe("false");
     expect(screen.getByTestId("right-state").textContent).toBe("true");
   });
@@ -412,27 +407,25 @@ describe("ThreeColumnSidebar header toggle buttons", () => {
     expect(screen.queryByTestId("icon-x")).not.toBeInTheDocument();
   });
 
-  it("clicking X closes the sidebar", async () => {
-    const user = userEvent.setup();
+  it("clicking X closes the sidebar", () => {
     renderWithProvider(
       <ThreeColumnSidebar links={defaultLinks} brandName="Ignix" position="left" />,
       { left: true }
     );
 
     expect(screen.getByText("Ignix")).toBeInTheDocument();
-    await user.click(screen.getByTestId("icon-x").closest("button")!);
+    fireEvent.click(screen.getByTestId("icon-x").closest("button")!);
     expect(screen.queryByText("Ignix")).not.toBeInTheDocument();
   });
 
-  it("clicking Menu opens the sidebar", async () => {
-    const user = userEvent.setup();
+  it("clicking Menu opens the sidebar", () => {
     renderWithProvider(
       <ThreeColumnSidebar links={defaultLinks} brandName="Ignix" position="left" />,
       { left: false }
     );
 
     expect(screen.queryByText("Ignix")).not.toBeInTheDocument();
-    await user.click(screen.getByTestId("icon-menu").closest("button")!);
+    fireEvent.click(screen.getByTestId("icon-menu").closest("button")!);
     expect(screen.getByText("Ignix")).toBeInTheDocument();
   });
 });
@@ -446,72 +439,62 @@ describe("ThreeColumnSidebar mobile show-more", () => {
     setWindowWidth(1024);
   });
 
-  it("renders the '...' show-more button on mobile for bottom positions", async () => {
-    await act(async () => {
-      renderWithProvider(
-        <ThreeColumnSidebar
-          links={manyLinks}
-          position="bottomLeft"
-          sidebarLayoutMode="BOTTOM_DOCKED"
-          direction="horizontal"
-        />,
-        { bottomLeft: true }
-      );
-    });
+  it("renders the '...' show-more button on mobile for bottom positions", () => {
+    renderWithProvider(
+      <ThreeColumnSidebar
+        links={manyLinks}
+        position="bottomLeft"
+        sidebarLayoutMode="BOTTOM_DOCKED"
+        direction="horizontal"
+      />,
+      { bottomLeft: true }
+    );
 
     expect(screen.getByText("...")).toBeInTheDocument();
   });
 
-  it("does NOT render show-more button for non-bottom positions on mobile", async () => {
-    await act(async () => {
-      renderWithProvider(
-        <ThreeColumnSidebar links={manyLinks} position="left" />,
-        { left: true }
-      );
-    });
+  it("does NOT render show-more button for non-bottom positions on mobile", () => {
+    renderWithProvider(
+      <ThreeColumnSidebar links={manyLinks} position="left" />,
+      { left: true }
+    );
 
     expect(screen.queryByText("...")).not.toBeInTheDocument();
   });
 
-  it("clicking '...' reveals extra links and changes button text to 'Hide'", async () => {
-    const user = userEvent.setup();
-    await act(async () => {
-      renderWithProvider(
-        <ThreeColumnSidebar
-          links={manyLinks}
-          position="bottomLeft"
-          sidebarLayoutMode="OVERLAY_ONLY"
-          direction="horizontal"
-        />,
-        { bottomLeft: true }
-      );
-    });
+  it("clicking '...' reveals extra links and changes button text to 'Hide'", () => {
+    renderWithProvider(
+      <ThreeColumnSidebar
+        links={manyLinks}
+        position="bottomLeft"
+        sidebarLayoutMode="OVERLAY_ONLY"
+        direction="horizontal"
+      />,
+      { bottomLeft: true }
+    );
 
     expect(screen.queryByText("Extra A")).not.toBeInTheDocument();
-    await user.click(screen.getByText("..."));
+    fireEvent.click(screen.getByText("..."));
     expect(screen.getByText("Extra A")).toBeInTheDocument();
     expect(screen.getByText("Extra B")).toBeInTheDocument();
     expect(screen.getByText("Hide")).toBeInTheDocument();
   });
 
-  it("clicking 'Hide' collapses extra links again", async () => {
-    const user = userEvent.setup();
-    await act(async () => {
-      renderWithProvider(
-        <ThreeColumnSidebar
-          links={manyLinks}
-          position="bottomLeft"
-          sidebarLayoutMode="OVERLAY_ONLY"
-          direction="horizontal"
-        />,
-        { bottomLeft: true }
-      );
-    });
+  it("clicking 'Hide' collapses extra links again", () => {
+    renderWithProvider(
+      <ThreeColumnSidebar
+        links={manyLinks}
+        position="bottomLeft"
+        sidebarLayoutMode="OVERLAY_ONLY"
+        direction="horizontal"
+      />,
+      { bottomLeft: true }
+    );
 
-    await user.click(screen.getByText("..."));
+    fireEvent.click(screen.getByText("..."));
     expect(screen.getByText("Extra A")).toBeInTheDocument();
 
-    await user.click(screen.getByText("Hide"));
+    fireEvent.click(screen.getByText("Hide"));
     expect(screen.queryByText("Extra A")).not.toBeInTheDocument();
     expect(screen.getByText("...")).toBeInTheDocument();
   });
@@ -663,8 +646,7 @@ describe("Dual sidebars from one provider", () => {
     expect(screen.getByText("RightBrand")).toBeInTheDocument();
   });
 
-  it("closing left does not close right", async () => {
-    const user = userEvent.setup();
+  it("closing left does not close right", () => {
     render(
       <SidebarProvider initialState={{ left: true, right: true }}>
         <ThreeColumnSidebar links={defaultLinks} brandName="LeftBrand" position="left" />
@@ -676,7 +658,7 @@ describe("Dual sidebars from one provider", () => {
       .getAllByTestId("icon-x")
       .map((el) => el.closest("button")!);
 
-    await user.click(closeButtons[0]);
+    fireEvent.click(closeButtons[0]);
 
     expect(screen.queryByText("LeftBrand")).not.toBeInTheDocument();
     expect(screen.getByText("RightBrand")).toBeInTheDocument();

--- a/packages/registry/components/threecolumnsidebar/threecolumnsidebar.test.tsx
+++ b/packages/registry/components/threecolumnsidebar/threecolumnsidebar.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 vi.mock("framer-motion", () => {
   const actual = vi.importActual<typeof import("framer-motion")>("framer-motion");
@@ -59,7 +59,7 @@ const manyLinks = [
   ...defaultLinks,
   { label: "Extra A", href: "/a", icon: Home },
   { label: "Extra B", href: "/b", icon: Inbox },
-  { label: "Extra C", href: "/c", icon: Settings},
+  { label: "Extra C", href: "/c", icon: Settings },
 ];
 
 function renderWithProvider(
@@ -246,11 +246,11 @@ describe("useSidebar", () => {
 
   it("each position is tracked independently", () => {
     const MultiProbe = () => {
-      const left  = useSidebar("left");
+      const left = useSidebar("left");
       const right = useSidebar("right");
       return (
         <>
-          <button onClick={left.toggle}  data-testid="toggle-left">{String(left.isOpen)}</button>
+          <button onClick={left.toggle} data-testid="toggle-left">{String(left.isOpen)}</button>
           <span data-testid="right-state">{String(right.isOpen)}</span>
         </>
       );
@@ -518,8 +518,8 @@ describe("ThreeColumnSidebar — responsive resize", () => {
     removeSpy.mockRestore();
   });
 
-  it("applies w-0 class when mobile and sidebar is closed", async () => {
-    await act(async () => setWindowWidth(480));
+  it("applies w-0 class when mobile and sidebar is closed", () => {
+    setWindowWidth(480);
 
     const { container } = renderWithProvider(
       <ThreeColumnSidebar links={defaultLinks} position="left" className="" />,
@@ -530,8 +530,8 @@ describe("ThreeColumnSidebar — responsive resize", () => {
     expect(root.className).toContain("w-0");
   });
 
-  it("does not apply w-0 class on desktop even when closed", async () => {
-    await act(async () => setWindowWidth(1280));
+  it("does not apply w-0 class on desktop even when closed", () => {
+    setWindowWidth(1280);
 
     const { container } = renderWithProvider(
       <ThreeColumnSidebar links={defaultLinks} position="left" className="" />,
@@ -637,7 +637,7 @@ describe("Dual sidebars from one provider", () => {
   it("left and right sidebars render independently", () => {
     render(
       <SidebarProvider initialState={{ left: true, right: true }}>
-        <ThreeColumnSidebar links={defaultLinks} brandName="LeftBrand" position="left"  />
+        <ThreeColumnSidebar links={defaultLinks} brandName="LeftBrand" position="left" />
         <ThreeColumnSidebar links={defaultLinks} brandName="RightBrand" position="right" />
       </SidebarProvider>
     );

--- a/packages/registry/templates/layouts/single-column-layout/index.tsx
+++ b/packages/registry/templates/layouts/single-column-layout/index.tsx
@@ -433,7 +433,7 @@ const SingleColumnLayout: React.FC<SingleColumnLayoutProps> = ({
         navLinks: DesktopNav,
         authControls: AuthControls,
         mobileMenuButton: MobileMenuButton,
-        variant,
+        variant: variant || "default",
         isMobileMenuOpen: menuOpen,
         toggleMobileMenu: () => setMenuOpen(!menuOpen),
     }) : (
@@ -528,7 +528,7 @@ const SingleColumnLayout: React.FC<SingleColumnLayoutProps> = ({
 
     /* ─────────────── Default Footer ─────────────── */
     const DefaultFooter = renderFooter ? renderFooter({
-        variant,
+        variant: variant || "default",
         content: footerContent || (
             <div className="text-center text-sm">
                 © 2025 My Application. All rights reserved.

--- a/packages/registry/templates/pages/analytics-dashboard-page/analytics-dashboard-page.test.tsx
+++ b/packages/registry/templates/pages/analytics-dashboard-page/analytics-dashboard-page.test.tsx
@@ -70,6 +70,7 @@ vi.mock("@ignix-ui/date-picker", () => {
   return {
     __esModule: true,
     default: DatePicker,
+    DatePicker,
   };
 });
 

--- a/packages/registry/templates/pages/analytics-dashboard-page/index.tsx
+++ b/packages/registry/templates/pages/analytics-dashboard-page/index.tsx
@@ -23,7 +23,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@ignix-ui/card";
-import DatePicker, { type DateRange } from "@ignix-ui/date-picker";
+import { DatePicker, type DateRange } from "@ignix-ui/date-picker";
 
 // =============================================================================
 // TYPES

--- a/packages/registry/templates/pages/api-keys/index.tsx
+++ b/packages/registry/templates/pages/api-keys/index.tsx
@@ -169,7 +169,7 @@ interface RevokeKeyModalProps {
 interface ViewKeyModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onReveal: (apiKey: ApiKey) => Promise<void>;
+    onReveal: (apiKey: ApiKey) => Promise<string>;
     apiKey: ApiKey | null;
     isLoading?: boolean;
     inputVariant?: string;
@@ -223,6 +223,8 @@ interface SearchFilterProps {
     searchPlaceholder?: string;
 }
 
+export type ApiKeysCardVariant = "default" | "glass" | "border" | "elevated";
+
 interface ApiKeysPageProps {
     headerTitle?: string;
     headerIcon?: React.ReactNode;
@@ -248,7 +250,7 @@ interface ApiKeysPageProps {
     | "slideUp"
     | "slideLeft"
     | "slideRight";
-    cardVariant?: string;
+    cardVariant?: ApiKeysCardVariant;
     inputVariant?: string;
     buttonVariant?: ButtonVariant;
     buttonAnimationVariant?: string;
@@ -1935,9 +1937,8 @@ const ViewKeyModal = ({
         }
 
         try {
-            const fullKey = `sk_live_${Math.random().toString(36).substring(2, 42)}`;
+            const fullKey = await onReveal(apiKey);
             setRevealedKey(fullKey);
-            await onReveal(apiKey);
             setError('');
         } catch (error) {
             setError('Failed to reveal API key');
@@ -2175,6 +2176,11 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
     autoHideDelay = 30,
     darkMode = false
 }) => {
+    const getTableVariant = (variant: ApiKeysCardVariant): "default" | "glass" | "border" => {
+        if (variant === "elevated") return "default";
+        return variant;
+    };
+
     const [apiKeys, setApiKeys] = useState<ApiKey[]>(initialApiKeys.length > 0 ? initialApiKeys : generateMockApiKeys());
     const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
     const [searchQuery, setSearchQuery] = useState('');
@@ -2615,7 +2621,7 @@ export const ApiKeysPage: React.FC<ApiKeysPageProps> = ({
                         </div>
                     ) : (
                         <div className={cn(CardVariants({ variant: cardVariant }), "overflow-hidden")}>
-                            <table className={cn("w-full", TableVariants({ variant: cardVariant }))}>
+                            <table className={cn("w-full", TableVariants({ variant: getTableVariant(cardVariant) }))}>
                                 <thead>
                                     <tr className="border-b border-border">
                                         <th className="px-6 py-3 text-left text-sm font-medium text-muted-foreground">

--- a/packages/registry/templates/pages/data-table/index.tsx
+++ b/packages/registry/templates/pages/data-table/index.tsx
@@ -1314,7 +1314,7 @@ export function DataTable<T extends Record<string, any>>({
         <table className="w-full min-w-[800px] table-fixed" role="grid" aria-label="Data table">
           <colgroup>
             {enableRowSelection && <col style={{ width: '48px' }} />}
-            {visibleColumnsList.map((col, idx) => (
+            {visibleColumnsList.map((_col, idx) => (
               <col key={idx} style={{ width: `${100 / visibleColumnsList.length}%` }} />
             ))}
           </colgroup>

--- a/packages/registry/templates/pages/dynamic-form/index.tsx
+++ b/packages/registry/templates/pages/dynamic-form/index.tsx
@@ -1885,6 +1885,8 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
 
     return (
         <Button
+            type="button"
+            aria-pressed={theme === 'dark'}
             variant="ghost"
             size="sm"
             onClick={toggleTheme}

--- a/packages/registry/templates/pages/dynamic-form/index.tsx
+++ b/packages/registry/templates/pages/dynamic-form/index.tsx
@@ -15,6 +15,8 @@ import {
     ChevronDownIcon,
     MagicWandIcon,
     RocketIcon,
+    SunIcon,
+    MoonIcon,
 } from '@radix-ui/react-icons';
 import { cn } from '../../../utils/cn';
 import { Button } from '@ignix-ui/button';
@@ -1862,6 +1864,41 @@ const DynamicDebugger: React.FC<DynamicDebuggerProps> = ({ className }) => {
 export interface ThemeToggleProps {
     className?: string;
 }
+
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+    useEffect(() => {
+        const isDark = document.documentElement.classList.contains('dark');
+        setTheme(isDark ? 'dark' : 'light');
+    }, []);
+
+    const toggleTheme = () => {
+        const nextTheme = theme === 'light' ? 'dark' : 'light';
+        setTheme(nextTheme);
+        if (nextTheme === 'dark') {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    };
+
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleTheme}
+            className={cn("w-9 h-9 p-0", className)}
+        >
+            {theme === 'light' ? (
+                <MoonIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+            ) : (
+                <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            )}
+            <span className="sr-only">Toggle theme</span>
+        </Button>
+    );
+};
 
 /* ============================================
    ASSIGN COMPOUND COMPONENTS

--- a/packages/registry/templates/pages/profile/index.tsx
+++ b/packages/registry/templates/pages/profile/index.tsx
@@ -515,7 +515,7 @@ const SaveCancelBar = ({
             "border-t border-border animate-fade-in cursor-pointer"
         )}>
             <Button
-                variant={cancelButtonVariant as any}
+                variant={cancelButtonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                 onClick={onCancel}
                 disabled={isSaving}
                 className="min-w-[100px] cursor-pointer"
@@ -525,7 +525,7 @@ const SaveCancelBar = ({
                 Cancel
             </Button>
             <Button
-                variant={saveButtonVariant as any}
+                variant={saveButtonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                 onClick={onSave}
                 disabled={isSaving}
                 className="min-w-[100px] cursor-pointer"
@@ -793,7 +793,7 @@ export const ProfilePage: React.FC<ProfileProps> = ({
                             {!isEditing && (
                                 <Button
                                     onClick={handleEdit}
-                                    variant={buttonVariant as any}
+                                    variant={buttonVariant as React.ComponentPropsWithoutRef<typeof Button>['variant']}
                                     animationVariant={buttonAnimationVariant}
                                     className='cursor-pointer'
                                 >

--- a/packages/registry/templates/pages/quiz-form/index.tsx
+++ b/packages/registry/templates/pages/quiz-form/index.tsx
@@ -68,7 +68,7 @@ interface QuizFormContextType {
   submitted: boolean;
   cardVariant: CardVariantType;
   stepLabels?: string[];
-  setAnswer: (id: string, value: any) => void;
+  setAnswer: (id: string, value: AnswerValue) => void;
   goNext: () => void;
   goPrev: () => void;
   handleSubmit: () => void;
@@ -780,7 +780,7 @@ export const QuizForm: React.FC<QuizFormProps> & {
   const [submitted, setSubmitted] = useState(false);
   const total = questions.length;
 
-  const setAnswer = useCallback((id: string, value: any) => {
+  const setAnswer = useCallback((id: string, value: AnswerValue) => {
     setAnswers((prev) => ({ ...prev, [id]: value }));
   }, []);
 

--- a/packages/registry/templates/pages/setting-page/index.tsx
+++ b/packages/registry/templates/pages/setting-page/index.tsx
@@ -174,12 +174,11 @@ const getCurrentDateTimeForTimezone = (timezone: string) =>
 
 export function getSupportedTimezones(): string[] {
   try {
-    if (
-      typeof Intl !== "undefined" &&
-      "supportedValuesOf" in Intl &&
-      typeof (Intl as any).supportedValuesOf === "function"
-    ) {
-      return (Intl as any).supportedValuesOf("timeZone");
+    if (typeof Intl !== "undefined") {
+      const intl = Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] };
+      if (typeof intl.supportedValuesOf === "function") {
+        return intl.supportedValuesOf("timeZone");
+      }
     }
   } catch(e) { console.log (e)}
   return [

--- a/packages/registry/templates/pages/sign-in/index.tsx
+++ b/packages/registry/templates/pages/sign-in/index.tsx
@@ -430,7 +430,7 @@ const SignIn: React.FC<SignInProps> = ({
             }
             socialTimeoutRef.current = setTimeout(() => {
                 if (isMounted.current) {
-                    setSocialLoading(null);
+                    setSocialLoading(prev => prev === provider ? null : prev);
                 }
             }, 500);
         }

--- a/packages/registry/templates/pages/sign-in/index.tsx
+++ b/packages/registry/templates/pages/sign-in/index.tsx
@@ -351,10 +351,13 @@ const SignIn: React.FC<SignInProps> = ({
     const [errors, setErrors] = React.useState<Record<string, string>>({});
     const [socialLoading, setSocialLoading] = React.useState<SocialProvider | null>(null);
     const socialTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isMounted = React.useRef(true);
 
     // Cleanup timeout on unmount
     React.useEffect(() => {
+        isMounted.current = true;
         return () => {
+            isMounted.current = false;
             if (socialTimeoutRef.current) {
                 clearTimeout(socialTimeoutRef.current);
             }
@@ -422,7 +425,14 @@ const SignIn: React.FC<SignInProps> = ({
         } catch (error) {
             alert(`Social sign-in failed for ${provider}: ${error}`);
         } finally {
-            socialTimeoutRef.current = setTimeout(() => setSocialLoading(null), 500);
+            if (socialTimeoutRef.current) {
+                clearTimeout(socialTimeoutRef.current);
+            }
+            socialTimeoutRef.current = setTimeout(() => {
+                if (isMounted.current) {
+                    setSocialLoading(null);
+                }
+            }, 500);
         }
     };
 

--- a/packages/registry/templates/pages/sign-up/index.tsx
+++ b/packages/registry/templates/pages/sign-up/index.tsx
@@ -616,7 +616,7 @@ const SignUp: React.FC<SignUpProps> = ({
             }
             socialTimeoutRef.current = setTimeout(() => {
                 if (isMounted.current) {
-                    setSocialLoading(null);
+                    setSocialLoading(prev => prev === provider ? null : prev);
                 }
             }, 500);
         }

--- a/packages/registry/templates/pages/sign-up/index.tsx
+++ b/packages/registry/templates/pages/sign-up/index.tsx
@@ -480,10 +480,13 @@ const SignUp: React.FC<SignUpProps> = ({
     const [socialLoading, setSocialLoading] = React.useState<SocialProvider | null>(null);
     const [captchaVerified, setCaptchaVerified] = React.useState(false);
     const socialTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isMounted = React.useRef(true);
 
     // Cleanup timeout on unmount
     React.useEffect(() => {
+        isMounted.current = true;
         return () => {
+            isMounted.current = false;
             if (socialTimeoutRef.current) {
                 clearTimeout(socialTimeoutRef.current);
             }
@@ -608,7 +611,14 @@ const SignUp: React.FC<SignUpProps> = ({
         } catch (error) {
             alert(`Social sign-up failed for ${provider}: ${error}`);
         } finally {
-            socialTimeoutRef.current = setTimeout(() => setSocialLoading(null), 500);
+            if (socialTimeoutRef.current) {
+                clearTimeout(socialTimeoutRef.current);
+            }
+            socialTimeoutRef.current = setTimeout(() => {
+                if (isMounted.current) {
+                    setSocialLoading(null);
+                }
+            }, 500);
         }
     };
 

--- a/packages/registry/templates/sections/faq-accordion/index.tsx
+++ b/packages/registry/templates/sections/faq-accordion/index.tsx
@@ -390,7 +390,7 @@ interface AccordionItemProps {
  * </AccordionItem>
  * ```
  */
-const AccordionItem = ({ _id, children, className, disabled = false }: AccordionItemProps) => {
+const AccordionItem = ({ children, className, disabled = false }: AccordionItemProps) => {
     const context = useAccordionContext();
     // const isOpen = context.openItems.includes(id);
 

--- a/packages/registry/templates/sections/stats-grid/index.tsx
+++ b/packages/registry/templates/sections/stats-grid/index.tsx
@@ -32,8 +32,8 @@ export interface StatItem {
 
 export interface StatsGridProps extends VariantProps<typeof statsGridVariants> {
     // Layout & Variants
-    variant?: "default" | "dark" | "light";
-    columns?: 2 | 3 | 4 | 5 | 6;
+    variant?: "default" | "dark" | "light" | "primary" | "secondary";
+    columns?: 1 | 2 | 3 | 4 | 5 | 6;
     contentAlign?: "left" | "center" | "right";
 
     // Animation
@@ -110,6 +110,8 @@ const statsGridVariants = cva("w-full transition-all duration-300", {
             default: "bg-white text-gray-900",
             dark: "bg-gray-950 text-white", // Solid dark, no gradient
             light: "bg-gray-50 text-gray-900",
+            primary: "bg-primary text-white",
+            secondary: "bg-secondary text-white",
         },
         padding: {
             sm: "py-8 md:py-12",
@@ -148,6 +150,7 @@ const gapClasses: Record<string, string> = {
 };
 
 const columnClasses: Record<number, string> = {
+    1: "grid-cols-1",
     2: "grid-cols-1 sm:grid-cols-2",
     3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
     4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
@@ -525,6 +528,12 @@ export interface StatIconProps {
     bgColor?: string;
     iconColor?: string;
     solid?: boolean; // Use solid vibrant colors instead of light backgrounds
+    // Story compatibility props
+    iconBg?: string;
+    iconFg?: string;
+    darkIconBg?: string;
+    darkIconFg?: string;
+    overrideAccent?: boolean;
 }
 
 /**
@@ -547,6 +556,11 @@ export const StatIcon: React.FC<StatIconProps> = ({
     bgColor,
     iconColor,
     solid = false,
+    iconBg,
+    iconFg,
+    darkIconBg,
+    darkIconFg,
+    overrideAccent = false,
 }) => {
     const context = useStatsGrid();
     const styles = vibrantAccentStyles[accent];
@@ -565,6 +579,9 @@ export const StatIcon: React.FC<StatIconProps> = ({
 
     // Determine background color
     const getBgClass = () => {
+        if (overrideAccent) {
+            return context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor || "";
+        }
         if (bgColor) return bgColor;
         if (solid) return styles.iconBg;
         return context.theme === "dark" ? styles.darkBg : styles.lightBg;
@@ -572,6 +589,9 @@ export const StatIcon: React.FC<StatIconProps> = ({
 
     // Determine icon color
     const getFgClass = () => {
+        if (overrideAccent) {
+            return context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor || "";
+        }
         if (iconColor) return iconColor;
         if (solid) return styles.iconFg;
         return context.theme === "dark" ? "text-gray-200" : `text-${accent}-600`;

--- a/packages/registry/templates/sections/stats-grid/index.tsx
+++ b/packages/registry/templates/sections/stats-grid/index.tsx
@@ -580,7 +580,8 @@ export const StatIcon: React.FC<StatIconProps> = ({
     // Determine background color
     const getBgClass = () => {
         if (overrideAccent) {
-            return context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor || "";
+            const overrideVal = context.theme === "dark" && darkIconBg ? darkIconBg : iconBg || bgColor;
+            if (overrideVal) return overrideVal;
         }
         if (bgColor) return bgColor;
         if (solid) return styles.iconBg;
@@ -590,7 +591,8 @@ export const StatIcon: React.FC<StatIconProps> = ({
     // Determine icon color
     const getFgClass = () => {
         if (overrideAccent) {
-            return context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor || "";
+            const overrideVal = context.theme === "dark" && darkIconFg ? darkIconFg : iconFg || iconColor;
+            if (overrideVal) return overrideVal;
         }
         if (iconColor) return iconColor;
         if (solid) return styles.iconFg;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       framer-motion:
-        specifier: ^12.4.10
-        version: 12.4.10(react-dom@19.1.1)(react@19.1.1)
+        specifier: ^12.23.24
+        version: 12.23.24(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1)(react@19.1.1)
       lucide-react:
         specifier: ^0.477.0
         version: 0.477.0(react@19.1.1)
@@ -12058,27 +12058,6 @@ packages:
       react-dom: 18.0.0(react@18.0.0)
       tslib: 2.8.1
     dev: true
-
-  /framer-motion@12.4.10(react-dom@19.1.1)(react@19.1.1):
-    resolution: {integrity: sha512-3Msuyjcr1Pb5hjkn4EJcRe1HumaveP0Gbv4DBMKTPKcV/1GSMkQXj+Uqgneys+9DPcZM18Hac9qY9iUEF5LZtg==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      motion-dom: 12.23.23
-      motion-utils: 12.23.6
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      tslib: 2.8.1
-    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -7,7 +7,15 @@ import React from 'react';
 
 // Mock framer-motion for testing to avoid context issues
 vi.mock('framer-motion', () => {
-  const mockMotion = (Component: any) => Component;
+  interface MockMotion {
+    (Component: any): any;
+    div: (props: any) => React.ReactElement;
+    span: (props: any) => React.ReactElement;
+    button: (props: any) => React.ReactElement;
+    create: (Component: any) => any;
+  }
+
+  const mockMotion = (((Component: any) => Component) as unknown) as MockMotion;
   mockMotion.div = ({ children, ...props }: any) => React.createElement('div', props, children);
   mockMotion.span = ({ children, ...props }: any) => React.createElement('span', props, children);
   mockMotion.button = ({ children, ...props }: any) =>

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -6,14 +6,19 @@ import { vi } from 'vitest';
 import React from 'react';
 
 // Mock framer-motion for testing to avoid context issues
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }: any) => React.createElement('div', props, children),
-    span: ({ children, ...props }: any) => React.createElement('span', props, children),
-    button: ({ children, ...props }: any) => React.createElement('button', props, children),
-  },
-  AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
-}));
+vi.mock('framer-motion', () => {
+  const mockMotion = (Component: any) => Component;
+  mockMotion.div = ({ children, ...props }: any) => React.createElement('div', props, children);
+  mockMotion.span = ({ children, ...props }: any) => React.createElement('span', props, children);
+  mockMotion.button = ({ children, ...props }: any) =>
+    React.createElement('button', props, children);
+  mockMotion.create = (Component: any) => Component;
+
+  return {
+    motion: mockMotion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
 
 // Mock React 18 features if needed
 global.React = React;


### PR DESCRIPTION
Release from Development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New components or component API changes**
  - Added `ThemeToggle` with dark-mode state, `aria-pressed`, and Sun/Moon icons.
  - Added `pill` button variants.
  - Added `ApiKeysCardVariant` typing and returned revealed API keys from `onReveal`.
  - Expanded `StatsGrid` variants, added one-column layouts, and added `StatIcon` color overrides.
  - Exported badge prop types.

- **Bug fixes**
  - Prevented delayed sign-in and sign-up state updates after unmount.
  - Fixed API key reveal behavior to display the returned key.
  - Corrected Framer Motion `skewX` usage.
  - Mapped unsupported `"elevated"` table variants to `"default"`.
  - Removed invalid prop destructuring and corrected supported error-page variants.
  - Improved DatePicker and FileUpload import compatibility.

- **Tooling / config changes**
  - Replaced explicit `any` usage with specific TypeScript types.
  - Added explicit Framer Motion `Variants` and transition typings.
  - Updated `framer-motion` to `^12.23.24`.
  - Improved the Framer Motion test mock, including `motion.create`.
  - Simplified sidebar tests by using synchronous `fireEvent`.

- **Docs / Storybook updates**
  - Migrated Breakpoint and LazyLoad stories to typed Storybook Vite metadata and `StoryObj`.
  - Updated story arguments, Tailwind styling, and supported component variants.
  - Removed obsolete Profile story controls.
  - Added stats-grid story data and icon examples.

- **Breaking changes**
  - Removed the exported `ButtonVariant` type from the docs button component.
  - Changed `ViewKeyModalProps.onReveal` to return `Promise<string>`.
  - Restricted `ApiKeysPageProps.cardVariant` to `ApiKeysCardVariant`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->