### PR TITLE
fix(cli): resolve local development bias and dynamically detect global stylesheet in init command

### DIFF
--- a/packages/cli-tool/src/commands/init.ts
+++ b/packages/cli-tool/src/commands/init.ts
@@ -8,6 +8,7 @@ import { DependencyService } from '../services/DependencyService';
 import prompts from 'prompts';
 import { ThemeService } from '../services/ThemeService';
 import { loadConfig } from '../utils/config';
+import axios from 'axios';
 
 const DEFAULT_CONFIG_PATH = 'ignix.config.js';
 
@@ -320,58 +321,80 @@ async function createIgnixConfigFIle() {
   }
 }
 
+async function findGlobalCssFile(dir: string): Promise<string | null> {
+  const possibleCssPaths = [
+    // Next.js App Router (without src/)
+    path.join(dir, 'app', 'globals.css'),
+    path.join(dir, 'app', 'global.css'),
+    // Next.js App Router (with src/)
+    path.join(dir, 'src', 'app', 'globals.css'),
+    path.join(dir, 'src', 'app', 'global.css'),
+    // Next.js Pages Router or generic styles
+    path.join(dir, 'src', 'styles', 'globals.css'),
+    path.join(dir, 'src', 'styles', 'global.css'),
+    // Vite/React / others
+    path.join(dir, 'src', 'index.css'),
+    path.join(dir, 'src', 'App.css'),
+    path.join(dir, 'src', 'styles.css'),
+    path.join(dir, 'src', 'app.css'),
+    path.join(dir, 'app.css'),
+    path.join(dir, 'index.css'),
+  ];
+
+  for (const cssPath of possibleCssPaths) {
+    if (await fs.pathExists(cssPath)) {
+      return cssPath;
+    }
+  }
+
+  const targetNames = ['globals.css', 'global.css', 'index.css', 'app.css', 'styles.css'];
+  const excludedDirs = ['node_modules', '.next', '.git', 'dist', 'build', 'out', 'coverage'];
+
+  async function walk(currentDir: string): Promise<string | null> {
+    try {
+      const files = await fs.readdir(currentDir);
+      for (const file of files) {
+        const fullPath = path.join(currentDir, file);
+        const stat = await fs.stat(fullPath);
+        if (stat.isDirectory()) {
+          if (excludedDirs.includes(file) || file.startsWith('.')) {
+            continue;
+          }
+          const found = await walk(fullPath);
+          if (found) return found;
+        } else if (stat.isFile()) {
+          if (targetNames.includes(file.toLowerCase())) {
+            return fullPath;
+          }
+        }
+      }
+    } catch (e) {
+      // Ignore errors for unreadable directories
+    }
+    return null;
+  }
+
+  return walk(dir);
+}
+
 async function updateGlobalStyles() {
   const root = process.cwd();
 
-  // Try multiple possible paths to find custom.css
-  // 1. Relative to CLI tool (monorepo structure)
-  // 2. Relative to project root (if docs is in the same repo)
-  const possibleCustomCssPaths = [
-    path.resolve(__dirname, '../../../apps/docs/src/css/custom.css'),
-    path.resolve(root, '../docs/src/css/custom.css'),
-    path.resolve(root, 'apps/docs/src/css/custom.css'),
-    path.resolve(root, 'docs/src/css/custom.css'),
-  ];
+  let customCssContent = '';
 
-  let customCssPath: string | null = null;
-  for (const cssPath of possibleCustomCssPaths) {
-    if (await fs.pathExists(cssPath)) {
-      customCssPath = cssPath;
-      break;
+  try {
+    const response = await axios.get(
+      'https://raw.githubusercontent.com/mindfiredigital/ignix-ui/main/apps/docs/src/css/custom.css'
+    );
+    customCssContent = response.data;
+  } catch (fetchError) {
+    logger.error('Failed to fetch custom styles from the Ignix UI GitHub repository.');
+    if (fetchError instanceof Error) {
+      logger.error(`Reason: ${fetchError.message}`);
     }
-  }
-
-  // Check if custom.css exists
-  if (!customCssPath) {
-    logger.warn('Custom CSS file not found. Skipping CSS update.');
     return;
   }
-
-  // Read the custom.css content
-  const customCssContent = await fs.readFile(customCssPath, 'utf-8');
-
-  // Detect project type and find the appropriate CSS file
-  const possibleCssPaths = [
-    // Next.js App Router
-    path.join(root, 'src', 'styles', 'globals.css'),
-    path.join(root, 'src', 'app', 'globals.css'),
-    // Vite/React
-    path.join(root, 'src', 'index.css'),
-    path.join(root, 'src', 'App.css'),
-    // Generic
-    path.join(root, 'src', 'styles.css'),
-    path.join(root, 'src', 'app.css'),
-    path.join(root, 'app.css'),
-    path.join(root, 'index.css'),
-  ];
-
-  let cssFilePath: string | null = null;
-  for (const cssPath of possibleCssPaths) {
-    if (await fs.pathExists(cssPath)) {
-      cssFilePath = cssPath;
-      break;
-    }
-  }
+  let cssFilePath = await findGlobalCssFile(root);
 
   // If no CSS file exists, create one in the most common location
   if (!cssFilePath) {

--- a/packages/cli-tool/src/commands/init.ts
+++ b/packages/cli-tool/src/commands/init.ts
@@ -343,7 +343,14 @@ async function findGlobalCssFile(dir: string): Promise<string | null> {
 
   for (const cssPath of possibleCssPaths) {
     if (await fs.pathExists(cssPath)) {
-      return cssPath;
+      try {
+        const stat = await fs.lstat(cssPath);
+        if (!stat.isSymbolicLink()) {
+          return cssPath;
+        }
+      } catch (e) {
+        // Skip inaccessible files
+      }
     }
   }
 
@@ -354,18 +361,25 @@ async function findGlobalCssFile(dir: string): Promise<string | null> {
     try {
       const files = await fs.readdir(currentDir);
       for (const file of files) {
-        const fullPath = path.join(currentDir, file);
-        const stat = await fs.stat(fullPath);
-        if (stat.isDirectory()) {
-          if (excludedDirs.includes(file) || file.startsWith('.')) {
+        try {
+          const fullPath = path.join(currentDir, file);
+          const stat = await fs.lstat(fullPath);
+          if (stat.isSymbolicLink()) {
             continue;
           }
-          const found = await walk(fullPath);
-          if (found) return found;
-        } else if (stat.isFile()) {
-          if (targetNames.includes(file.toLowerCase())) {
-            return fullPath;
+          if (stat.isDirectory()) {
+            if (excludedDirs.includes(file) || file.startsWith('.')) {
+              continue;
+            }
+            const found = await walk(fullPath);
+            if (found) return found;
+          } else if (stat.isFile()) {
+            if (targetNames.includes(file.toLowerCase())) {
+              return fullPath;
+            }
           }
+        } catch (e) {
+          // Skip individual failed/inaccessible paths and continue scanning other siblings
         }
       }
     } catch (e) {
@@ -384,7 +398,8 @@ async function updateGlobalStyles() {
 
   try {
     const response = await axios.get(
-      'https://raw.githubusercontent.com/mindfiredigital/ignix-ui/main/apps/docs/src/css/custom.css'
+      'https://raw.githubusercontent.com/mindfiredigital/ignix-ui/main/apps/docs/src/css/custom.css',
+      { timeout: 10000 }
     );
     customCssContent = response.data;
   } catch (fetchError) {

--- a/packages/registry/templates/pages/profile/index.tsx
+++ b/packages/registry/templates/pages/profile/index.tsx
@@ -714,7 +714,7 @@ export const ProfilePage: React.FC<ProfileProps> = ({
                 }, avatarFile);
             } else {
                 // Simulate API call
-                await new Promise(resolve => setTimeout(resolve, 1000));
+                await new Promise(resolve => setTimeout(resolve, typeof process !== 'undefined' && process.env?.NODE_ENV === 'test' ? 0 : 1000));
 
                 setProfileData({
                     ...editedData,

--- a/packages/registry/templates/pages/profile/index.tsx
+++ b/packages/registry/templates/pages/profile/index.tsx
@@ -714,7 +714,7 @@ export const ProfilePage: React.FC<ProfileProps> = ({
                 }, avatarFile);
             } else {
                 // Simulate API call
-                await new Promise(resolve => setTimeout(resolve, typeof process !== 'undefined' && process.env?.NODE_ENV === 'test' ? 0 : 1000));
+                await new Promise(resolve => setTimeout(resolve, 1000));
 
                 setProfileData({
                     ...editedData,

--- a/packages/registry/templates/pages/profile/profile.test.tsx
+++ b/packages/registry/templates/pages/profile/profile.test.tsx
@@ -431,6 +431,11 @@ describe('ProfilePage', () => {
         });
 
         it('handles undefined onSave callback gracefully', async () => {
+            const originalSetTimeout = global.setTimeout;
+            global.setTimeout = ((fn: (...args: any[]) => void, delay?: number, ...args: any[]) => {
+                return originalSetTimeout(fn, 0, ...args);
+            }) as any;
+
             const user = userEvent.setup();
 
             render(<ProfilePage initialProfileData={defaultProfileData} />);
@@ -452,6 +457,8 @@ describe('ProfilePage', () => {
                 const viewEditButton = editButtons.find(btn => btn.textContent?.includes('Edit Profile'));
                 expect(viewEditButton).toBeInTheDocument();
             });
+
+            global.setTimeout = originalSetTimeout;
         });
 
         it('handles long text in fields', () => {


### PR DESCRIPTION
## Description

### What does this PR do?

This PR fixes issues in the `ignix init` CLI command where the tool was unable to locate or write styles correctly in external projects

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [X] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Bug fixes
- Update `init` to detect global stylesheets across common framework paths and project directories.
- Exclude generated, dependency, and hidden directories during stylesheet discovery.
- Fetch Ignix UI custom CSS from GitHub.
- Handle stylesheet fetch and directory read failures without throwing.
- Reduce the profile save delay to zero during tests.

### Tooling / config changes
- Remove the CLI’s dependency on a local `custom.css` path.

### Breaking changes
None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->