### PR TITLE
fix(cli): remove unused import to remove liniting issue

### DIFF
--- a/packages/cli-tool/src/commands/init.ts
+++ b/packages/cli-tool/src/commands/init.ts
@@ -8,7 +8,6 @@ import { DependencyService } from '../services/DependencyService';
 import prompts from 'prompts';
 import { ThemeService } from '../services/ThemeService';
 import { loadConfig } from '../utils/config';
-import { writeAgentsFile } from '../utils/agentsFile';
 
 const DEFAULT_CONFIG_PATH = 'ignix.config.js';
 


### PR DESCRIPTION
## Description

### What does this PR do?

Remove unused import from init.ts code file to avoid liniting error

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [X] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Bug fixes**
  - Removed the unused `writeAgentsFile` import from `packages/cli-tool/src/commands/init.ts`.
  - Resolved the related linting error.
  - Verified with `npm run lint`.

- **Breaking changes**
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->