### PR TITLE
fix(registry): add button-with-icon dependency to errorpage template

### DIFF
--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -216,7 +216,8 @@
       ],
       "componentDependencies": [
         "button",
-        "typography"
+        "typography",
+        "button-with-icon"
       ],
       "files": {
         "main": {


### PR DESCRIPTION
## Description

### What does this PR do?

Resolves the missing dependency issue in the errorpage template where button-with-icon is not downloaded during template installation, causing the project to fail compilation with a missing module error.

### Related Issues

- Closes #936 


## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

<img width="1145" height="432" alt="image" src="https://github.com/user-attachments/assets/d21d154a-d659-484b-94f0-9abe0661b193" />


## Additional Context

- Bug fix

  - Added the missing button-with-icon dependency to the errorpage template's registryDependencies in packages/registry/templates.json.
  - The dependency is now downloaded along with the other declared registry dependencies, preventing the Cannot find module '../../components/ui/button-with-icon' compilation error.
---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New components or component API changes**
  - Added `button-with-icon` to the `errorPage` template dependencies.

- **Bug fixes**
  - Fixed missing component installation for the `errorpage` template.
  - Prevents the `Cannot find module '../../components/ui/button-with-icon'` TypeScript compilation error.

- **Tooling / config changes**
  - Updated `packages/registry/registry.json` to include `button-with-icon` with `button` and `typography`.

- **Breaking changes**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->