### PR TITLE
fix(component): remove duplicate clear all button

### DIFF
--- a/apps/docs/src/components/UI/file-upload/index.tsx
+++ b/apps/docs/src/components/UI/file-upload/index.tsx
@@ -408,7 +408,6 @@ interface UploadButtonProps {
     isUploading: boolean;
     disabled: boolean;
     onClick: () => void;
-    onClearAll: () => void;
 }
 
 // Simple Button component (since the actual Button component is imported)
@@ -451,8 +450,7 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
     files,
     isUploading,
     disabled,
-    onClick,
-    onClearAll
+    onClick
 }) => {
     return (
         <motion.div
@@ -493,17 +491,6 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
                     )}
                 </div>
             </div>
-
-            {files.length > 0 && (
-                <button
-                    onClick={onClearAll}
-                    disabled={isUploading}
-                    className="text-slate-600 hover:text-rose-600 dark:text-gray-400 dark:hover:text-rose-400 font-medium transition-colors disabled:opacity-50 flex items-center"
-                >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Clear All
-                </button>
-            )}
         </motion.div>
     );
 };
@@ -1131,7 +1118,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
                         isUploading={isUploading}
                         disabled={disabled}
                         onClick={handleButtonClick}
-                        onClearAll={clearAll}
                     />
                 )}
 

--- a/apps/storybook/src/components/file-upload/index.tsx
+++ b/apps/storybook/src/components/file-upload/index.tsx
@@ -408,7 +408,6 @@ interface UploadButtonProps {
     isUploading: boolean;
     disabled: boolean;
     onClick: () => void;
-    onClearAll: () => void;
 }
 
 // Simple Button component (since the actual Button component is imported)
@@ -451,8 +450,7 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
     files,
     isUploading,
     disabled,
-    onClick,
-    onClearAll
+    onClick
 }) => {
     return (
         <motion.div
@@ -493,17 +491,6 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
                     )}
                 </div>
             </div>
-
-            {files.length > 0 && (
-                <button
-                    onClick={onClearAll}
-                    disabled={isUploading}
-                    className="text-slate-600 hover:text-rose-600 dark:text-gray-400 dark:hover:text-rose-400 font-medium transition-colors disabled:opacity-50 flex items-center"
-                >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Clear All
-                </button>
-            )}
         </motion.div>
     );
 };
@@ -1131,7 +1118,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
                         isUploading={isUploading}
                         disabled={disabled}
                         onClick={handleButtonClick}
-                        onClearAll={clearAll}
                     />
                 )}
 

--- a/packages/registry/components/file-upload/file-upload.test.tsx
+++ b/packages/registry/components/file-upload/file-upload.test.tsx
@@ -365,10 +365,9 @@ describe('FileUpload', () => {
                 expect(screen.getByText('test2.pdf')).toBeInTheDocument();
             });
 
-            // Click clear all button from the file list section (not the top one)
-            const clearAllButtons = screen.getAllByRole('button', { name: /Clear All/i });
-            // Use the second one (file list section)
-            await user.click(clearAllButtons[1]);
+            //  Click clear all button from the file list section.
+            const clearAllButton = screen.getByRole('button', { name: /Clear All/i });
+            await user.click(clearAllButton);
 
             await waitFor(() => {
                 expect(screen.queryByText('test1.pdf')).not.toBeInTheDocument();

--- a/packages/registry/components/file-upload/index.tsx
+++ b/packages/registry/components/file-upload/index.tsx
@@ -408,7 +408,6 @@ interface UploadButtonProps {
     isUploading: boolean;
     disabled: boolean;
     onClick: () => void;
-    onClearAll: () => void;
 }
 
 // Simple Button component (since the actual Button component is imported)
@@ -451,8 +450,7 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
     files,
     isUploading,
     disabled,
-    onClick,
-    onClearAll
+    onClick
 }) => {
     return (
         <motion.div
@@ -493,17 +491,6 @@ const UploadButtonComponent: React.FC<UploadButtonProps> = ({
                     )}
                 </div>
             </div>
-
-            {files.length > 0 && (
-                <button
-                    onClick={onClearAll}
-                    disabled={isUploading}
-                    className="text-slate-600 hover:text-rose-600 dark:text-gray-400 dark:hover:text-rose-400 font-medium transition-colors disabled:opacity-50 flex items-center"
-                >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Clear All
-                </button>
-            )}
         </motion.div>
     );
 };
@@ -1149,7 +1136,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
                         isUploading={isUploading}
                         disabled={disabled}
                         onClick={handleButtonClick}
-                        onClearAll={clearAll}
                     />
                 )}
 


### PR DESCRIPTION
## Description

### What does this PR do?

Resolves the duplicate Clear All button issue in the File Upload component, where two Clear All options were displayed for deleting uploaded files.

### Related Issues



- Closes #920 

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

### Before
<img width="1108" height="671" alt="image" src="https://github.com/user-attachments/assets/b4f1d860-983f-4449-b445-cc3bbb72d42e" />

### After 
<img width="1112" height="733" alt="image" src="https://github.com/user-attachments/assets/39914fff-545d-4faf-b11a-a807414c3243" />


## Additional Context

- Bug fix

  - Removed the duplicate Clear All button from the upload-action row next to the Upload Files button and selected file count.
  - Kept the Clear All button in the Selected Files section.
  - Applied the fix consistently across all three File Upload component copies:
    - `packages/registry/components/file-upload/index.tsx`
    - `apps/storybook/src/components/file-upload/index.tsx`
    - `apps/docs/src/components/UI/file-upload/index.tsx`

- Test update

  - Updated the File Upload test to use getByRole for the Clear All button instead of assuming that two Clear All buttons exist.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New components or component API changes**
  - Removed the duplicate `Clear All` control from the upload button in all three File Upload component copies.
  - Removed the internal `onClearAll` prop. The public `FileUpload` API remains unchanged.
  - Kept file clearing in the `FileList` component.

- **Bug fixes**
  - Prevented duplicate clear controls in the File Upload interface.
  - Updated the test to find the file-list clear button by role and name instead of button position.

- **Docs / Storybook updates**
  - Applied the UI fix to the documentation and Storybook File Upload components.

- **Breaking changes**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->