### PR TITLE
feat(component): add Documentation layout with docs and stories

### DIFF
--- a/apps/docs/src/components/Demo/DocumentationLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/DocumentationLayoutDemo.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react';
+import VariantSelector from './VariantSelector';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { DocumentationLayout } from '@site/src/components/UI/documentation-layout';
+import { Github, Sparkles } from 'lucide-react';
+import { Navbar } from '@site/src/components/UI/navbar';
+
+const sidebarWidths = ['220', '260', '280', '320'];
+const tocWidths = ['180', '220', '240', '280'];
+
+const navSections = [
+  {
+    label: 'Getting Started',
+    items: [
+      { label: 'Introduction', href: '#', active: true },
+      { label: 'Installation', href: '#' },
+      { label: 'Quick Start', href: '#' },
+    ],
+  },
+  {
+    label: 'Guides',
+    items: [
+      {
+        label: 'Theming',
+        items: [
+          { label: 'Core Concepts', href: '#' },
+          { label: 'Dark Mode', href: '#' },
+        ],
+      },
+      {
+        label: 'Components',
+        items: [
+          { label: 'Button', href: '#' },
+          { label: 'Textarea', href: '#' },
+        ],
+      },
+    ],
+  },
+];
+
+const tocHeadings = [
+  { id: 'demo-overview', label: 'Overview' },
+  { id: 'demo-installation', label: 'Installation' },
+  { id: 'demo-usage', label: 'Usage' },
+  { id: 'demo-props', label: 'Props' },
+];
+
+const mainContent = (
+  <article className="prose prose-sm max-w-none">
+    <h2 id="demo-overview" className="text-2xl font-bold mb-4 text-[var(--foreground)]">
+      Overview
+    </h2>
+    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+      DocumentationLayout provides a sticky header, a collapsible-tree navigation sidebar
+      (a drawer on mobile), and a scroll-spy "On this page" panel - the shape most
+      documentation and reference sites need out of the box.
+    </p>
+    <h2 id="demo-installation" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+      Installation
+    </h2>
+    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+      Add the template to your project, then wrap your page content with it.
+    </p>
+    <h2 id="demo-usage" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+      Usage
+    </h2>
+    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+      Pass <code>navSections</code> for the left sidebar and <code>tocHeadings</code> for the
+      right panel - the active heading highlights automatically as you scroll.
+    </p>
+    <h2 id="demo-props" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+      Props
+    </h2>
+    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+      See the Props table below this demo for the full API, including breadcrumbs, page
+      title, and previous/next page links.
+    </p>
+  </article>
+);
+
+const DocumentationLayoutDemo = () => {
+  const [sidebarWidth, setSidebarWidth] = useState<number>(280);
+  const [tocWidth, setTocWidth] = useState<number>(240);
+
+  const codeString = `
+import { DocumentationLayout } from '@ignix-ui/documentationlayout';
+
+<DocumentationLayout
+  header={<span className="font-bold">Ignix UI</span>}
+  searchSlot={<SearchBox placeholder="Search docs..." />}
+  actions={<ThemeToggle />}
+  navSections={[
+    {
+      label: 'Getting Started',
+      items: [
+        { label: 'Introduction', href: '/intro', active: true },
+        { label: 'Installation', href: '/install' },
+      ],
+    },
+    {
+      label: 'Guides',
+      items: [
+        {
+          label: 'Theming',
+          items: [
+            { label: 'Core Concepts', href: '/theming/core' },
+            { label: 'Dark Mode', href: '/theming/dark-mode' },
+          ],
+        },
+      ],
+    },
+  ]}
+  tocHeadings={[
+    { id: 'overview', label: 'Overview' },
+    { id: 'installation', label: 'Installation' },
+  ]}
+  breadcrumbs={[
+    { label: 'Docs', href: '/docs' },
+    { label: 'Getting Started', href: '/docs/getting-started' },
+  ]}
+  title="Introduction"
+  previousPage={{ label: 'Home', href: '/' }}
+  nextPage={{ label: 'Installation', href: '/install' }}
+  editPageUrl="https://github.com/org/repo/edit/main/intro.mdx"
+  sidebarWidth={${sidebarWidth}}
+  tocWidth={${tocWidth}}
+>
+  <article>{/* page content, with matching heading ids for the TOC */}</article>
+</DocumentationLayout>
+`;
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-4 justify-start sm:justify-end">
+        <VariantSelector
+          variants={sidebarWidths}
+          selectedVariant={sidebarWidth.toString()}
+          onSelectVariant={(val) => setSidebarWidth(Number(val))}
+          type="Sidebar Width"
+        />
+        <VariantSelector
+          variants={tocWidths}
+          selectedVariant={tocWidth.toString()}
+          onSelectVariant={(val) => setTocWidth(Number(val))}
+          type="TOC Width"
+        />
+      </div>
+      <Tabs>
+        <TabItem value="preview" label="Preview" default>
+          <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 560 }}>
+            <div className="h-full overflow-y-auto">
+              <DocumentationLayout
+                header={
+                  <Navbar variant="primary" size="md" className="rounded-none px-4 w-full">
+                    <div className="flex items-center gap-2">
+                      <Sparkles className="h-4 w-4" />
+                      <span className="text-sm font-semibold tracking-tight">Ignix UI</span>
+                    </div>
+                  </Navbar>
+                }
+                actions={
+                  <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+                    <Github className="h-4 w-4" />
+                  </a>
+                }
+                navSections={navSections}
+                tocHeadings={tocHeadings}
+                breadcrumbs={[
+                  { label: 'Docs', href: '#' },
+                  { label: 'Getting Started', href: '#' },
+                ]}
+                title="Introduction"
+                previousPage={{ label: 'Home', href: '#' }}
+                nextPage={{ label: 'Installation', href: '#' }}
+                editPageUrl="#"
+                sidebarWidth={sidebarWidth}
+                tocWidth={tocWidth}
+              >
+                {mainContent}
+              </DocumentationLayout>
+            </div>
+          </div>
+        </TabItem>
+        <TabItem value="code" label="Code">
+          <div className="mt-4">
+            <CodeBlock language="tsx" className="text-sm">
+              {codeString}
+            </CodeBlock>
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  );
+};
+
+export default DocumentationLayoutDemo;

--- a/apps/docs/src/components/Demo/DocumentationLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/DocumentationLayoutDemo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import VariantSelector from './VariantSelector';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -49,40 +49,50 @@ const tocHeadings = [
 
 const mainContent = (
   <article className="prose prose-sm max-w-none">
-    <h2 id="demo-overview" className="text-2xl font-bold mb-4 text-[var(--foreground)]">
-      Overview
-    </h2>
-    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
-      DocumentationLayout provides a sticky header, a collapsible-tree navigation sidebar
-      (a drawer on mobile), and a scroll-spy "On this page" panel - the shape most
-      documentation and reference sites need out of the box.
-    </p>
-    <h2 id="demo-installation" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
-      Installation
-    </h2>
-    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
-      Add the template to your project, then wrap your page content with it.
-    </p>
-    <h2 id="demo-usage" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
-      Usage
-    </h2>
-    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
-      Pass <code>navSections</code> for the left sidebar and <code>tocHeadings</code> for the
-      right panel - the active heading highlights automatically as you scroll.
-    </p>
-    <h2 id="demo-props" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
-      Props
-    </h2>
-    <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
-      See the Props table below this demo for the full API, including breadcrumbs, page
-      title, and previous/next page links.
-    </p>
+    <div className="min-h-[260px]">
+      <h2 id="demo-overview" className="text-2xl font-bold mb-4 text-[var(--foreground)]">
+        Overview
+      </h2>
+      <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+        DocumentationLayout provides a sticky header, a collapsible-tree navigation sidebar
+        (a drawer on mobile), and a scroll-spy "On this page" panel - the shape most
+        documentation and reference sites need out of the box. Scroll this preview to see the
+        "On this page" panel on the right track which section you're reading.
+      </p>
+    </div>
+    <div className="min-h-[260px]">
+      <h2 id="demo-installation" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+        Installation
+      </h2>
+      <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+        Add the template to your project, then wrap your page content with it.
+      </p>
+    </div>
+    <div className="min-h-[260px]">
+      <h2 id="demo-usage" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+        Usage
+      </h2>
+      <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+        Pass <code>navSections</code> for the left sidebar and <code>tocHeadings</code> for the
+        right panel - the active heading highlights automatically as you scroll.
+      </p>
+    </div>
+    <div className="min-h-[260px]">
+      <h2 id="demo-props" className="text-2xl font-bold mt-8 mb-4 text-[var(--foreground)]">
+        Props
+      </h2>
+      <p className="text-[var(--muted-foreground)] mb-6 leading-relaxed">
+        See the Props table below this demo for the full API, including breadcrumbs, page
+        title, and previous/next page links.
+      </p>
+    </div>
   </article>
 );
 
 const DocumentationLayoutDemo = () => {
   const [sidebarWidth, setSidebarWidth] = useState<number>(280);
   const [tocWidth, setTocWidth] = useState<number>(240);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const codeString = `
 import { DocumentationLayout } from '@ignix-ui/documentationlayout';
@@ -150,8 +160,9 @@ import { DocumentationLayout } from '@ignix-ui/documentationlayout';
       <Tabs>
         <TabItem value="preview" label="Preview" default>
           <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 560 }}>
-            <div className="h-full overflow-y-auto">
+            <div ref={scrollContainerRef} className="h-full overflow-y-auto">
               <DocumentationLayout
+                scrollContainerRef={scrollContainerRef}
                 header={
                   <Navbar variant="primary" size="md" className="rounded-none px-4 w-full">
                     <div className="flex items-center gap-2">

--- a/apps/docs/src/components/UI/documentation-layout/index.tsx
+++ b/apps/docs/src/components/UI/documentation-layout/index.tsx
@@ -116,14 +116,9 @@ function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: 
 }
 
 /**
- * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
- * so the right-hand "On this page" panel can highlight it. Falls back to `null`
- * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
- *
- * `root` defaults to the browser viewport, matching the common case where this layout
- * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
- * a scrollable container instead, so headings are measured against that container's
- * visible area rather than the (possibly unrelated) viewport.
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`, so the
+ * right-hand "On this page" panel can highlight it. Falls back to `null` in environments
+ * without `IntersectionObserver` (e.g. tests) instead of throwing.
  */
 function useActiveHeading(
   headings?: TocHeading[],
@@ -148,8 +143,6 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
-    // Read `.current` here (not at render time): refs attach during commit, after this
-    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         // `entries` order reflects browser-specific intersection-change batching, not document
@@ -407,7 +400,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
     <div
       className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
     >
-      {/* HEADER */}
       <header
         className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
         role="banner"
@@ -430,7 +422,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       </header>
 
       <div className="mx-auto flex w-full max-w-[1600px] flex-1">
-        {/* LEFT SIDEBAR - desktop */}
         {hasLeftNav && !isMobile && (
           <aside
             className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
@@ -442,7 +433,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </aside>
         )}
 
-        {/* LEFT SIDEBAR - mobile drawer */}
         {hasLeftNav && isMobile && (
           <>
             <AnimatePresence>
@@ -479,7 +469,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </>
         )}
 
-        {/* MAIN CONTENT */}
         <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
           <div className="mx-auto max-w-3xl">
             {breadcrumbs && breadcrumbs.length > 0 && (
@@ -553,7 +542,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </div>
         </main>
 
-        {/* RIGHT SIDEBAR - "On this page" */}
         {hasToc && !isMobile && (
           <aside
             className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
@@ -595,7 +583,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
         )}
       </div>
 
-      {/* FOOTER */}
       {footer && (
         <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
           {footer}

--- a/apps/docs/src/components/UI/documentation-layout/index.tsx
+++ b/apps/docs/src/components/UI/documentation-layout/index.tsx
@@ -1,0 +1,492 @@
+import * as React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ChevronRight, Menu, X, ArrowLeft, ArrowRight, Pencil } from "lucide-react";
+import { cn } from "@site/src/utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A single entry in the left navigation tree. Entries without `href` render
+ * as a non-clickable group label; entries with nested `items` are
+ * collapsible, auto-expanding when one of their descendants is `active`.
+ */
+export interface DocNavItem {
+  label: string;
+  href?: string;
+  active?: boolean;
+  items?: DocNavItem[];
+}
+
+/** A labeled group of {@link DocNavItem} entries in the left sidebar. */
+export interface DocNavSection {
+  label?: string;
+  items: DocNavItem[];
+}
+
+/** A heading tracked by the right-hand "On this page" table of contents. */
+export interface TocHeading {
+  /** Must match the `id` of the corresponding heading element on the page. */
+  id: string;
+  label: string;
+  /** Nesting level, used for indentation. Defaults to `2`. */
+  depth?: 2 | 3;
+}
+
+/** A labeled link, used for breadcrumbs and prev/next page navigation. */
+export interface DocPageLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * Props for the {@link DocumentationLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the header (e.g. a logo/title).
+ * @property searchSlot - Optional node rendered in the header (e.g. a search box).
+ * @property actions - Optional node rendered at the end of the header (e.g. theme toggle, GitHub link).
+ * @property navSections - Left sidebar navigation, grouped into labeled sections.
+ * @property sidebar - Fully custom left sidebar content; overrides `navSections`.
+ * @property tocHeadings - Headings for the right "On this page" panel; the active one is
+ * tracked automatically via scroll position (`IntersectionObserver`).
+ * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
+ * @property title - Optional page title (rendered as the page's `<h1>`).
+ * @property children - Page content.
+ * @property previousPage - Optional "previous page" link rendered below the content.
+ * @property nextPage - Optional "next page" link rendered below the content.
+ * @property editPageUrl - Optional "Edit this page" link rendered below the content.
+ * @property footer - Optional site footer, rendered below everything else.
+ * @property sidebarWidth - Left sidebar width in px. Default `280`.
+ * @property tocWidth - Right "On this page" panel width in px. Default `240`.
+ * @property mobileBreakpoint - Breakpoint below which the left sidebar collapses into a
+ * drawer opened via a hamburger button. Default `"lg"`.
+ * @property className - Class name for the root container.
+ */
+export interface DocumentationLayoutProps {
+  header?: React.ReactNode;
+  searchSlot?: React.ReactNode;
+  actions?: React.ReactNode;
+  navSections?: DocNavSection[];
+  sidebar?: React.ReactNode;
+  tocHeadings?: TocHeading[];
+  toc?: React.ReactNode;
+  breadcrumbs?: DocPageLink[];
+  title?: string;
+  children: React.ReactNode;
+  previousPage?: DocPageLink;
+  nextPage?: DocPageLink;
+  editPageUrl?: string;
+  footer?: React.ReactNode;
+  sidebarWidth?: number;
+  tocWidth?: number;
+  mobileBreakpoint?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              HELPERS & HOOKS                               */
+/* -------------------------------------------------------------------------- */
+
+function itemsContainActive(items: DocNavItem[]): boolean {
+  return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
+}
+
+/** Labels of every group that has an active descendant, so they render pre-expanded. */
+function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
+  for (const item of items) {
+    if (item.items?.length && itemsContainActive(item.items)) {
+      acc.add(item.label);
+      collectExpandedAncestors(item.items, acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
+ * so the right-hand "On this page" panel can highlight it. Falls back to `null`
+ * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ */
+function useActiveHeading(headings?: TocHeading[]): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!headings || headings.length === 0) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return activeId;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              NAV TREE                                      */
+/* -------------------------------------------------------------------------- */
+
+const DocNavTree: React.FC<{
+  items: DocNavItem[];
+  expanded: Set<string>;
+  onToggle: (label: string) => void;
+  onNavigate?: () => void;
+  depth?: number;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
+    {items.map((item) => {
+      const hasChildren = !!item.items?.length;
+      const isExpanded = hasChildren && expanded.has(item.label);
+
+      return (
+        <li key={item.label}>
+          <div className="flex items-center">
+            {item.href ? (
+              <a
+                href={item.href}
+                aria-current={item.active ? "page" : undefined}
+                onClick={onNavigate}
+                className={cn(
+                  "flex-1 block px-3 py-1.5 rounded-md text-sm transition-colors",
+                  item.active
+                    ? "bg-[var(--primary)]/10 text-[var(--primary)] font-medium"
+                    : "text-[var(--foreground)] hover:bg-[var(--accent)]"
+                )}
+              >
+                {item.label}
+              </a>
+            ) : hasChildren ? (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span className="flex-1 px-3 py-1.5 text-sm font-semibold text-[var(--foreground)]">
+                {item.label}
+              </span>
+            )}
+            {hasChildren && (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
+                className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              </button>
+            )}
+          </div>
+          {hasChildren && isExpanded && (
+            <DocNavTree
+              items={item.items!}
+              expanded={expanded}
+              onToggle={onToggle}
+              onNavigate={onNavigate}
+              depth={depth + 1}
+            />
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * DocumentationLayout is a full-page shell for documentation/reference sites:
+ * a sticky header, a collapsible-tree left navigation sidebar (a drawer on
+ * mobile), the page content, and a right-hand "On this page" panel whose
+ * active heading tracks scroll position automatically. Breadcrumbs, a page
+ * title, and prev/next page links are optional and rendered around the
+ * content when provided.
+ */
+export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
+  header,
+  searchSlot,
+  actions,
+  navSections,
+  sidebar,
+  tocHeadings,
+  toc,
+  breadcrumbs,
+  title,
+  children,
+  previousPage,
+  nextPage,
+  editPageUrl,
+  footer,
+  sidebarWidth = 280,
+  tocWidth = 240,
+  mobileBreakpoint = "lg",
+  className,
+}) => {
+  const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
+
+  React.useEffect(() => {
+    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [mobileBp]);
+
+  const [expanded, setExpanded] = React.useState<Set<string>>(() =>
+    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+  );
+
+  const toggleExpanded = React.useCallback((label: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  }, []);
+
+  const activeHeadingId = useActiveHeading(tocHeadings);
+
+  const hasLeftNav = !!(sidebar || navSections);
+  const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  const renderNav = (onNavigate?: () => void): React.ReactNode => {
+    if (sidebar) return sidebar;
+    if (!navSections) return null;
+    return (
+      <nav className="space-y-6 p-4" aria-label="Documentation navigation">
+        {navSections.map((section, index) => (
+          <div key={section.label ?? index}>
+            {section.label && (
+              <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                {section.label}
+              </h2>
+            )}
+            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+          </div>
+        ))}
+      </nav>
+    );
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
+    >
+      {/* HEADER */}
+      <header
+        className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+        role="banner"
+      >
+        {hasLeftNav && isMobile && (
+          <button
+            type="button"
+            onClick={() => setIsMobileNavOpen((open) => !open)}
+            aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
+            aria-expanded={isMobileNavOpen}
+            className="shrink-0 rounded-md p-2 text-[var(--foreground)] hover:bg-[var(--accent)]"
+          >
+            {isMobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        )}
+        {header && <div className="flex shrink-0 items-center">{header}</div>}
+        {searchSlot && <div className="min-w-0 flex-1 md:max-w-sm">{searchSlot}</div>}
+        {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+      </header>
+
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1">
+        {/* LEFT SIDEBAR - desktop */}
+        {hasLeftNav && !isMobile && (
+          <aside
+            className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
+            style={{ width: sidebarWidth }}
+            role="complementary"
+            aria-label="Sidebar navigation"
+          >
+            {renderNav()}
+          </aside>
+        )}
+
+        {/* LEFT SIDEBAR - mobile drawer */}
+        {hasLeftNav && isMobile && (
+          <>
+            <AnimatePresence>
+              {isMobileNavOpen && (
+                <motion.div
+                  className="fixed inset-0 z-40 bg-black/50"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  onClick={() => setIsMobileNavOpen(false)}
+                  aria-hidden="true"
+                />
+              )}
+            </AnimatePresence>
+            <motion.aside
+              className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
+              style={{ width: sidebarWidth }}
+              initial={false}
+              animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
+              transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              role="complementary"
+              aria-label="Mobile sidebar navigation"
+              aria-hidden={!isMobileNavOpen}
+            >
+              {renderNav(() => setIsMobileNavOpen(false))}
+            </motion.aside>
+          </>
+        )}
+
+        {/* MAIN CONTENT */}
+        <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
+          <div className="mx-auto max-w-3xl">
+            {breadcrumbs && breadcrumbs.length > 0 && (
+              <nav aria-label="Breadcrumb" className="mb-4">
+                <ol className="flex flex-wrap items-center gap-1.5 text-sm text-[var(--muted-foreground)]">
+                  {breadcrumbs.map((crumb, index) => (
+                    <li key={`${crumb.label}-${index}`} className="flex items-center gap-1.5">
+                      {index > 0 && <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
+                      {index === breadcrumbs.length - 1 ? (
+                        <span aria-current="page" className="text-[var(--foreground)]">
+                          {crumb.label}
+                        </span>
+                      ) : (
+                        <a href={crumb.href} className="hover:text-[var(--foreground)]">
+                          {crumb.label}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            {title && <h1 className="mb-6 text-3xl font-bold tracking-tight text-[var(--foreground)]">{title}</h1>}
+
+            {children}
+
+            {(previousPage || nextPage || editPageUrl) && (
+              <div className="mt-12 border-t border-[var(--border)] pt-6">
+                {editPageUrl && (
+                  <a
+                    href={editPageUrl}
+                    className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                  >
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    Edit this page
+                  </a>
+                )}
+                {(previousPage || nextPage) && (
+                  <nav aria-label="Page navigation" className="flex items-stretch gap-4">
+                    {previousPage ? (
+                      <a
+                        href={previousPage.href}
+                        className="flex flex-1 flex-col items-start gap-1 rounded-lg border border-[var(--border)] p-4 text-left transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                          Previous
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{previousPage.label}</span>
+                      </a>
+                    ) : (
+                      <span className="flex-1" />
+                    )}
+                    {nextPage && (
+                      <a
+                        href={nextPage.href}
+                        className="flex flex-1 flex-col items-end gap-1 rounded-lg border border-[var(--border)] p-4 text-right transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          Next
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{nextPage.label}</span>
+                      </a>
+                    )}
+                  </nav>
+                )}
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* RIGHT SIDEBAR - "On this page" */}
+        {hasToc && !isMobile && (
+          <aside
+            className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
+            style={{ width: tocWidth }}
+            role="complementary"
+            aria-label="Table of contents"
+          >
+            {toc ? (
+              toc
+            ) : tocHeadings ? (
+              <>
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                  On this page
+                </h2>
+                <ul className="space-y-1.5 border-l border-[var(--border)]">
+                  {tocHeadings.map((heading) => {
+                    const isActive = heading.id === activeHeadingId;
+                    return (
+                      <li key={heading.id} style={{ paddingLeft: heading.depth === 3 ? 24 : 12 }}>
+                        <a
+                          href={`#${heading.id}`}
+                          aria-current={isActive ? "location" : undefined}
+                          className={cn(
+                            "-ml-px block border-l-2 pl-3 text-sm transition-colors",
+                            isActive
+                              ? "border-[var(--primary)] font-medium text-[var(--primary)]"
+                              : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                          )}
+                        >
+                          {heading.label}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : null}
+          </aside>
+        )}
+      </div>
+
+      {/* FOOTER */}
+      {footer && (
+        <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
+          {footer}
+        </footer>
+      )}
+    </div>
+  );
+};
+
+DocumentationLayout.displayName = "DocumentationLayout";
+
+export default DocumentationLayout;

--- a/apps/docs/src/components/UI/documentation-layout/index.tsx
+++ b/apps/docs/src/components/UI/documentation-layout/index.tsx
@@ -143,14 +143,20 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Persists across callback invocations rather than being rebuilt from just this batch's
+    // `entries` - IntersectionObserver only reports entries whose intersection state just
+    // changed, so a heading that's still visible without changing wouldn't appear in `entries`
+    // at all, and a fresh-each-time set would incorrectly drop it.
+    const visibleIds = new Set<string>();
     const observer = new IntersectionObserver(
       (entries) => {
-        // `entries` order reflects browser-specific intersection-change batching, not document
-        // order, so when multiple headings cross the threshold in the same batch, pick whichever
-        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
-        const visibleIds = new Set(
-          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
-        );
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        });
+        // `currentHeadings` order (not `entries` order, which reflects browser-specific
+        // intersection-change batching) decides which visible heading wins when more than one
+        // is visible at once.
         const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
         if (firstVisible) {
           setActiveId(firstVisible.id);
@@ -330,6 +336,21 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       mobileDrawerRef.current.inert = !isMobileNavOpen;
     }
   }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Resets eagerly at the start of every open/close transition, not just via
+  // onAnimationComplete below - otherwise closing before the open transition has finished
+  // (isDrawerFullyClosed still `true` from before) would drop visibility to "hidden"
+  // immediately, clipping the close animation instead of letting it slide out. useLayoutEffect
+  // (not useEffect) so this resolves before the browser paints that intermediate state. Skips
+  // the initial mount so the drawer still starts genuinely hidden before it's ever been opened.
+  const hasMountedDrawerRef = React.useRef(false);
+  React.useLayoutEffect(() => {
+    if (!hasMountedDrawerRef.current) {
+      hasMountedDrawerRef.current = true;
+      return;
+    }
+    setIsDrawerFullyClosed(false);
+  }, [isMobileNavOpen]);
 
   // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
   // focus to the hamburger trigger on close. Skips the very first run so mounting with the

--- a/apps/docs/src/components/UI/documentation-layout/index.tsx
+++ b/apps/docs/src/components/UI/documentation-layout/index.tsx
@@ -152,9 +152,15 @@ function useActiveHeading(
     // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length > 0) {
-          setActiveId(visible[0].target.id);
+        // `entries` order reflects browser-specific intersection-change batching, not document
+        // order, so when multiple headings cross the threshold in the same batch, pick whichever
+        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
+        const visibleIds = new Set(
+          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
+        );
+        const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
+        if (firstVisible) {
+          setActiveId(firstVisible.id);
         }
       },
       { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
@@ -287,9 +293,12 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
-  const [isMobile, setIsMobile] = React.useState(() =>
-    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
-  );
+  // Starts `false` unconditionally (not derived from `window.innerWidth`) so server and client
+  // render the same markup on first paint; the mount effect below corrects it via `matchMedia`
+  // right after hydration. Deriving this from `window` would only match on truly client-only
+  // renders - during SSR hydration the client's own first pass already sees `window`, so the
+  // guard doesn't help there and the two renders could still disagree.
+  const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;

--- a/apps/docs/src/components/UI/documentation-layout/index.tsx
+++ b/apps/docs/src/components/UI/documentation-layout/index.tsx
@@ -51,6 +51,10 @@ export interface DocPageLink {
  * @property tocHeadings - Headings for the right "On this page" panel; the active one is
  * tracked automatically via scroll position (`IntersectionObserver`).
  * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property scrollContainerRef - Ref to the scrollable ancestor that actually scrolls the
+ * page content, used as the `IntersectionObserver` root for the scroll-spy. Only needed when
+ * this layout is rendered inside a scrollable container instead of the document itself (e.g.
+ * an embedded preview); omit it when the layout owns page-level scroll.
  * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
  * @property title - Optional page title (rendered as the page's `<h1>`).
  * @property children - Page content.
@@ -72,6 +76,7 @@ export interface DocumentationLayoutProps {
   sidebar?: React.ReactNode;
   tocHeadings?: TocHeading[];
   toc?: React.ReactNode;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
   breadcrumbs?: DocPageLink[];
   title?: string;
   children: React.ReactNode;
@@ -93,14 +98,20 @@ function itemsContainActive(items: DocNavItem[]): boolean {
   return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
 }
 
-/** Labels of every group that has an active descendant, so they render pre-expanded. */
-function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
-  for (const item of items) {
+/**
+ * Tree-position paths (not labels) of every group that has an active descendant, so they
+ * render pre-expanded. Paths (e.g. "s0-1-0") are used instead of labels throughout the nav
+ * tree's expand/collapse state so that two groups sharing the same label in different
+ * branches - a common case with a generic name like "Overview" - expand independently.
+ */
+function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: Set<string> = new Set()): Set<string> {
+  items.forEach((item, index) => {
+    const path = `${parentPath}-${index}`;
     if (item.items?.length && itemsContainActive(item.items)) {
-      acc.add(item.label);
-      collectExpandedAncestors(item.items, acc);
+      acc.add(path);
+      collectExpandedAncestors(item.items, path, acc);
     }
-  }
+  });
   return acc;
 }
 
@@ -108,19 +119,37 @@ function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Se
  * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
  * so the right-hand "On this page" panel can highlight it. Falls back to `null`
  * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ *
+ * `root` defaults to the browser viewport, matching the common case where this layout
+ * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
+ * a scrollable container instead, so headings are measured against that container's
+ * visible area rather than the (possibly unrelated) viewport.
  */
-function useActiveHeading(headings?: TocHeading[]): string | null {
+function useActiveHeading(
+  headings?: TocHeading[],
+  scrollContainerRef?: React.RefObject<HTMLElement | null>
+): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
+  // Consumers commonly pass an inline array literal (see the Usage docs), which gets a new
+  // identity every render. Keying the effect on a derived id string - instead of the array
+  // reference - avoids tearing down and recreating the observer on every unrelated re-render.
+  const headingsRef = React.useRef(headings);
+  headingsRef.current = headings;
+  const headingIds = headings?.map((heading) => heading.id).join(",") ?? "";
+
   React.useEffect(() => {
-    if (!headings || headings.length === 0) return;
+    const currentHeadings = headingsRef.current;
+    if (!currentHeadings || currentHeadings.length === 0) return;
     if (typeof IntersectionObserver === "undefined") return;
 
-    const elements = headings
+    const elements = currentHeadings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Read `.current` here (not at render time): refs attach during commit, after this
+    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries.filter((entry) => entry.isIntersecting);
@@ -128,12 +157,12 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
           setActiveId(visible[0].target.id);
         }
       },
-      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+      { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
     );
 
     elements.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [headings]);
+  }, [headingIds, scrollContainerRef]);
 
   return activeId;
 }
@@ -145,17 +174,19 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
 const DocNavTree: React.FC<{
   items: DocNavItem[];
   expanded: Set<string>;
-  onToggle: (label: string) => void;
+  onToggle: (path: string) => void;
   onNavigate?: () => void;
   depth?: number;
-}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  parentPath: string;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0, parentPath }) => (
   <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
-    {items.map((item) => {
+    {items.map((item, index) => {
+      const path = `${parentPath}-${index}`;
       const hasChildren = !!item.items?.length;
-      const isExpanded = hasChildren && expanded.has(item.label);
+      const isExpanded = hasChildren && expanded.has(path);
 
       return (
-        <li key={item.label}>
+        <li key={path}>
           <div className="flex items-center">
             {item.href ? (
               <a
@@ -174,7 +205,7 @@ const DocNavTree: React.FC<{
             ) : hasChildren ? (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
               >
@@ -188,7 +219,7 @@ const DocNavTree: React.FC<{
             {hasChildren && (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
                 className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
@@ -204,6 +235,7 @@ const DocNavTree: React.FC<{
               onToggle={onToggle}
               onNavigate={onNavigate}
               depth={depth + 1}
+              parentPath={path}
             />
           )}
         </li>
@@ -232,6 +264,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   sidebar,
   tocHeadings,
   toc,
+  scrollContainerRef,
   breadcrumbs,
   title,
   children,
@@ -245,34 +278,96 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   className,
 }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(false);
+  // Tracks whether the close slide-out has actually finished (via onAnimationComplete below),
+  // so `visibility: hidden` only applies once it's done - not the instant `isMobileNavOpen`
+  // flips false, which would clip the exit animation instead of letting it play out.
+  const [isDrawerFullyClosed, setIsDrawerFullyClosed] = React.useState(true);
+  const mobileDrawerRef = React.useRef<HTMLElement>(null);
+  const mobileNavTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
+  const [isMobile, setIsMobile] = React.useState(() =>
+    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
+  );
+
   React.useEffect(() => {
-    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(`(max-width: ${mobileBp - 1}px)`);
+    setIsMobile(mediaQuery.matches);
+    const handleChange = (event: MediaQueryListEvent): void => setIsMobile(event.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [mobileBp]);
 
   const [expanded, setExpanded] = React.useState<Set<string>>(() =>
-    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+    navSections
+      ? navSections.reduce((acc, section, index) => collectExpandedAncestors(section.items, `s${index}`, acc), new Set<string>())
+      : new Set()
   );
 
-  const toggleExpanded = React.useCallback((label: string) => {
+  const toggleExpanded = React.useCallback((path: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(label)) next.delete(label);
-      else next.add(label);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
       return next;
     });
   }, []);
 
-  const activeHeadingId = useActiveHeading(tocHeadings);
+  const activeHeadingId = useActiveHeading(tocHeadings, scrollContainerRef);
 
   const hasLeftNav = !!(sidebar || navSections);
   const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  // `aria-hidden` alone doesn't stop the closed drawer's links from being keyboard-focusable.
+  // `inert` (not yet in framer-motion's HTMLMotionProps types) is set imperatively via the DOM
+  // property instead, so focus/tab order and clicks are actually blocked while it's off-screen.
+  React.useEffect(() => {
+    if (mobileDrawerRef.current) {
+      mobileDrawerRef.current.inert = !isMobileNavOpen;
+    }
+  }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
+  // focus to the hamburger trigger on close. Skips the very first run so mounting with the
+  // drawer already closed doesn't yank focus onto the (not-yet-clicked) trigger button.
+  const hasOpenedDrawerRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasOpenedDrawerRef.current) {
+      hasOpenedDrawerRef.current = true;
+      return;
+    }
+    if (isMobileNavOpen) {
+      mobileDrawerRef.current?.focus();
+    } else {
+      mobileNavTriggerRef.current?.focus();
+    }
+  }, [isMobileNavOpen]);
+
+  const handleDrawerKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    if (event.key === "Escape") {
+      setIsMobileNavOpen(false);
+      return;
+    }
+    if (event.key !== "Tab" || !mobileDrawerRef.current) return;
+
+    // Trap focus within the open drawer: wrap Tab/Shift+Tab at its edges instead of
+    // letting focus escape into the (inert-but-visually-hidden) rest of the page.
+    const focusable = mobileDrawerRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const renderNav = (onNavigate?: () => void): React.ReactNode => {
     if (sidebar) return sidebar;
@@ -286,7 +381,13 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
                 {section.label}
               </h2>
             )}
-            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+            <DocNavTree
+              items={section.items}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onNavigate={onNavigate}
+              parentPath={`s${index}`}
+            />
           </div>
         ))}
       </nav>
@@ -304,6 +405,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       >
         {hasLeftNav && isMobile && (
           <button
+            ref={mobileNavTriggerRef}
             type="button"
             onClick={() => setIsMobileNavOpen((open) => !open)}
             aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
@@ -347,11 +449,18 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
               )}
             </AnimatePresence>
             <motion.aside
+              ref={mobileDrawerRef}
+              tabIndex={-1}
+              onKeyDown={handleDrawerKeyDown}
               className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
-              style={{ width: sidebarWidth }}
+              style={{
+                width: sidebarWidth,
+                visibility: isMobileNavOpen || !isDrawerFullyClosed ? "visible" : "hidden",
+              }}
               initial={false}
               animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
               transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              onAnimationComplete={() => setIsDrawerFullyClosed(!isMobileNavOpen)}
               role="complementary"
               aria-label="Mobile sidebar navigation"
               aria-hidden={!isMobileNavOpen}

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
@@ -21,11 +21,14 @@ The **Documentation Layout** template provides the shell most documentation and 
     ```
   </TabItem>
   <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
+
+  `cn` is a small `clsx` + `tailwind-merge` helper (installed automatically by the CLI, at `src/utils/cn.ts`). Placing this file at `src/templates/DocumentationLayout/index.tsx` resolves the import below as-is; adjust the relative path if you place it elsewhere.
+
   ```tsx
 import * as React from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, ChevronRight, Menu, X, ArrowLeft, ArrowRight, Pencil } from "lucide-react";
-import { cn } from "../../../utils/cn";
+import { cn } from "../../utils/cn";
 
 /* -------------------------------------------------------------------------- */
 /*                              TYPES & INTERFACES                            */
@@ -75,6 +78,10 @@ export interface DocPageLink {
  * @property tocHeadings - Headings for the right "On this page" panel; the active one is
  * tracked automatically via scroll position (`IntersectionObserver`).
  * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property scrollContainerRef - Ref to the scrollable ancestor that actually scrolls the
+ * page content, used as the `IntersectionObserver` root for the scroll-spy. Only needed when
+ * this layout is rendered inside a scrollable container instead of the document itself (e.g.
+ * an embedded preview); omit it when the layout owns page-level scroll.
  * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
  * @property title - Optional page title (rendered as the page's `<h1>`).
  * @property children - Page content.
@@ -96,6 +103,7 @@ export interface DocumentationLayoutProps {
   sidebar?: React.ReactNode;
   tocHeadings?: TocHeading[];
   toc?: React.ReactNode;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
   breadcrumbs?: DocPageLink[];
   title?: string;
   children: React.ReactNode;
@@ -117,14 +125,20 @@ function itemsContainActive(items: DocNavItem[]): boolean {
   return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
 }
 
-/** Labels of every group that has an active descendant, so they render pre-expanded. */
-function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
-  for (const item of items) {
+/**
+ * Tree-position paths (not labels) of every group that has an active descendant, so they
+ * render pre-expanded. Paths (e.g. "s0-1-0") are used instead of labels throughout the nav
+ * tree's expand/collapse state so that two groups sharing the same label in different
+ * branches - a common case with a generic name like "Overview" - expand independently.
+ */
+function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: Set<string> = new Set()): Set<string> {
+  items.forEach((item, index) => {
+    const path = `${parentPath}-${index}`;
     if (item.items?.length && itemsContainActive(item.items)) {
-      acc.add(item.label);
-      collectExpandedAncestors(item.items, acc);
+      acc.add(path);
+      collectExpandedAncestors(item.items, path, acc);
     }
-  }
+  });
   return acc;
 }
 
@@ -132,19 +146,37 @@ function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Se
  * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
  * so the right-hand "On this page" panel can highlight it. Falls back to `null`
  * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ *
+ * `root` defaults to the browser viewport, matching the common case where this layout
+ * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
+ * a scrollable container instead, so headings are measured against that container's
+ * visible area rather than the (possibly unrelated) viewport.
  */
-function useActiveHeading(headings?: TocHeading[]): string | null {
+function useActiveHeading(
+  headings?: TocHeading[],
+  scrollContainerRef?: React.RefObject<HTMLElement | null>
+): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
+  // Consumers commonly pass an inline array literal (see the Usage docs), which gets a new
+  // identity every render. Keying the effect on a derived id string - instead of the array
+  // reference - avoids tearing down and recreating the observer on every unrelated re-render.
+  const headingsRef = React.useRef(headings);
+  headingsRef.current = headings;
+  const headingIds = headings?.map((heading) => heading.id).join(",") ?? "";
+
   React.useEffect(() => {
-    if (!headings || headings.length === 0) return;
+    const currentHeadings = headingsRef.current;
+    if (!currentHeadings || currentHeadings.length === 0) return;
     if (typeof IntersectionObserver === "undefined") return;
 
-    const elements = headings
+    const elements = currentHeadings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Read `.current` here (not at render time): refs attach during commit, after this
+    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries.filter((entry) => entry.isIntersecting);
@@ -152,12 +184,12 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
           setActiveId(visible[0].target.id);
         }
       },
-      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+      { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
     );
 
     elements.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [headings]);
+  }, [headingIds, scrollContainerRef]);
 
   return activeId;
 }
@@ -169,17 +201,19 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
 const DocNavTree: React.FC<{
   items: DocNavItem[];
   expanded: Set<string>;
-  onToggle: (label: string) => void;
+  onToggle: (path: string) => void;
   onNavigate?: () => void;
   depth?: number;
-}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  parentPath: string;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0, parentPath }) => (
   <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
-    {items.map((item) => {
+    {items.map((item, index) => {
+      const path = `${parentPath}-${index}`;
       const hasChildren = !!item.items?.length;
-      const isExpanded = hasChildren && expanded.has(item.label);
+      const isExpanded = hasChildren && expanded.has(path);
 
       return (
-        <li key={item.label}>
+        <li key={path}>
           <div className="flex items-center">
             {item.href ? (
               <a
@@ -198,7 +232,7 @@ const DocNavTree: React.FC<{
             ) : hasChildren ? (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
               >
@@ -212,7 +246,7 @@ const DocNavTree: React.FC<{
             {hasChildren && (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
                 className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
@@ -228,6 +262,7 @@ const DocNavTree: React.FC<{
               onToggle={onToggle}
               onNavigate={onNavigate}
               depth={depth + 1}
+              parentPath={path}
             />
           )}
         </li>
@@ -256,6 +291,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   sidebar,
   tocHeadings,
   toc,
+  scrollContainerRef,
   breadcrumbs,
   title,
   children,
@@ -269,34 +305,96 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   className,
 }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(false);
+  // Tracks whether the close slide-out has actually finished (via onAnimationComplete below),
+  // so `visibility: hidden` only applies once it's done - not the instant `isMobileNavOpen`
+  // flips false, which would clip the exit animation instead of letting it play out.
+  const [isDrawerFullyClosed, setIsDrawerFullyClosed] = React.useState(true);
+  const mobileDrawerRef = React.useRef<HTMLElement>(null);
+  const mobileNavTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
+  const [isMobile, setIsMobile] = React.useState(() =>
+    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
+  );
+
   React.useEffect(() => {
-    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(`(max-width: ${mobileBp - 1}px)`);
+    setIsMobile(mediaQuery.matches);
+    const handleChange = (event: MediaQueryListEvent): void => setIsMobile(event.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [mobileBp]);
 
   const [expanded, setExpanded] = React.useState<Set<string>>(() =>
-    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+    navSections
+      ? navSections.reduce((acc, section, index) => collectExpandedAncestors(section.items, `s${index}`, acc), new Set<string>())
+      : new Set()
   );
 
-  const toggleExpanded = React.useCallback((label: string) => {
+  const toggleExpanded = React.useCallback((path: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(label)) next.delete(label);
-      else next.add(label);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
       return next;
     });
   }, []);
 
-  const activeHeadingId = useActiveHeading(tocHeadings);
+  const activeHeadingId = useActiveHeading(tocHeadings, scrollContainerRef);
 
   const hasLeftNav = !!(sidebar || navSections);
   const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  // `aria-hidden` alone doesn't stop the closed drawer's links from being keyboard-focusable.
+  // `inert` (not yet in framer-motion's HTMLMotionProps types) is set imperatively via the DOM
+  // property instead, so focus/tab order and clicks are actually blocked while it's off-screen.
+  React.useEffect(() => {
+    if (mobileDrawerRef.current) {
+      mobileDrawerRef.current.inert = !isMobileNavOpen;
+    }
+  }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
+  // focus to the hamburger trigger on close. Skips the very first run so mounting with the
+  // drawer already closed doesn't yank focus onto the (not-yet-clicked) trigger button.
+  const hasOpenedDrawerRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasOpenedDrawerRef.current) {
+      hasOpenedDrawerRef.current = true;
+      return;
+    }
+    if (isMobileNavOpen) {
+      mobileDrawerRef.current?.focus();
+    } else {
+      mobileNavTriggerRef.current?.focus();
+    }
+  }, [isMobileNavOpen]);
+
+  const handleDrawerKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    if (event.key === "Escape") {
+      setIsMobileNavOpen(false);
+      return;
+    }
+    if (event.key !== "Tab" || !mobileDrawerRef.current) return;
+
+    // Trap focus within the open drawer: wrap Tab/Shift+Tab at its edges instead of
+    // letting focus escape into the (inert-but-visually-hidden) rest of the page.
+    const focusable = mobileDrawerRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const renderNav = (onNavigate?: () => void): React.ReactNode => {
     if (sidebar) return sidebar;
@@ -310,7 +408,13 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
                 {section.label}
               </h2>
             )}
-            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+            <DocNavTree
+              items={section.items}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onNavigate={onNavigate}
+              parentPath={`s${index}`}
+            />
           </div>
         ))}
       </nav>
@@ -328,6 +432,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       >
         {hasLeftNav && isMobile && (
           <button
+            ref={mobileNavTriggerRef}
             type="button"
             onClick={() => setIsMobileNavOpen((open) => !open)}
             aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
@@ -371,11 +476,18 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
               )}
             </AnimatePresence>
             <motion.aside
+              ref={mobileDrawerRef}
+              tabIndex={-1}
+              onKeyDown={handleDrawerKeyDown}
               className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
-              style={{ width: sidebarWidth }}
+              style={{
+                width: sidebarWidth,
+                visibility: isMobileNavOpen || !isDrawerFullyClosed ? "visible" : "hidden",
+              }}
               initial={false}
               animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
               transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              onAnimationComplete={() => setIsDrawerFullyClosed(!isMobileNavOpen)}
               role="complementary"
               aria-label="Mobile sidebar navigation"
               aria-hidden={!isMobileNavOpen}
@@ -599,6 +711,7 @@ function App() {
 | `sidebar` | `React.ReactNode` | `undefined` | Fully custom left sidebar content; overrides `navSections` |
 | `tocHeadings` | `TocHeading[]` | `undefined` | Headings for the right "On this page" panel; the active one is tracked automatically via scroll position |
 | `toc` | `React.ReactNode` | `undefined` | Fully custom right sidebar content; overrides `tocHeadings` |
+| `scrollContainerRef` | `React.RefObject<HTMLElement \| null>` | `undefined` | Ref to the scrollable ancestor used as the scroll-spy's `IntersectionObserver` root. Only needed when this layout is embedded inside a scrollable container instead of the document itself |
 | `breadcrumbs` | `DocPageLink[]` | `undefined` | Optional breadcrumb trail rendered above the title |
 | `title` | `string` | `undefined` | Optional page title (rendered as the page's `<h1>`) |
 | `children` | `React.ReactNode` | — | Page content |

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
@@ -143,14 +143,9 @@ function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: 
 }
 
 /**
- * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
- * so the right-hand "On this page" panel can highlight it. Falls back to `null`
- * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
- *
- * `root` defaults to the browser viewport, matching the common case where this layout
- * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
- * a scrollable container instead, so headings are measured against that container's
- * visible area rather than the (possibly unrelated) viewport.
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`, so the
+ * right-hand "On this page" panel can highlight it. Falls back to `null` in environments
+ * without `IntersectionObserver` (e.g. tests) instead of throwing.
  */
 function useActiveHeading(
   headings?: TocHeading[],
@@ -175,8 +170,6 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
-    // Read `.current` here (not at render time): refs attach during commit, after this
-    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         // `entries` order reflects browser-specific intersection-change batching, not document
@@ -434,7 +427,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
     <div
       className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
     >
-      {/* HEADER */}
       <header
         className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
         role="banner"
@@ -457,7 +449,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       </header>
 
       <div className="mx-auto flex w-full max-w-[1600px] flex-1">
-        {/* LEFT SIDEBAR - desktop */}
         {hasLeftNav && !isMobile && (
           <aside
             className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
@@ -469,7 +460,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </aside>
         )}
 
-        {/* LEFT SIDEBAR - mobile drawer */}
         {hasLeftNav && isMobile && (
           <>
             <AnimatePresence>
@@ -506,7 +496,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </>
         )}
 
-        {/* MAIN CONTENT */}
         <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
           <div className="mx-auto max-w-3xl">
             {breadcrumbs && breadcrumbs.length > 0 && (
@@ -580,7 +569,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </div>
         </main>
 
-        {/* RIGHT SIDEBAR - "On this page" */}
         {hasToc && !isMobile && (
           <aside
             className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
@@ -622,7 +610,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
         )}
       </div>
 
-      {/* FOOTER */}
       {footer && (
         <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
           {footer}

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
@@ -179,9 +179,15 @@ function useActiveHeading(
     // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length > 0) {
-          setActiveId(visible[0].target.id);
+        // `entries` order reflects browser-specific intersection-change batching, not document
+        // order, so when multiple headings cross the threshold in the same batch, pick whichever
+        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
+        const visibleIds = new Set(
+          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
+        );
+        const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
+        if (firstVisible) {
+          setActiveId(firstVisible.id);
         }
       },
       { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
@@ -314,9 +320,12 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
-  const [isMobile, setIsMobile] = React.useState(() =>
-    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
-  );
+  // Starts `false` unconditionally (not derived from `window.innerWidth`) so server and client
+  // render the same markup on first paint; the mount effect below corrects it via `matchMedia`
+  // right after hydration. Deriving this from `window` would only match on truly client-only
+  // renders - during SSR hydration the client's own first pass already sees `window`, so the
+  // guard doesn't help there and the two renders could still disagree.
+  const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
@@ -1,0 +1,643 @@
+---
+sidebar_position: 8
+title: DocumentationLayout
+description: A full-page documentation/reference site shell with a sticky header, a collapsible-tree navigation sidebar, breadcrumbs, prev/next page links, and a scroll-spy table of contents.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import DocumentationLayoutDemo from '@site/src/components/Demo/DocumentationLayoutDemo';
+
+The **Documentation Layout** template provides the shell most documentation and reference sites need out of the box: a sticky header with optional search and actions, a collapsible-tree left navigation sidebar that collapses into a drawer on mobile, page content with breadcrumbs and a title, previous/next page navigation, and a scroll-spy "On this page" panel that highlights the active heading as you scroll.
+
+<DocumentationLayoutDemo/>
+
+## Installation
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+    ```bash
+    ignix add component DocumentationLayout
+    ```
+  </TabItem>
+  <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
+  ```tsx
+import * as React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ChevronRight, Menu, X, ArrowLeft, ArrowRight, Pencil } from "lucide-react";
+import { cn } from "../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A single entry in the left navigation tree. Entries without `href` render
+ * as a non-clickable group label; entries with nested `items` are
+ * collapsible, auto-expanding when one of their descendants is `active`.
+ */
+export interface DocNavItem {
+  label: string;
+  href?: string;
+  active?: boolean;
+  items?: DocNavItem[];
+}
+
+/** A labeled group of {@link DocNavItem} entries in the left sidebar. */
+export interface DocNavSection {
+  label?: string;
+  items: DocNavItem[];
+}
+
+/** A heading tracked by the right-hand "On this page" table of contents. */
+export interface TocHeading {
+  /** Must match the `id` of the corresponding heading element on the page. */
+  id: string;
+  label: string;
+  /** Nesting level, used for indentation. Defaults to `2`. */
+  depth?: 2 | 3;
+}
+
+/** A labeled link, used for breadcrumbs and prev/next page navigation. */
+export interface DocPageLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * Props for the {@link DocumentationLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the header (e.g. a logo/title).
+ * @property searchSlot - Optional node rendered in the header (e.g. a search box).
+ * @property actions - Optional node rendered at the end of the header (e.g. theme toggle, GitHub link).
+ * @property navSections - Left sidebar navigation, grouped into labeled sections.
+ * @property sidebar - Fully custom left sidebar content; overrides `navSections`.
+ * @property tocHeadings - Headings for the right "On this page" panel; the active one is
+ * tracked automatically via scroll position (`IntersectionObserver`).
+ * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
+ * @property title - Optional page title (rendered as the page's `<h1>`).
+ * @property children - Page content.
+ * @property previousPage - Optional "previous page" link rendered below the content.
+ * @property nextPage - Optional "next page" link rendered below the content.
+ * @property editPageUrl - Optional "Edit this page" link rendered below the content.
+ * @property footer - Optional site footer, rendered below everything else.
+ * @property sidebarWidth - Left sidebar width in px. Default `280`.
+ * @property tocWidth - Right "On this page" panel width in px. Default `240`.
+ * @property mobileBreakpoint - Breakpoint below which the left sidebar collapses into a
+ * drawer opened via a hamburger button. Default `"lg"`.
+ * @property className - Class name for the root container.
+ */
+export interface DocumentationLayoutProps {
+  header?: React.ReactNode;
+  searchSlot?: React.ReactNode;
+  actions?: React.ReactNode;
+  navSections?: DocNavSection[];
+  sidebar?: React.ReactNode;
+  tocHeadings?: TocHeading[];
+  toc?: React.ReactNode;
+  breadcrumbs?: DocPageLink[];
+  title?: string;
+  children: React.ReactNode;
+  previousPage?: DocPageLink;
+  nextPage?: DocPageLink;
+  editPageUrl?: string;
+  footer?: React.ReactNode;
+  sidebarWidth?: number;
+  tocWidth?: number;
+  mobileBreakpoint?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              HELPERS & HOOKS                               */
+/* -------------------------------------------------------------------------- */
+
+function itemsContainActive(items: DocNavItem[]): boolean {
+  return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
+}
+
+/** Labels of every group that has an active descendant, so they render pre-expanded. */
+function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
+  for (const item of items) {
+    if (item.items?.length && itemsContainActive(item.items)) {
+      acc.add(item.label);
+      collectExpandedAncestors(item.items, acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
+ * so the right-hand "On this page" panel can highlight it. Falls back to `null`
+ * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ */
+function useActiveHeading(headings?: TocHeading[]): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!headings || headings.length === 0) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return activeId;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              NAV TREE                                      */
+/* -------------------------------------------------------------------------- */
+
+const DocNavTree: React.FC<{
+  items: DocNavItem[];
+  expanded: Set<string>;
+  onToggle: (label: string) => void;
+  onNavigate?: () => void;
+  depth?: number;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
+    {items.map((item) => {
+      const hasChildren = !!item.items?.length;
+      const isExpanded = hasChildren && expanded.has(item.label);
+
+      return (
+        <li key={item.label}>
+          <div className="flex items-center">
+            {item.href ? (
+              <a
+                href={item.href}
+                aria-current={item.active ? "page" : undefined}
+                onClick={onNavigate}
+                className={cn(
+                  "flex-1 block px-3 py-1.5 rounded-md text-sm transition-colors",
+                  item.active
+                    ? "bg-[var(--primary)]/10 text-[var(--primary)] font-medium"
+                    : "text-[var(--foreground)] hover:bg-[var(--accent)]"
+                )}
+              >
+                {item.label}
+              </a>
+            ) : hasChildren ? (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span className="flex-1 px-3 py-1.5 text-sm font-semibold text-[var(--foreground)]">
+                {item.label}
+              </span>
+            )}
+            {hasChildren && (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
+                className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              </button>
+            )}
+          </div>
+          {hasChildren && isExpanded && (
+            <DocNavTree
+              items={item.items!}
+              expanded={expanded}
+              onToggle={onToggle}
+              onNavigate={onNavigate}
+              depth={depth + 1}
+            />
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * DocumentationLayout is a full-page shell for documentation/reference sites:
+ * a sticky header, a collapsible-tree left navigation sidebar (a drawer on
+ * mobile), the page content, and a right-hand "On this page" panel whose
+ * active heading tracks scroll position automatically. Breadcrumbs, a page
+ * title, and prev/next page links are optional and rendered around the
+ * content when provided.
+ */
+export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
+  header,
+  searchSlot,
+  actions,
+  navSections,
+  sidebar,
+  tocHeadings,
+  toc,
+  breadcrumbs,
+  title,
+  children,
+  previousPage,
+  nextPage,
+  editPageUrl,
+  footer,
+  sidebarWidth = 280,
+  tocWidth = 240,
+  mobileBreakpoint = "lg",
+  className,
+}) => {
+  const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
+
+  React.useEffect(() => {
+    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [mobileBp]);
+
+  const [expanded, setExpanded] = React.useState<Set<string>>(() =>
+    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+  );
+
+  const toggleExpanded = React.useCallback((label: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  }, []);
+
+  const activeHeadingId = useActiveHeading(tocHeadings);
+
+  const hasLeftNav = !!(sidebar || navSections);
+  const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  const renderNav = (onNavigate?: () => void): React.ReactNode => {
+    if (sidebar) return sidebar;
+    if (!navSections) return null;
+    return (
+      <nav className="space-y-6 p-4" aria-label="Documentation navigation">
+        {navSections.map((section, index) => (
+          <div key={section.label ?? index}>
+            {section.label && (
+              <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                {section.label}
+              </h2>
+            )}
+            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+          </div>
+        ))}
+      </nav>
+    );
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
+    >
+      {/* HEADER */}
+      <header
+        className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+        role="banner"
+      >
+        {hasLeftNav && isMobile && (
+          <button
+            type="button"
+            onClick={() => setIsMobileNavOpen((open) => !open)}
+            aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
+            aria-expanded={isMobileNavOpen}
+            className="shrink-0 rounded-md p-2 text-[var(--foreground)] hover:bg-[var(--accent)]"
+          >
+            {isMobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        )}
+        {header && <div className="flex shrink-0 items-center">{header}</div>}
+        {searchSlot && <div className="min-w-0 flex-1 md:max-w-sm">{searchSlot}</div>}
+        {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+      </header>
+
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1">
+        {/* LEFT SIDEBAR - desktop */}
+        {hasLeftNav && !isMobile && (
+          <aside
+            className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
+            style={{ width: sidebarWidth }}
+            role="complementary"
+            aria-label="Sidebar navigation"
+          >
+            {renderNav()}
+          </aside>
+        )}
+
+        {/* LEFT SIDEBAR - mobile drawer */}
+        {hasLeftNav && isMobile && (
+          <>
+            <AnimatePresence>
+              {isMobileNavOpen && (
+                <motion.div
+                  className="fixed inset-0 z-40 bg-black/50"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  onClick={() => setIsMobileNavOpen(false)}
+                  aria-hidden="true"
+                />
+              )}
+            </AnimatePresence>
+            <motion.aside
+              className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
+              style={{ width: sidebarWidth }}
+              initial={false}
+              animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
+              transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              role="complementary"
+              aria-label="Mobile sidebar navigation"
+              aria-hidden={!isMobileNavOpen}
+            >
+              {renderNav(() => setIsMobileNavOpen(false))}
+            </motion.aside>
+          </>
+        )}
+
+        {/* MAIN CONTENT */}
+        <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
+          <div className="mx-auto max-w-3xl">
+            {breadcrumbs && breadcrumbs.length > 0 && (
+              <nav aria-label="Breadcrumb" className="mb-4">
+                <ol className="flex flex-wrap items-center gap-1.5 text-sm text-[var(--muted-foreground)]">
+                  {breadcrumbs.map((crumb, index) => (
+                    <li key={`${crumb.label}-${index}`} className="flex items-center gap-1.5">
+                      {index > 0 && <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
+                      {index === breadcrumbs.length - 1 ? (
+                        <span aria-current="page" className="text-[var(--foreground)]">
+                          {crumb.label}
+                        </span>
+                      ) : (
+                        <a href={crumb.href} className="hover:text-[var(--foreground)]">
+                          {crumb.label}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            {title && <h1 className="mb-6 text-3xl font-bold tracking-tight text-[var(--foreground)]">{title}</h1>}
+
+            {children}
+
+            {(previousPage || nextPage || editPageUrl) && (
+              <div className="mt-12 border-t border-[var(--border)] pt-6">
+                {editPageUrl && (
+                  <a
+                    href={editPageUrl}
+                    className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                  >
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    Edit this page
+                  </a>
+                )}
+                {(previousPage || nextPage) && (
+                  <nav aria-label="Page navigation" className="flex items-stretch gap-4">
+                    {previousPage ? (
+                      <a
+                        href={previousPage.href}
+                        className="flex flex-1 flex-col items-start gap-1 rounded-lg border border-[var(--border)] p-4 text-left transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                          Previous
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{previousPage.label}</span>
+                      </a>
+                    ) : (
+                      <span className="flex-1" />
+                    )}
+                    {nextPage && (
+                      <a
+                        href={nextPage.href}
+                        className="flex flex-1 flex-col items-end gap-1 rounded-lg border border-[var(--border)] p-4 text-right transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          Next
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{nextPage.label}</span>
+                      </a>
+                    )}
+                  </nav>
+                )}
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* RIGHT SIDEBAR - "On this page" */}
+        {hasToc && !isMobile && (
+          <aside
+            className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
+            style={{ width: tocWidth }}
+            role="complementary"
+            aria-label="Table of contents"
+          >
+            {toc ? (
+              toc
+            ) : tocHeadings ? (
+              <>
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                  On this page
+                </h2>
+                <ul className="space-y-1.5 border-l border-[var(--border)]">
+                  {tocHeadings.map((heading) => {
+                    const isActive = heading.id === activeHeadingId;
+                    return (
+                      <li key={heading.id} style={{ paddingLeft: heading.depth === 3 ? 24 : 12 }}>
+                        <a
+                          href={`#${heading.id}`}
+                          aria-current={isActive ? "location" : undefined}
+                          className={cn(
+                            "-ml-px block border-l-2 pl-3 text-sm transition-colors",
+                            isActive
+                              ? "border-[var(--primary)] font-medium text-[var(--primary)]"
+                              : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                          )}
+                        >
+                          {heading.label}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : null}
+          </aside>
+        )}
+      </div>
+
+      {/* FOOTER */}
+      {footer && (
+        <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
+          {footer}
+        </footer>
+      )}
+    </div>
+  );
+};
+
+DocumentationLayout.displayName = "DocumentationLayout";
+
+export default DocumentationLayout;
+  ```
+  </TabItem>
+</Tabs>
+
+## Usage
+
+```tsx
+import { DocumentationLayout } from '@ignix-ui/documentationlayout';
+```
+
+### Basic Usage
+
+```tsx
+function App() {
+  return (
+    <DocumentationLayout
+      header={<span className="font-bold">Ignix UI</span>}
+      navSections={[
+        {
+          label: 'Getting Started',
+          items: [
+            { label: 'Introduction', href: '/intro', active: true },
+            { label: 'Installation', href: '/install' },
+          ],
+        },
+      ]}
+      tocHeadings={[
+        { id: 'overview', label: 'Overview' },
+        { id: 'installation', label: 'Installation' },
+      ]}
+      title="Introduction"
+    >
+      <article>
+        <h2 id="overview">Overview</h2>
+        <p>Page content goes here, with heading ids matching tocHeadings.</p>
+        <h2 id="installation">Installation</h2>
+        <p>More content...</p>
+      </article>
+    </DocumentationLayout>
+  );
+}
+```
+
+### With Breadcrumbs and Page Navigation
+
+```tsx
+<DocumentationLayout
+  navSections={navSections}
+  breadcrumbs={[
+    { label: 'Docs', href: '/docs' },
+    { label: 'Getting Started', href: '/docs/getting-started' },
+  ]}
+  title="Introduction"
+  previousPage={{ label: 'Home', href: '/' }}
+  nextPage={{ label: 'Installation', href: '/install' }}
+  editPageUrl="https://github.com/org/repo/edit/main/intro.mdx"
+>
+  <article>{/* page content */}</article>
+</DocumentationLayout>
+```
+
+### Custom Sidebar or Table of Contents
+
+```tsx
+<DocumentationLayout
+  sidebar={<MyCustomSidebar />}
+  toc={<MyCustomToc />}
+>
+  <article>{/* page content */}</article>
+</DocumentationLayout>
+```
+
+## Props
+
+### DocumentationLayout
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `header` | `React.ReactNode` | `undefined` | Custom node rendered at the start of the header (e.g. a logo/title) |
+| `searchSlot` | `React.ReactNode` | `undefined` | Optional node rendered in the header (e.g. a search box) |
+| `actions` | `React.ReactNode` | `undefined` | Optional node rendered at the end of the header (e.g. theme toggle, GitHub link) |
+| `navSections` | `DocNavSection[]` | `undefined` | Left sidebar navigation, grouped into labeled sections |
+| `sidebar` | `React.ReactNode` | `undefined` | Fully custom left sidebar content; overrides `navSections` |
+| `tocHeadings` | `TocHeading[]` | `undefined` | Headings for the right "On this page" panel; the active one is tracked automatically via scroll position |
+| `toc` | `React.ReactNode` | `undefined` | Fully custom right sidebar content; overrides `tocHeadings` |
+| `breadcrumbs` | `DocPageLink[]` | `undefined` | Optional breadcrumb trail rendered above the title |
+| `title` | `string` | `undefined` | Optional page title (rendered as the page's `<h1>`) |
+| `children` | `React.ReactNode` | — | Page content |
+| `previousPage` | `DocPageLink` | `undefined` | Optional "previous page" link rendered below the content |
+| `nextPage` | `DocPageLink` | `undefined` | Optional "next page" link rendered below the content |
+| `editPageUrl` | `string` | `undefined` | Optional "Edit this page" link rendered below the content |
+| `footer` | `React.ReactNode` | `undefined` | Optional site footer, rendered below everything else |
+| `sidebarWidth` | `number` | `280` | Left sidebar width in pixels |
+| `tocWidth` | `number` | `240` | Right "On this page" panel width in pixels |
+| `mobileBreakpoint` | `"sm" \| "md" \| "lg"` | `"lg"` | Breakpoint below which the left sidebar collapses into a drawer |
+| `className` | `string` | `undefined` | Additional CSS classes applied to the root container |
+
+### DocNavItem
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Display label for the nav entry |
+| `href` | `string` | `undefined` | Link target; entries without `href` render as a non-clickable group label |
+| `active` | `boolean` | `undefined` | Marks the entry as the current page (`aria-current="page"`) |
+| `items` | `DocNavItem[]` | `undefined` | Nested entries; presence makes this entry a collapsible group |
+
+### DocNavSection
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | `undefined` | Optional section heading rendered above `items` |
+| `items` | `DocNavItem[]` | — | Nav entries in this section |
+
+### TocHeading
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — | Must match the `id` of the corresponding heading element on the page |
+| `label` | `string` | — | Display label in the "On this page" panel |
+| `depth` | `2 \| 3` | `2` | Nesting level, used for indentation |
+
+### DocPageLink
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Display label |
+| `href` | `string` | — | Link target |

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/documentation-layout.mdx
@@ -170,14 +170,20 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Persists across callback invocations rather than being rebuilt from just this batch's
+    // `entries` - IntersectionObserver only reports entries whose intersection state just
+    // changed, so a heading that's still visible without changing wouldn't appear in `entries`
+    // at all, and a fresh-each-time set would incorrectly drop it.
+    const visibleIds = new Set<string>();
     const observer = new IntersectionObserver(
       (entries) => {
-        // `entries` order reflects browser-specific intersection-change batching, not document
-        // order, so when multiple headings cross the threshold in the same batch, pick whichever
-        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
-        const visibleIds = new Set(
-          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
-        );
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        });
+        // `currentHeadings` order (not `entries` order, which reflects browser-specific
+        // intersection-change batching) decides which visible heading wins when more than one
+        // is visible at once.
         const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
         if (firstVisible) {
           setActiveId(firstVisible.id);
@@ -357,6 +363,21 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       mobileDrawerRef.current.inert = !isMobileNavOpen;
     }
   }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Resets eagerly at the start of every open/close transition, not just via
+  // onAnimationComplete below - otherwise closing before the open transition has finished
+  // (isDrawerFullyClosed still `true` from before) would drop visibility to "hidden"
+  // immediately, clipping the close animation instead of letting it slide out. useLayoutEffect
+  // (not useEffect) so this resolves before the browser paints that intermediate state. Skips
+  // the initial mount so the drawer still starts genuinely hidden before it's ever been opened.
+  const hasMountedDrawerRef = React.useRef(false);
+  React.useLayoutEffect(() => {
+    if (!hasMountedDrawerRef.current) {
+      hasMountedDrawerRef.current = true;
+      return;
+    }
+    setIsDrawerFullyClosed(false);
+  }, [isMobileNavOpen]);
 
   // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
   // focus to the hamburger trigger on close. Skips the very first run so mounting with the

--- a/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
@@ -147,13 +147,13 @@
           "type": "category",
           "label": "Page Layout",
           "items": [
+            "templates/layouts/documentation-layout",
             "templates/layouts/full-height-sidebar-layout",
             "templates/layouts/responsive-grid-layout",
             "templates/layouts/sidebar-left-layout",
             "templates/layouts/sidebar-right-layout",
             "templates/layouts/single-column-layout",
-            "templates/layouts/three-column-sidebar-layout",
-            "templates/layouts/documentation-layout"
+            "templates/layouts/three-column-sidebar-layout"
           ]
         },
         {

--- a/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
@@ -152,7 +152,8 @@
             "templates/layouts/sidebar-left-layout",
             "templates/layouts/sidebar-right-layout",
             "templates/layouts/single-column-layout",
-            "templates/layouts/three-column-sidebar-layout"
+            "templates/layouts/three-column-sidebar-layout",
+            "templates/layouts/documentation-layout"
           ]
         },
         {

--- a/apps/storybook/src/templates/layouts/documentation-layout/documentation-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/documentation-layout.stories.tsx
@@ -1,0 +1,212 @@
+/**
+ * @file documentation-layout.stories.tsx
+ * @description Storybook stories for the DocumentationLayout template. Covers the
+ * navigation sidebar (flat and nested/collapsible), the scroll-spy table of contents,
+ * breadcrumbs, prev/next page links, and responsive (mobile drawer) behavior.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DocumentationLayout, type DocNavSection, type TocHeading } from ".";
+import { Github } from "lucide-react";
+
+const meta: Meta<typeof DocumentationLayout> = {
+  title: "Templates/Layouts/DocumentationLayout",
+  component: DocumentationLayout,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A full-page documentation/reference site shell: sticky header, a collapsible-tree left navigation sidebar (a drawer on mobile), page content with breadcrumbs and prev/next links, and a scroll-spy 'On this page' panel.",
+      },
+    },
+  },
+  argTypes: {
+    sidebarWidth: {
+      control: { type: "number", min: 200, max: 400, step: 20 },
+      description: "Left sidebar width in px",
+    },
+    tocWidth: {
+      control: { type: "number", min: 160, max: 320, step: 20 },
+      description: "Right 'On this page' panel width in px",
+    },
+    mobileBreakpoint: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+      description: "Breakpoint below which the left sidebar becomes a drawer",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DocumentationLayout>;
+
+const navSections: DocNavSection[] = [
+  {
+    label: "Getting Started",
+    items: [
+      { label: "Introduction", href: "#", active: true },
+      { label: "Installation", href: "#" },
+      { label: "Quick Start", href: "#" },
+    ],
+  },
+  {
+    label: "Guides",
+    items: [
+      {
+        label: "Theming",
+        items: [
+          { label: "Core Concepts", href: "#" },
+          { label: "Dark Mode", href: "#" },
+        ],
+      },
+      {
+        label: "Components",
+        items: [
+          { label: "Button", href: "#" },
+          { label: "Textarea", href: "#" },
+        ],
+      },
+    ],
+  },
+];
+
+const tocHeadings: TocHeading[] = [
+  { id: "overview", label: "Overview" },
+  { id: "installation", label: "Installation" },
+  { id: "usage", label: "Usage" },
+  { id: "basic-example", label: "Basic Example", depth: 3 },
+  { id: "advanced-example", label: "Advanced Example", depth: 3 },
+  { id: "props", label: "Props" },
+];
+
+const SampleContent = () => (
+  <article className="prose prose-neutral max-w-none dark:prose-invert">
+    <h2 id="overview">Overview</h2>
+    <p>
+      This layout provides a sticky header, a collapsible navigation sidebar, and a
+      scroll-spy table of contents - the standard shape for a documentation or
+      reference site.
+    </p>
+    <h2 id="installation">Installation</h2>
+    <p>Add the template to your project via the CLI, then wrap your page content with it.</p>
+    <h2 id="usage">Usage</h2>
+    <p>Pass navSections for the left sidebar and tocHeadings for the right panel.</p>
+    <h3 id="basic-example">Basic Example</h3>
+    <p>A minimal setup with just navSections and children.</p>
+    <h3 id="advanced-example">Advanced Example</h3>
+    <p>Add breadcrumbs, a title, and previous/next page links for a complete page.</p>
+    <h2 id="props">Props</h2>
+    <p>See the Props table below for the full API.</p>
+  </article>
+);
+
+export const Default: Story = {
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    navSections,
+    tocHeadings,
+    title: "Documentation Layout",
+    breadcrumbs: [
+      { label: "Docs", href: "#" },
+      { label: "Templates", href: "#" },
+      { label: "Documentation Layout", href: "#" },
+    ],
+    previousPage: { label: "Installation", href: "#" },
+    nextPage: { label: "Theming", href: "#" },
+    editPageUrl: "#",
+    children: <SampleContent />,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    ...Default.args,
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    actions: (
+      <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+        <Github className="h-4 w-4" />
+      </a>
+    ),
+  },
+};
+
+export const NestedCollapsibleNav: Story = {
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    navSections,
+    title: "Nested Navigation",
+    children: (
+      <p>
+        Click the chevron next to "Theming" or "Components" in the sidebar to expand or
+        collapse its nested items.
+      </p>
+    ),
+  },
+};
+
+export const CustomSidebarOverride: Story = {
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    sidebar: (
+      <div className="p-4 text-sm text-[var(--muted-foreground)]">
+        Fully custom sidebar content, passed via the <code>sidebar</code> prop instead of{" "}
+        <code>navSections</code>.
+      </div>
+    ),
+    title: "Custom Sidebar",
+    children: <p>The sidebar prop always takes precedence over navSections.</p>,
+  },
+};
+
+export const CustomTocOverride: Story = {
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    navSections,
+    toc: (
+      <div className="text-sm text-[var(--muted-foreground)]">
+        Fully custom TOC content, passed via the <code>toc</code> prop instead of{" "}
+        <code>tocHeadings</code>.
+      </div>
+    ),
+    title: "Custom Table of Contents",
+    children: <p>The toc prop always takes precedence over tocHeadings.</p>,
+  },
+};
+
+export const NoSidebars: Story = {
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    title: "No Sidebars",
+    children: <p>A page with neither a left navigation nor a right table of contents.</p>,
+  },
+};
+
+export const NoHeader: Story = {
+  args: {
+    navSections,
+    title: "No Header",
+    children: <p>The header is entirely optional.</p>,
+  },
+};
+
+export const MobileView: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+  args: {
+    header: <span className="text-sm font-bold">Ignix UI</span>,
+    navSections,
+    tocHeadings,
+    title: "Mobile View",
+    mobileBreakpoint: "lg",
+    children: (
+      <p>
+        At narrow widths the left sidebar collapses into a drawer, opened via the
+        hamburger button in the header.
+      </p>
+    ),
+  },
+};

--- a/apps/storybook/src/templates/layouts/documentation-layout/documentation-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/documentation-layout.stories.tsx
@@ -193,8 +193,8 @@ export const NoHeader: Story = {
 };
 
 export const MobileView: Story = {
-  parameters: {
-    viewport: { defaultViewport: "mobile1" },
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
   },
   args: {
     header: <span className="text-sm font-bold">Ignix UI</span>,

--- a/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
@@ -116,14 +116,9 @@ function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: 
 }
 
 /**
- * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
- * so the right-hand "On this page" panel can highlight it. Falls back to `null`
- * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
- *
- * `root` defaults to the browser viewport, matching the common case where this layout
- * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
- * a scrollable container instead, so headings are measured against that container's
- * visible area rather than the (possibly unrelated) viewport.
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`, so the
+ * right-hand "On this page" panel can highlight it. Falls back to `null` in environments
+ * without `IntersectionObserver` (e.g. tests) instead of throwing.
  */
 function useActiveHeading(
   headings?: TocHeading[],
@@ -148,8 +143,6 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
-    // Read `.current` here (not at render time): refs attach during commit, after this
-    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         // `entries` order reflects browser-specific intersection-change batching, not document
@@ -407,7 +400,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
     <div
       className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
     >
-      {/* HEADER */}
       <header
         className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
         role="banner"
@@ -430,7 +422,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       </header>
 
       <div className="mx-auto flex w-full max-w-[1600px] flex-1">
-        {/* LEFT SIDEBAR - desktop */}
         {hasLeftNav && !isMobile && (
           <aside
             className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
@@ -442,7 +433,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </aside>
         )}
 
-        {/* LEFT SIDEBAR - mobile drawer */}
         {hasLeftNav && isMobile && (
           <>
             <AnimatePresence>
@@ -479,7 +469,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </>
         )}
 
-        {/* MAIN CONTENT */}
         <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
           <div className="mx-auto max-w-3xl">
             {breadcrumbs && breadcrumbs.length > 0 && (
@@ -553,7 +542,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </div>
         </main>
 
-        {/* RIGHT SIDEBAR - "On this page" */}
         {hasToc && !isMobile && (
           <aside
             className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
@@ -595,7 +583,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
         )}
       </div>
 
-      {/* FOOTER */}
       {footer && (
         <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
           {footer}

--- a/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
@@ -1,0 +1,492 @@
+import * as React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ChevronRight, Menu, X, ArrowLeft, ArrowRight, Pencil } from "lucide-react";
+import { cn } from "../../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A single entry in the left navigation tree. Entries without `href` render
+ * as a non-clickable group label; entries with nested `items` are
+ * collapsible, auto-expanding when one of their descendants is `active`.
+ */
+export interface DocNavItem {
+  label: string;
+  href?: string;
+  active?: boolean;
+  items?: DocNavItem[];
+}
+
+/** A labeled group of {@link DocNavItem} entries in the left sidebar. */
+export interface DocNavSection {
+  label?: string;
+  items: DocNavItem[];
+}
+
+/** A heading tracked by the right-hand "On this page" table of contents. */
+export interface TocHeading {
+  /** Must match the `id` of the corresponding heading element on the page. */
+  id: string;
+  label: string;
+  /** Nesting level, used for indentation. Defaults to `2`. */
+  depth?: 2 | 3;
+}
+
+/** A labeled link, used for breadcrumbs and prev/next page navigation. */
+export interface DocPageLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * Props for the {@link DocumentationLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the header (e.g. a logo/title).
+ * @property searchSlot - Optional node rendered in the header (e.g. a search box).
+ * @property actions - Optional node rendered at the end of the header (e.g. theme toggle, GitHub link).
+ * @property navSections - Left sidebar navigation, grouped into labeled sections.
+ * @property sidebar - Fully custom left sidebar content; overrides `navSections`.
+ * @property tocHeadings - Headings for the right "On this page" panel; the active one is
+ * tracked automatically via scroll position (`IntersectionObserver`).
+ * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
+ * @property title - Optional page title (rendered as the page's `<h1>`).
+ * @property children - Page content.
+ * @property previousPage - Optional "previous page" link rendered below the content.
+ * @property nextPage - Optional "next page" link rendered below the content.
+ * @property editPageUrl - Optional "Edit this page" link rendered below the content.
+ * @property footer - Optional site footer, rendered below everything else.
+ * @property sidebarWidth - Left sidebar width in px. Default `280`.
+ * @property tocWidth - Right "On this page" panel width in px. Default `240`.
+ * @property mobileBreakpoint - Breakpoint below which the left sidebar collapses into a
+ * drawer opened via a hamburger button. Default `"lg"`.
+ * @property className - Class name for the root container.
+ */
+export interface DocumentationLayoutProps {
+  header?: React.ReactNode;
+  searchSlot?: React.ReactNode;
+  actions?: React.ReactNode;
+  navSections?: DocNavSection[];
+  sidebar?: React.ReactNode;
+  tocHeadings?: TocHeading[];
+  toc?: React.ReactNode;
+  breadcrumbs?: DocPageLink[];
+  title?: string;
+  children: React.ReactNode;
+  previousPage?: DocPageLink;
+  nextPage?: DocPageLink;
+  editPageUrl?: string;
+  footer?: React.ReactNode;
+  sidebarWidth?: number;
+  tocWidth?: number;
+  mobileBreakpoint?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              HELPERS & HOOKS                               */
+/* -------------------------------------------------------------------------- */
+
+function itemsContainActive(items: DocNavItem[]): boolean {
+  return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
+}
+
+/** Labels of every group that has an active descendant, so they render pre-expanded. */
+function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
+  for (const item of items) {
+    if (item.items?.length && itemsContainActive(item.items)) {
+      acc.add(item.label);
+      collectExpandedAncestors(item.items, acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
+ * so the right-hand "On this page" panel can highlight it. Falls back to `null`
+ * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ */
+function useActiveHeading(headings?: TocHeading[]): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!headings || headings.length === 0) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return activeId;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              NAV TREE                                      */
+/* -------------------------------------------------------------------------- */
+
+const DocNavTree: React.FC<{
+  items: DocNavItem[];
+  expanded: Set<string>;
+  onToggle: (label: string) => void;
+  onNavigate?: () => void;
+  depth?: number;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
+    {items.map((item) => {
+      const hasChildren = !!item.items?.length;
+      const isExpanded = hasChildren && expanded.has(item.label);
+
+      return (
+        <li key={item.label}>
+          <div className="flex items-center">
+            {item.href ? (
+              <a
+                href={item.href}
+                aria-current={item.active ? "page" : undefined}
+                onClick={onNavigate}
+                className={cn(
+                  "flex-1 block px-3 py-1.5 rounded-md text-sm transition-colors",
+                  item.active
+                    ? "bg-[var(--primary)]/10 text-[var(--primary)] font-medium"
+                    : "text-[var(--foreground)] hover:bg-[var(--accent)]"
+                )}
+              >
+                {item.label}
+              </a>
+            ) : hasChildren ? (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span className="flex-1 px-3 py-1.5 text-sm font-semibold text-[var(--foreground)]">
+                {item.label}
+              </span>
+            )}
+            {hasChildren && (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
+                className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              </button>
+            )}
+          </div>
+          {hasChildren && isExpanded && (
+            <DocNavTree
+              items={item.items!}
+              expanded={expanded}
+              onToggle={onToggle}
+              onNavigate={onNavigate}
+              depth={depth + 1}
+            />
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * DocumentationLayout is a full-page shell for documentation/reference sites:
+ * a sticky header, a collapsible-tree left navigation sidebar (a drawer on
+ * mobile), the page content, and a right-hand "On this page" panel whose
+ * active heading tracks scroll position automatically. Breadcrumbs, a page
+ * title, and prev/next page links are optional and rendered around the
+ * content when provided.
+ */
+export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
+  header,
+  searchSlot,
+  actions,
+  navSections,
+  sidebar,
+  tocHeadings,
+  toc,
+  breadcrumbs,
+  title,
+  children,
+  previousPage,
+  nextPage,
+  editPageUrl,
+  footer,
+  sidebarWidth = 280,
+  tocWidth = 240,
+  mobileBreakpoint = "lg",
+  className,
+}) => {
+  const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
+
+  React.useEffect(() => {
+    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [mobileBp]);
+
+  const [expanded, setExpanded] = React.useState<Set<string>>(() =>
+    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+  );
+
+  const toggleExpanded = React.useCallback((label: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  }, []);
+
+  const activeHeadingId = useActiveHeading(tocHeadings);
+
+  const hasLeftNav = !!(sidebar || navSections);
+  const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  const renderNav = (onNavigate?: () => void): React.ReactNode => {
+    if (sidebar) return sidebar;
+    if (!navSections) return null;
+    return (
+      <nav className="space-y-6 p-4" aria-label="Documentation navigation">
+        {navSections.map((section, index) => (
+          <div key={section.label ?? index}>
+            {section.label && (
+              <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                {section.label}
+              </h2>
+            )}
+            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+          </div>
+        ))}
+      </nav>
+    );
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
+    >
+      {/* HEADER */}
+      <header
+        className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+        role="banner"
+      >
+        {hasLeftNav && isMobile && (
+          <button
+            type="button"
+            onClick={() => setIsMobileNavOpen((open) => !open)}
+            aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
+            aria-expanded={isMobileNavOpen}
+            className="shrink-0 rounded-md p-2 text-[var(--foreground)] hover:bg-[var(--accent)]"
+          >
+            {isMobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        )}
+        {header && <div className="flex shrink-0 items-center">{header}</div>}
+        {searchSlot && <div className="min-w-0 flex-1 md:max-w-sm">{searchSlot}</div>}
+        {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+      </header>
+
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1">
+        {/* LEFT SIDEBAR - desktop */}
+        {hasLeftNav && !isMobile && (
+          <aside
+            className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
+            style={{ width: sidebarWidth }}
+            role="complementary"
+            aria-label="Sidebar navigation"
+          >
+            {renderNav()}
+          </aside>
+        )}
+
+        {/* LEFT SIDEBAR - mobile drawer */}
+        {hasLeftNav && isMobile && (
+          <>
+            <AnimatePresence>
+              {isMobileNavOpen && (
+                <motion.div
+                  className="fixed inset-0 z-40 bg-black/50"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  onClick={() => setIsMobileNavOpen(false)}
+                  aria-hidden="true"
+                />
+              )}
+            </AnimatePresence>
+            <motion.aside
+              className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
+              style={{ width: sidebarWidth }}
+              initial={false}
+              animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
+              transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              role="complementary"
+              aria-label="Mobile sidebar navigation"
+              aria-hidden={!isMobileNavOpen}
+            >
+              {renderNav(() => setIsMobileNavOpen(false))}
+            </motion.aside>
+          </>
+        )}
+
+        {/* MAIN CONTENT */}
+        <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
+          <div className="mx-auto max-w-3xl">
+            {breadcrumbs && breadcrumbs.length > 0 && (
+              <nav aria-label="Breadcrumb" className="mb-4">
+                <ol className="flex flex-wrap items-center gap-1.5 text-sm text-[var(--muted-foreground)]">
+                  {breadcrumbs.map((crumb, index) => (
+                    <li key={`${crumb.label}-${index}`} className="flex items-center gap-1.5">
+                      {index > 0 && <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
+                      {index === breadcrumbs.length - 1 ? (
+                        <span aria-current="page" className="text-[var(--foreground)]">
+                          {crumb.label}
+                        </span>
+                      ) : (
+                        <a href={crumb.href} className="hover:text-[var(--foreground)]">
+                          {crumb.label}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            {title && <h1 className="mb-6 text-3xl font-bold tracking-tight text-[var(--foreground)]">{title}</h1>}
+
+            {children}
+
+            {(previousPage || nextPage || editPageUrl) && (
+              <div className="mt-12 border-t border-[var(--border)] pt-6">
+                {editPageUrl && (
+                  <a
+                    href={editPageUrl}
+                    className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                  >
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    Edit this page
+                  </a>
+                )}
+                {(previousPage || nextPage) && (
+                  <nav aria-label="Page navigation" className="flex items-stretch gap-4">
+                    {previousPage ? (
+                      <a
+                        href={previousPage.href}
+                        className="flex flex-1 flex-col items-start gap-1 rounded-lg border border-[var(--border)] p-4 text-left transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                          Previous
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{previousPage.label}</span>
+                      </a>
+                    ) : (
+                      <span className="flex-1" />
+                    )}
+                    {nextPage && (
+                      <a
+                        href={nextPage.href}
+                        className="flex flex-1 flex-col items-end gap-1 rounded-lg border border-[var(--border)] p-4 text-right transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          Next
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{nextPage.label}</span>
+                      </a>
+                    )}
+                  </nav>
+                )}
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* RIGHT SIDEBAR - "On this page" */}
+        {hasToc && !isMobile && (
+          <aside
+            className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
+            style={{ width: tocWidth }}
+            role="complementary"
+            aria-label="Table of contents"
+          >
+            {toc ? (
+              toc
+            ) : tocHeadings ? (
+              <>
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                  On this page
+                </h2>
+                <ul className="space-y-1.5 border-l border-[var(--border)]">
+                  {tocHeadings.map((heading) => {
+                    const isActive = heading.id === activeHeadingId;
+                    return (
+                      <li key={heading.id} style={{ paddingLeft: heading.depth === 3 ? 24 : 12 }}>
+                        <a
+                          href={`#${heading.id}`}
+                          aria-current={isActive ? "location" : undefined}
+                          className={cn(
+                            "-ml-px block border-l-2 pl-3 text-sm transition-colors",
+                            isActive
+                              ? "border-[var(--primary)] font-medium text-[var(--primary)]"
+                              : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                          )}
+                        >
+                          {heading.label}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : null}
+          </aside>
+        )}
+      </div>
+
+      {/* FOOTER */}
+      {footer && (
+        <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
+          {footer}
+        </footer>
+      )}
+    </div>
+  );
+};
+
+DocumentationLayout.displayName = "DocumentationLayout";
+
+export default DocumentationLayout;

--- a/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
@@ -143,14 +143,20 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Persists across callback invocations rather than being rebuilt from just this batch's
+    // `entries` - IntersectionObserver only reports entries whose intersection state just
+    // changed, so a heading that's still visible without changing wouldn't appear in `entries`
+    // at all, and a fresh-each-time set would incorrectly drop it.
+    const visibleIds = new Set<string>();
     const observer = new IntersectionObserver(
       (entries) => {
-        // `entries` order reflects browser-specific intersection-change batching, not document
-        // order, so when multiple headings cross the threshold in the same batch, pick whichever
-        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
-        const visibleIds = new Set(
-          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
-        );
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        });
+        // `currentHeadings` order (not `entries` order, which reflects browser-specific
+        // intersection-change batching) decides which visible heading wins when more than one
+        // is visible at once.
         const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
         if (firstVisible) {
           setActiveId(firstVisible.id);
@@ -330,6 +336,21 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       mobileDrawerRef.current.inert = !isMobileNavOpen;
     }
   }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Resets eagerly at the start of every open/close transition, not just via
+  // onAnimationComplete below - otherwise closing before the open transition has finished
+  // (isDrawerFullyClosed still `true` from before) would drop visibility to "hidden"
+  // immediately, clipping the close animation instead of letting it slide out. useLayoutEffect
+  // (not useEffect) so this resolves before the browser paints that intermediate state. Skips
+  // the initial mount so the drawer still starts genuinely hidden before it's ever been opened.
+  const hasMountedDrawerRef = React.useRef(false);
+  React.useLayoutEffect(() => {
+    if (!hasMountedDrawerRef.current) {
+      hasMountedDrawerRef.current = true;
+      return;
+    }
+    setIsDrawerFullyClosed(false);
+  }, [isMobileNavOpen]);
 
   // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
   // focus to the hamburger trigger on close. Skips the very first run so mounting with the

--- a/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
@@ -152,9 +152,15 @@ function useActiveHeading(
     // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length > 0) {
-          setActiveId(visible[0].target.id);
+        // `entries` order reflects browser-specific intersection-change batching, not document
+        // order, so when multiple headings cross the threshold in the same batch, pick whichever
+        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
+        const visibleIds = new Set(
+          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
+        );
+        const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
+        if (firstVisible) {
+          setActiveId(firstVisible.id);
         }
       },
       { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
@@ -287,9 +293,12 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
-  const [isMobile, setIsMobile] = React.useState(() =>
-    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
-  );
+  // Starts `false` unconditionally (not derived from `window.innerWidth`) so server and client
+  // render the same markup on first paint; the mount effect below corrects it via `matchMedia`
+  // right after hydration. Deriving this from `window` would only match on truly client-only
+  // renders - during SSR hydration the client's own first pass already sees `window`, so the
+  // guard doesn't help there and the two renders could still disagree.
+  const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;

--- a/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/documentation-layout/index.tsx
@@ -51,6 +51,10 @@ export interface DocPageLink {
  * @property tocHeadings - Headings for the right "On this page" panel; the active one is
  * tracked automatically via scroll position (`IntersectionObserver`).
  * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property scrollContainerRef - Ref to the scrollable ancestor that actually scrolls the
+ * page content, used as the `IntersectionObserver` root for the scroll-spy. Only needed when
+ * this layout is rendered inside a scrollable container instead of the document itself (e.g.
+ * an embedded preview); omit it when the layout owns page-level scroll.
  * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
  * @property title - Optional page title (rendered as the page's `<h1>`).
  * @property children - Page content.
@@ -72,6 +76,7 @@ export interface DocumentationLayoutProps {
   sidebar?: React.ReactNode;
   tocHeadings?: TocHeading[];
   toc?: React.ReactNode;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
   breadcrumbs?: DocPageLink[];
   title?: string;
   children: React.ReactNode;
@@ -93,14 +98,20 @@ function itemsContainActive(items: DocNavItem[]): boolean {
   return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
 }
 
-/** Labels of every group that has an active descendant, so they render pre-expanded. */
-function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
-  for (const item of items) {
+/**
+ * Tree-position paths (not labels) of every group that has an active descendant, so they
+ * render pre-expanded. Paths (e.g. "s0-1-0") are used instead of labels throughout the nav
+ * tree's expand/collapse state so that two groups sharing the same label in different
+ * branches - a common case with a generic name like "Overview" - expand independently.
+ */
+function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: Set<string> = new Set()): Set<string> {
+  items.forEach((item, index) => {
+    const path = `${parentPath}-${index}`;
     if (item.items?.length && itemsContainActive(item.items)) {
-      acc.add(item.label);
-      collectExpandedAncestors(item.items, acc);
+      acc.add(path);
+      collectExpandedAncestors(item.items, path, acc);
     }
-  }
+  });
   return acc;
 }
 
@@ -108,19 +119,37 @@ function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Se
  * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
  * so the right-hand "On this page" panel can highlight it. Falls back to `null`
  * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ *
+ * `root` defaults to the browser viewport, matching the common case where this layout
+ * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
+ * a scrollable container instead, so headings are measured against that container's
+ * visible area rather than the (possibly unrelated) viewport.
  */
-function useActiveHeading(headings?: TocHeading[]): string | null {
+function useActiveHeading(
+  headings?: TocHeading[],
+  scrollContainerRef?: React.RefObject<HTMLElement | null>
+): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
+  // Consumers commonly pass an inline array literal (see the Usage docs), which gets a new
+  // identity every render. Keying the effect on a derived id string - instead of the array
+  // reference - avoids tearing down and recreating the observer on every unrelated re-render.
+  const headingsRef = React.useRef(headings);
+  headingsRef.current = headings;
+  const headingIds = headings?.map((heading) => heading.id).join(",") ?? "";
+
   React.useEffect(() => {
-    if (!headings || headings.length === 0) return;
+    const currentHeadings = headingsRef.current;
+    if (!currentHeadings || currentHeadings.length === 0) return;
     if (typeof IntersectionObserver === "undefined") return;
 
-    const elements = headings
+    const elements = currentHeadings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Read `.current` here (not at render time): refs attach during commit, after this
+    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries.filter((entry) => entry.isIntersecting);
@@ -128,12 +157,12 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
           setActiveId(visible[0].target.id);
         }
       },
-      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+      { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
     );
 
     elements.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [headings]);
+  }, [headingIds, scrollContainerRef]);
 
   return activeId;
 }
@@ -145,17 +174,19 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
 const DocNavTree: React.FC<{
   items: DocNavItem[];
   expanded: Set<string>;
-  onToggle: (label: string) => void;
+  onToggle: (path: string) => void;
   onNavigate?: () => void;
   depth?: number;
-}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  parentPath: string;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0, parentPath }) => (
   <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
-    {items.map((item) => {
+    {items.map((item, index) => {
+      const path = `${parentPath}-${index}`;
       const hasChildren = !!item.items?.length;
-      const isExpanded = hasChildren && expanded.has(item.label);
+      const isExpanded = hasChildren && expanded.has(path);
 
       return (
-        <li key={item.label}>
+        <li key={path}>
           <div className="flex items-center">
             {item.href ? (
               <a
@@ -174,7 +205,7 @@ const DocNavTree: React.FC<{
             ) : hasChildren ? (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
               >
@@ -188,7 +219,7 @@ const DocNavTree: React.FC<{
             {hasChildren && (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
                 className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
@@ -204,6 +235,7 @@ const DocNavTree: React.FC<{
               onToggle={onToggle}
               onNavigate={onNavigate}
               depth={depth + 1}
+              parentPath={path}
             />
           )}
         </li>
@@ -232,6 +264,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   sidebar,
   tocHeadings,
   toc,
+  scrollContainerRef,
   breadcrumbs,
   title,
   children,
@@ -245,34 +278,96 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   className,
 }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(false);
+  // Tracks whether the close slide-out has actually finished (via onAnimationComplete below),
+  // so `visibility: hidden` only applies once it's done - not the instant `isMobileNavOpen`
+  // flips false, which would clip the exit animation instead of letting it play out.
+  const [isDrawerFullyClosed, setIsDrawerFullyClosed] = React.useState(true);
+  const mobileDrawerRef = React.useRef<HTMLElement>(null);
+  const mobileNavTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
+  const [isMobile, setIsMobile] = React.useState(() =>
+    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
+  );
+
   React.useEffect(() => {
-    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(`(max-width: ${mobileBp - 1}px)`);
+    setIsMobile(mediaQuery.matches);
+    const handleChange = (event: MediaQueryListEvent): void => setIsMobile(event.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [mobileBp]);
 
   const [expanded, setExpanded] = React.useState<Set<string>>(() =>
-    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+    navSections
+      ? navSections.reduce((acc, section, index) => collectExpandedAncestors(section.items, `s${index}`, acc), new Set<string>())
+      : new Set()
   );
 
-  const toggleExpanded = React.useCallback((label: string) => {
+  const toggleExpanded = React.useCallback((path: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(label)) next.delete(label);
-      else next.add(label);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
       return next;
     });
   }, []);
 
-  const activeHeadingId = useActiveHeading(tocHeadings);
+  const activeHeadingId = useActiveHeading(tocHeadings, scrollContainerRef);
 
   const hasLeftNav = !!(sidebar || navSections);
   const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  // `aria-hidden` alone doesn't stop the closed drawer's links from being keyboard-focusable.
+  // `inert` (not yet in framer-motion's HTMLMotionProps types) is set imperatively via the DOM
+  // property instead, so focus/tab order and clicks are actually blocked while it's off-screen.
+  React.useEffect(() => {
+    if (mobileDrawerRef.current) {
+      mobileDrawerRef.current.inert = !isMobileNavOpen;
+    }
+  }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
+  // focus to the hamburger trigger on close. Skips the very first run so mounting with the
+  // drawer already closed doesn't yank focus onto the (not-yet-clicked) trigger button.
+  const hasOpenedDrawerRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasOpenedDrawerRef.current) {
+      hasOpenedDrawerRef.current = true;
+      return;
+    }
+    if (isMobileNavOpen) {
+      mobileDrawerRef.current?.focus();
+    } else {
+      mobileNavTriggerRef.current?.focus();
+    }
+  }, [isMobileNavOpen]);
+
+  const handleDrawerKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    if (event.key === "Escape") {
+      setIsMobileNavOpen(false);
+      return;
+    }
+    if (event.key !== "Tab" || !mobileDrawerRef.current) return;
+
+    // Trap focus within the open drawer: wrap Tab/Shift+Tab at its edges instead of
+    // letting focus escape into the (inert-but-visually-hidden) rest of the page.
+    const focusable = mobileDrawerRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const renderNav = (onNavigate?: () => void): React.ReactNode => {
     if (sidebar) return sidebar;
@@ -286,7 +381,13 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
                 {section.label}
               </h2>
             )}
-            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+            <DocNavTree
+              items={section.items}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onNavigate={onNavigate}
+              parentPath={`s${index}`}
+            />
           </div>
         ))}
       </nav>
@@ -304,6 +405,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       >
         {hasLeftNav && isMobile && (
           <button
+            ref={mobileNavTriggerRef}
             type="button"
             onClick={() => setIsMobileNavOpen((open) => !open)}
             aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
@@ -347,11 +449,18 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
               )}
             </AnimatePresence>
             <motion.aside
+              ref={mobileDrawerRef}
+              tabIndex={-1}
+              onKeyDown={handleDrawerKeyDown}
               className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
-              style={{ width: sidebarWidth }}
+              style={{
+                width: sidebarWidth,
+                visibility: isMobileNavOpen || !isDrawerFullyClosed ? "visible" : "hidden",
+              }}
               initial={false}
               animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
               transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              onAnimationComplete={() => setIsDrawerFullyClosed(!isMobileNavOpen)}
               role="complementary"
               aria-label="Mobile sidebar navigation"
               aria-hidden={!isMobileNavOpen}

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -1109,6 +1109,20 @@
         }
       }
     },
+    "documentationlayout": {
+      "name": "DocumentationLayout",
+      "description": "A full-page documentation/reference site shell: sticky header, a collapsible-tree left navigation sidebar (a drawer on mobile), page content with breadcrumbs and prev/next links, and a scroll-spy 'On this page' panel.",
+      "dependencies": [
+        "framer-motion",
+        "lucide-react"
+      ],
+      "files": {
+        "main": {
+          "path": "templates/layouts/documentation-layout/index.tsx",
+          "type": "template"
+        }
+      }
+    },
     "forgot-password": {
       "name": "forgotPassword",
       "description": "A fully responsive and customizable Forgot Password component with an input field and submit button, built to support secure in-app password reset processes.",

--- a/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
@@ -428,6 +428,53 @@ describe("DocumentationLayout", () => {
       document.body.removeChild(usage);
       vi.unstubAllGlobals();
     });
+
+    it("keeps the initially visible heading active when a later batch omits it (still intersecting, unchanged)", () => {
+      let capturedCallback: IntersectionObserverCallback | undefined;
+      class MockIntersectionObserver {
+        constructor(cb: IntersectionObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn();
+      }
+      vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+      const overview = document.createElement("div");
+      overview.id = "overview";
+      document.body.appendChild(overview);
+      const usage = document.createElement("div");
+      usage.id = "usage";
+      document.body.appendChild(usage);
+
+      render(<DocumentationLayout tocHeadings={tocHeadings}><p>Content</p></DocumentationLayout>);
+
+      act(() => {
+        capturedCallback?.(
+          [{ isIntersecting: true, target: overview } as unknown as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+      expect(screen.getByRole("link", { name: "Overview" })).toHaveAttribute("aria-current", "location");
+
+      // "overview" is still intersecting and unchanged, so a real IntersectionObserver wouldn't
+      // report it again here - only "usage" entering shows up in this batch. "overview" must
+      // stay active since it's still visible and first in reading order.
+      act(() => {
+        capturedCallback?.(
+          [{ isIntersecting: true, target: usage } as unknown as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+      expect(screen.getByRole("link", { name: "Overview" })).toHaveAttribute("aria-current", "location");
+      expect(screen.getByRole("link", { name: "Usage" })).not.toHaveAttribute("aria-current");
+
+      document.body.removeChild(overview);
+      document.body.removeChild(usage);
+      vi.unstubAllGlobals();
+    });
   });
 
   describe("responsive behavior", () => {

--- a/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
@@ -1,6 +1,6 @@
 // documentation-layout.test.tsx
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /* ------------------ HOISTED MOCKS (must be before importing component) ------------------ */
@@ -386,6 +386,48 @@ describe("DocumentationLayout", () => {
       document.body.removeChild(overview);
       vi.unstubAllGlobals();
     });
+
+    it("picks the heading first in currentHeadings order when multiple intersect in one batch", () => {
+      let capturedCallback: IntersectionObserverCallback | undefined;
+      class MockIntersectionObserver {
+        constructor(cb: IntersectionObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn();
+      }
+      vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+      const overview = document.createElement("div");
+      overview.id = "overview";
+      document.body.appendChild(overview);
+      const usage = document.createElement("div");
+      usage.id = "usage";
+      document.body.appendChild(usage);
+
+      render(<DocumentationLayout tocHeadings={tocHeadings}><p>Content</p></DocumentationLayout>);
+
+      // Real browsers don't guarantee entries arrive in document order - simulate "usage"
+      // (second in tocHeadings) reported before "overview" (first) in the same batch.
+      act(() => {
+        capturedCallback?.(
+          [
+            { isIntersecting: true, target: usage } as unknown as IntersectionObserverEntry,
+            { isIntersecting: true, target: overview } as unknown as IntersectionObserverEntry,
+          ],
+          {} as IntersectionObserver
+        );
+      });
+
+      expect(screen.getByRole("link", { name: "Overview" })).toHaveAttribute("aria-current", "location");
+      expect(screen.getByRole("link", { name: "Usage" })).not.toHaveAttribute("aria-current");
+
+      document.body.removeChild(overview);
+      document.body.removeChild(usage);
+      vi.unstubAllGlobals();
+    });
   });
 
   describe("responsive behavior", () => {
@@ -396,9 +438,40 @@ describe("DocumentationLayout", () => {
       expect(screen.queryByRole("button", { name: "Open navigation" })).not.toBeInTheDocument();
     });
 
+    it("responds to a live breakpoint change via the matchMedia 'change' listener", () => {
+      global.innerWidth = 1280;
+      let changeHandler: ((event: MediaQueryListEvent) => void) | undefined;
+      // Capture the "change" handler the component registers, so we can fire it directly -
+      // this is what actually drives responsiveness after mount now (not a resize listener).
+      vi.mocked(window.matchMedia).mockImplementation(
+        (query: string) =>
+          ({
+            matches: matchesMaxWidthQuery(query),
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn((_event: string, handler: (event: MediaQueryListEvent) => void) => {
+              changeHandler = handler;
+            }),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          }) as unknown as MediaQueryList
+      );
+
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      expect(screen.getByRole("complementary", { name: "Sidebar navigation" })).toBeInTheDocument();
+
+      act(() => {
+        changeHandler?.({ matches: true } as MediaQueryListEvent);
+      });
+
+      expect(screen.queryByRole("complementary", { name: "Sidebar navigation" })).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open navigation" })).toBeInTheDocument();
+    });
+
     it("hides the desktop sidebar and shows a hamburger toggle at mobile widths", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
       expect(screen.queryByRole("complementary", { name: "Sidebar navigation" })).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Open navigation" })).toBeInTheDocument();
@@ -406,7 +479,6 @@ describe("DocumentationLayout", () => {
 
     it("opens the mobile drawer when the hamburger button is clicked", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
 
       const toggle = screen.getByRole("button", { name: "Open navigation" });
@@ -421,7 +493,6 @@ describe("DocumentationLayout", () => {
 
     it("closes the mobile drawer when a nav link is clicked", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       const { container } = render(
         <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
       );
@@ -442,7 +513,6 @@ describe("DocumentationLayout", () => {
       // browsers also need `inert` for that. jsdom doesn't enforce inert's actual focus-blocking
       // behavior, so this asserts the DOM property our fix sets, which is what drives it.
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       const { container } = render(
         <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
       );
@@ -461,7 +531,6 @@ describe("DocumentationLayout", () => {
 
     it("moves focus into the drawer on open and restores it to the trigger on close", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       const { container } = render(
         <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
       );
@@ -478,7 +547,6 @@ describe("DocumentationLayout", () => {
 
     it("closes the mobile drawer when Escape is pressed", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       const { container } = render(
         <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
       );
@@ -493,7 +561,6 @@ describe("DocumentationLayout", () => {
 
     it("traps Tab focus within the open drawer, wrapping at both ends", () => {
       global.innerWidth = 500;
-      global.dispatchEvent(new Event("resize"));
       const { container } = render(
         <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
       );

--- a/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
@@ -1,7 +1,7 @@
 // documentation-layout.test.tsx
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /* ------------------ HOISTED MOCKS (must be before importing component) ------------------ */
 vi.mock("lucide-react", () => ({
@@ -16,9 +16,14 @@ vi.mock("lucide-react", () => ({
 
 vi.mock("framer-motion", () => ({
   motion: {
-    aside: React.forwardRef(({ children, initial: _i, animate: _a, transition: _t, ...props }: any, ref: any) => (
-      <aside ref={ref} {...props}>{children}</aside>
-    )),
+    aside: React.forwardRef(
+      (
+        { children, initial: _i, animate: _a, transition: _t, onAnimationComplete: _oac, ...props }: any,
+        ref: any
+      ) => (
+        <aside ref={ref} {...props}>{children}</aside>
+      )
+    ),
     div: React.forwardRef(({ children, initial: _i, animate: _a, exit: _e, ...props }: any, ref: any) => (
       <div ref={ref} {...props}>{children}</div>
     )),
@@ -56,9 +61,35 @@ const tocHeadings: TocHeading[] = [
   { id: "usage", label: "Usage", depth: 3 },
 ];
 
+function matchesMaxWidthQuery(query: string): boolean {
+  const match = /max-width:\s*(\d+)px/.exec(query);
+  const maxWidth = match ? Number(match[1]) : Infinity;
+  return window.innerWidth <= maxWidth;
+}
+
 describe("DocumentationLayout", () => {
   beforeEach(() => {
     global.innerWidth = 1280;
+    // The shared setupTests.ts mock always returns `matches: false`, which breaks real
+    // breakpoint detection - this component's mobile/desktop split relies on it. Replace it
+    // per-file with one that actually parses `(max-width: Npx)` against the current width.
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: matchesMaxWidthQuery(query),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("rendering", () => {
@@ -123,7 +154,7 @@ describe("DocumentationLayout", () => {
       expect(screen.getByRole("link", { name: "Installation" })).not.toHaveAttribute("aria-current");
     });
 
-    it("auto-expands a group that contains no active descendant only after being toggled", () => {
+    it("keeps a group with no active descendant collapsed until it is toggled", () => {
       render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
       // "Advanced" has no active descendant, so its children start collapsed.
       expect(screen.queryByRole("link", { name: "Theming" })).not.toBeInTheDocument();
@@ -151,6 +182,39 @@ describe("DocumentationLayout", () => {
       fireEvent.click(label);
       expect(screen.queryByRole("link", { name: "Theming" })).not.toBeInTheDocument();
       expect(label).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("toggles two groups that share a label in different branches independently", () => {
+      // Both branches have a group named "Overview" - expand/collapse state is keyed by
+      // tree position, not label, so toggling one must not affect the other.
+      const duplicateLabelSections: DocNavSection[] = [
+        {
+          label: "Section A",
+          items: [{ label: "Overview", items: [{ label: "Alpha Child", href: "/alpha" }] }],
+        },
+        {
+          label: "Section B",
+          items: [{ label: "Overview", items: [{ label: "Beta Child", href: "/beta" }] }],
+        },
+      ];
+      render(
+        <DocumentationLayout navSections={duplicateLabelSections}>
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+
+      expect(screen.queryByRole("link", { name: "Alpha Child" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Beta Child" })).not.toBeInTheDocument();
+
+      const [expandA, expandB] = screen.getAllByRole("button", { name: "Expand Overview" });
+      fireEvent.click(expandA);
+
+      expect(screen.getByRole("link", { name: "Alpha Child" })).toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Beta Child" })).not.toBeInTheDocument();
+
+      fireEvent.click(expandB);
+      expect(screen.getByRole("link", { name: "Beta Child" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Alpha Child" })).toBeInTheDocument();
     });
   });
 
@@ -262,9 +326,10 @@ describe("DocumentationLayout", () => {
     it("observes each heading element when IntersectionObserver is available", () => {
       const observe = vi.fn();
       const disconnect = vi.fn();
+      let capturedOptions: IntersectionObserverInit | undefined;
       class MockIntersectionObserver {
-        constructor(_cb: IntersectionObserverCallback) {
-          void _cb;
+        constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+          capturedOptions = options;
         }
         observe = observe;
         disconnect = disconnect;
@@ -280,6 +345,43 @@ describe("DocumentationLayout", () => {
       render(<DocumentationLayout tocHeadings={tocHeadings}><p>Content</p></DocumentationLayout>);
 
       expect(observe).toHaveBeenCalledWith(overview);
+      // No scrollContainerRef provided: falls back to the viewport (root: null).
+      expect(capturedOptions?.root).toBeNull();
+
+      document.body.removeChild(overview);
+      vi.unstubAllGlobals();
+    });
+
+    it("uses a provided scrollContainerRef as the IntersectionObserver root", () => {
+      let capturedOptions: IntersectionObserverInit | undefined;
+      class MockIntersectionObserver {
+        constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+          capturedOptions = options;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn();
+      }
+      vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+      const overview = document.createElement("div");
+      overview.id = "overview";
+      document.body.appendChild(overview);
+
+      const ScrollableDemo: React.FC = () => {
+        const containerRef = React.useRef<HTMLDivElement>(null);
+        return (
+          <div ref={containerRef} data-testid="scroll-container">
+            <DocumentationLayout tocHeadings={tocHeadings} scrollContainerRef={containerRef}>
+              <p>Content</p>
+            </DocumentationLayout>
+          </div>
+        );
+      };
+      render(<ScrollableDemo />);
+
+      expect(capturedOptions?.root).toBe(screen.getByTestId("scroll-container"));
 
       document.body.removeChild(overview);
       vi.unstubAllGlobals();
@@ -333,6 +435,82 @@ describe("DocumentationLayout", () => {
       // tech) - so this specific check queries the raw DOM attribute instead.
       const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]');
       expect(drawer).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("makes the closed mobile drawer inert so its links drop out of the tab order", () => {
+      // `aria-hidden` alone doesn't stop hidden content from being keyboard-focusable - real
+      // browsers also need `inert` for that. jsdom doesn't enforce inert's actual focus-blocking
+      // behavior, so this asserts the DOM property our fix sets, which is what drives it.
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      const { container } = render(
+        <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
+      );
+
+      const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]') as HTMLElement & {
+        inert: boolean;
+      };
+      expect(drawer.inert).toBe(true);
+
+      fireEvent.click(screen.getByRole("button", { name: "Open navigation" }));
+      expect(drawer.inert).toBe(false);
+
+      fireEvent.click(screen.getByRole("button", { name: "Close navigation" }));
+      expect(drawer.inert).toBe(true);
+    });
+
+    it("moves focus into the drawer on open and restores it to the trigger on close", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      const { container } = render(
+        <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
+      );
+
+      const trigger = screen.getByRole("button", { name: "Open navigation" });
+      fireEvent.click(trigger);
+
+      const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]');
+      expect(document.activeElement).toBe(drawer);
+
+      fireEvent.click(screen.getByRole("button", { name: "Close navigation" }));
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it("closes the mobile drawer when Escape is pressed", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      const { container } = render(
+        <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Open navigation" }));
+      const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]') as HTMLElement;
+      expect(drawer).toHaveAttribute("aria-hidden", "false");
+
+      fireEvent.keyDown(drawer, { key: "Escape" });
+      expect(drawer).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("traps Tab focus within the open drawer, wrapping at both ends", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      const { container } = render(
+        <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Open navigation" }));
+      const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]') as HTMLElement;
+      const focusable = drawer.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      last.focus();
+      fireEvent.keyDown(drawer, { key: "Tab" });
+      expect(document.activeElement).toBe(first);
+
+      first.focus();
+      fireEvent.keyDown(drawer, { key: "Tab", shiftKey: true });
+      expect(document.activeElement).toBe(last);
     });
   });
 

--- a/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/documentation-layout.test.tsx
@@ -1,0 +1,363 @@
+// documentation-layout.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/* ------------------ HOISTED MOCKS (must be before importing component) ------------------ */
+vi.mock("lucide-react", () => ({
+  ChevronDown: () => <div data-testid="chevron-down-icon" />,
+  ChevronRight: () => <div data-testid="chevron-right-icon" />,
+  Menu: () => <div data-testid="menu-icon" />,
+  X: () => <div data-testid="x-icon" />,
+  ArrowLeft: () => <div data-testid="arrow-left-icon" />,
+  ArrowRight: () => <div data-testid="arrow-right-icon" />,
+  Pencil: () => <div data-testid="pencil-icon" />,
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    aside: React.forwardRef(({ children, initial: _i, animate: _a, transition: _t, ...props }: any, ref: any) => (
+      <aside ref={ref} {...props}>{children}</aside>
+    )),
+    div: React.forwardRef(({ children, initial: _i, animate: _a, exit: _e, ...props }: any, ref: any) => (
+      <div ref={ref} {...props}>{children}</div>
+    )),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+/* ------------------ Now import the component under test ------------------ */
+import { DocumentationLayout, type DocNavSection, type TocHeading } from ".";
+
+const navSections: DocNavSection[] = [
+  {
+    label: "Getting Started",
+    items: [
+      { label: "Introduction", href: "/intro", active: true },
+      { label: "Installation", href: "/install" },
+    ],
+  },
+  {
+    label: "Guides",
+    items: [
+      {
+        label: "Advanced",
+        items: [
+          { label: "Theming", href: "/theming" },
+          { label: "Plugins", href: "/plugins" },
+        ],
+      },
+    ],
+  },
+];
+
+const tocHeadings: TocHeading[] = [
+  { id: "overview", label: "Overview" },
+  { id: "usage", label: "Usage", depth: 3 },
+];
+
+describe("DocumentationLayout", () => {
+  beforeEach(() => {
+    global.innerWidth = 1280;
+  });
+
+  describe("rendering", () => {
+    it("renders children in the main content area", () => {
+      render(
+        <DocumentationLayout>
+          <p>Page body</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("main")).toHaveTextContent("Page body");
+    });
+
+    it("renders header, searchSlot, and actions", () => {
+      render(
+        <DocumentationLayout
+          header={<span>Logo</span>}
+          searchSlot={<input placeholder="Search docs" />}
+          actions={<button>GitHub</button>}
+        >
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByText("Logo")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Search docs")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "GitHub" })).toBeInTheDocument();
+    });
+
+    it("renders the page title as an h1", () => {
+      render(<DocumentationLayout title="Getting Started"><p>Body</p></DocumentationLayout>);
+      expect(screen.getByRole("heading", { level: 1, name: "Getting Started" })).toBeInTheDocument();
+    });
+
+    it("renders a custom sidebar override instead of navSections", () => {
+      render(
+        <DocumentationLayout sidebar={<div>Custom Sidebar</div>} navSections={navSections}>
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByText("Custom Sidebar")).toBeInTheDocument();
+      expect(screen.queryByText("Introduction")).not.toBeInTheDocument();
+    });
+
+    it("applies a custom className to the root container", () => {
+      const { container } = render(
+        <DocumentationLayout className="custom-root"><p>Content</p></DocumentationLayout>
+      );
+      expect(container.firstChild).toHaveClass("custom-root");
+    });
+  });
+
+  describe("navigation sidebar", () => {
+    it("renders section labels and leaf links", () => {
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      expect(screen.getByText("Getting Started")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Introduction" })).toHaveAttribute("href", "/intro");
+      expect(screen.getByRole("link", { name: "Installation" })).toHaveAttribute("href", "/install");
+    });
+
+    it("marks the active item with aria-current", () => {
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      expect(screen.getByRole("link", { name: "Introduction" })).toHaveAttribute("aria-current", "page");
+      expect(screen.getByRole("link", { name: "Installation" })).not.toHaveAttribute("aria-current");
+    });
+
+    it("auto-expands a group that contains no active descendant only after being toggled", () => {
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      // "Advanced" has no active descendant, so its children start collapsed.
+      expect(screen.queryByRole("link", { name: "Theming" })).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Expand Advanced" }));
+      expect(screen.getByRole("link", { name: "Theming" })).toBeInTheDocument();
+    });
+
+    it("collapses an expanded group when toggled again", () => {
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      fireEvent.click(screen.getByRole("button", { name: "Expand Advanced" }));
+      expect(screen.getByRole("link", { name: "Theming" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Collapse Advanced" }));
+      expect(screen.queryByRole("link", { name: "Theming" })).not.toBeInTheDocument();
+    });
+
+    it("also expands and collapses a group when its label text is clicked", () => {
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      const label = screen.getByRole("button", { name: "Advanced" });
+      expect(label).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.click(label);
+      expect(screen.getByRole("link", { name: "Theming" })).toBeInTheDocument();
+      expect(label).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.click(label);
+      expect(screen.queryByRole("link", { name: "Theming" })).not.toBeInTheDocument();
+      expect(label).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  describe("breadcrumbs", () => {
+    it("renders breadcrumb links and marks the last one as the current page", () => {
+      render(
+        <DocumentationLayout
+          breadcrumbs={[
+            { label: "Docs", href: "/docs" },
+            { label: "Components", href: "/docs/components" },
+          ]}
+        >
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute("href", "/docs");
+      const current = screen.getByText("Components");
+      expect(current).toHaveAttribute("aria-current", "page");
+      expect(current.tagName).not.toBe("A");
+    });
+
+    it("renders every breadcrumb even when hrefs are duplicated (e.g. placeholder '#' links)", () => {
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      render(
+        <DocumentationLayout
+          breadcrumbs={[
+            { label: "Docs", href: "#" },
+            { label: "Templates", href: "#" },
+            { label: "Documentation Layout", href: "#" },
+          ]}
+        >
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getAllByRole("link", { name: /Docs|Templates/ })).toHaveLength(2);
+      expect(screen.getByText("Documentation Layout")).toHaveAttribute("aria-current", "page");
+      // React logs a "two children with the same key" warning via console.error
+      // when list keys collide - duplicate hrefs must not trigger that.
+      const keyWarning = warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes("same key")
+      );
+      expect(keyWarning).toBe(false);
+      warnSpy.mockRestore();
+    });
+
+    it("does not render a breadcrumb nav when omitted", () => {
+      render(<DocumentationLayout><p>Content</p></DocumentationLayout>);
+      expect(screen.queryByRole("navigation", { name: "Breadcrumb" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("page navigation footer", () => {
+    it("renders previous/next page links", () => {
+      render(
+        <DocumentationLayout
+          previousPage={{ label: "Installation", href: "/install" }}
+          nextPage={{ label: "Configuration", href: "/config" }}
+        >
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("link", { name: /Installation/ })).toHaveAttribute("href", "/install");
+      expect(screen.getByRole("link", { name: /Configuration/ })).toHaveAttribute("href", "/config");
+    });
+
+    it("renders an edit-this-page link when editPageUrl is provided", () => {
+      render(
+        <DocumentationLayout editPageUrl="https://github.com/org/repo/edit/main/page.mdx">
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("link", { name: /Edit this page/ })).toHaveAttribute(
+        "href",
+        "https://github.com/org/repo/edit/main/page.mdx"
+      );
+    });
+
+    it("renders neither prev/next nor edit link, and no divider, when none are provided", () => {
+      render(<DocumentationLayout><p>Content</p></DocumentationLayout>);
+      expect(screen.queryByRole("navigation", { name: "Page navigation" })).not.toBeInTheDocument();
+      expect(screen.queryByText(/Edit this page/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("table of contents", () => {
+    it("renders tocHeadings as anchor links", () => {
+      render(<DocumentationLayout tocHeadings={tocHeadings}><p>Content</p></DocumentationLayout>);
+      expect(screen.getByRole("link", { name: "Overview" })).toHaveAttribute("href", "#overview");
+      expect(screen.getByRole("link", { name: "Usage" })).toHaveAttribute("href", "#usage");
+    });
+
+    it("renders a custom toc override instead of tocHeadings", () => {
+      render(
+        <DocumentationLayout toc={<div>Custom TOC</div>} tocHeadings={tocHeadings}>
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByText("Custom TOC")).toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Overview" })).not.toBeInTheDocument();
+    });
+
+    it("does not render a table-of-contents complementary region when omitted", () => {
+      render(<DocumentationLayout><p>Content</p></DocumentationLayout>);
+      expect(screen.queryByRole("complementary", { name: "Table of contents" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("scroll-spy (IntersectionObserver)", () => {
+    it("observes each heading element when IntersectionObserver is available", () => {
+      const observe = vi.fn();
+      const disconnect = vi.fn();
+      class MockIntersectionObserver {
+        constructor(_cb: IntersectionObserverCallback) {
+          void _cb;
+        }
+        observe = observe;
+        disconnect = disconnect;
+        unobserve = vi.fn();
+        takeRecords = vi.fn();
+      }
+      vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+      const overview = document.createElement("div");
+      overview.id = "overview";
+      document.body.appendChild(overview);
+
+      render(<DocumentationLayout tocHeadings={tocHeadings}><p>Content</p></DocumentationLayout>);
+
+      expect(observe).toHaveBeenCalledWith(overview);
+
+      document.body.removeChild(overview);
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("responsive behavior", () => {
+    it("renders the desktop sidebar (no hamburger) at desktop widths", () => {
+      global.innerWidth = 1280;
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      expect(screen.getByRole("complementary", { name: "Sidebar navigation" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Open navigation" })).not.toBeInTheDocument();
+    });
+
+    it("hides the desktop sidebar and shows a hamburger toggle at mobile widths", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+      expect(screen.queryByRole("complementary", { name: "Sidebar navigation" })).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open navigation" })).toBeInTheDocument();
+    });
+
+    it("opens the mobile drawer when the hamburger button is clicked", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      render(<DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>);
+
+      const toggle = screen.getByRole("button", { name: "Open navigation" });
+      fireEvent.click(toggle);
+
+      expect(screen.getByRole("complementary", { name: "Mobile sidebar navigation" })).toHaveAttribute(
+        "aria-hidden",
+        "false"
+      );
+      expect(screen.getByRole("button", { name: "Close navigation" })).toBeInTheDocument();
+    });
+
+    it("closes the mobile drawer when a nav link is clicked", () => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event("resize"));
+      const { container } = render(
+        <DocumentationLayout navSections={navSections}><p>Content</p></DocumentationLayout>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Open navigation" }));
+      const mobileLinks = screen.getAllByRole("link", { name: "Introduction" });
+      fireEvent.click(mobileLinks[mobileLinks.length - 1]);
+
+      // Once closed, the drawer is aria-hidden, which `getByRole` correctly
+      // excludes from the accessibility tree by default (mirroring assistive
+      // tech) - so this specific check queries the raw DOM attribute instead.
+      const drawer = container.querySelector('[aria-label="Mobile sidebar navigation"]');
+      expect(drawer).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("landmarks", () => {
+    it("exposes banner, main, and contentinfo roles", () => {
+      render(
+        <DocumentationLayout footer={<span>Footer</span>}>
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+      expect(screen.getByRole("main")).toBeInTheDocument();
+      expect(screen.getByRole("contentinfo")).toHaveTextContent("Footer");
+    });
+  });
+
+  describe("sizing", () => {
+    it("applies sidebarWidth and tocWidth as inline styles", () => {
+      render(
+        <DocumentationLayout navSections={navSections} tocHeadings={tocHeadings} sidebarWidth={320} tocWidth={200}>
+          <p>Content</p>
+        </DocumentationLayout>
+      );
+      expect(screen.getByRole("complementary", { name: "Sidebar navigation" })).toHaveStyle({ width: "320px" });
+      expect(screen.getByRole("complementary", { name: "Table of contents" })).toHaveStyle({ width: "200px" });
+    });
+  });
+});

--- a/packages/registry/templates/layouts/documentation-layout/index.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/index.tsx
@@ -1,0 +1,492 @@
+import * as React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ChevronRight, Menu, X, ArrowLeft, ArrowRight, Pencil } from "lucide-react";
+import { cn } from "../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A single entry in the left navigation tree. Entries without `href` render
+ * as a non-clickable group label; entries with nested `items` are
+ * collapsible, auto-expanding when one of their descendants is `active`.
+ */
+export interface DocNavItem {
+  label: string;
+  href?: string;
+  active?: boolean;
+  items?: DocNavItem[];
+}
+
+/** A labeled group of {@link DocNavItem} entries in the left sidebar. */
+export interface DocNavSection {
+  label?: string;
+  items: DocNavItem[];
+}
+
+/** A heading tracked by the right-hand "On this page" table of contents. */
+export interface TocHeading {
+  /** Must match the `id` of the corresponding heading element on the page. */
+  id: string;
+  label: string;
+  /** Nesting level, used for indentation. Defaults to `2`. */
+  depth?: 2 | 3;
+}
+
+/** A labeled link, used for breadcrumbs and prev/next page navigation. */
+export interface DocPageLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * Props for the {@link DocumentationLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the header (e.g. a logo/title).
+ * @property searchSlot - Optional node rendered in the header (e.g. a search box).
+ * @property actions - Optional node rendered at the end of the header (e.g. theme toggle, GitHub link).
+ * @property navSections - Left sidebar navigation, grouped into labeled sections.
+ * @property sidebar - Fully custom left sidebar content; overrides `navSections`.
+ * @property tocHeadings - Headings for the right "On this page" panel; the active one is
+ * tracked automatically via scroll position (`IntersectionObserver`).
+ * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
+ * @property title - Optional page title (rendered as the page's `<h1>`).
+ * @property children - Page content.
+ * @property previousPage - Optional "previous page" link rendered below the content.
+ * @property nextPage - Optional "next page" link rendered below the content.
+ * @property editPageUrl - Optional "Edit this page" link rendered below the content.
+ * @property footer - Optional site footer, rendered below everything else.
+ * @property sidebarWidth - Left sidebar width in px. Default `280`.
+ * @property tocWidth - Right "On this page" panel width in px. Default `240`.
+ * @property mobileBreakpoint - Breakpoint below which the left sidebar collapses into a
+ * drawer opened via a hamburger button. Default `"lg"`.
+ * @property className - Class name for the root container.
+ */
+export interface DocumentationLayoutProps {
+  header?: React.ReactNode;
+  searchSlot?: React.ReactNode;
+  actions?: React.ReactNode;
+  navSections?: DocNavSection[];
+  sidebar?: React.ReactNode;
+  tocHeadings?: TocHeading[];
+  toc?: React.ReactNode;
+  breadcrumbs?: DocPageLink[];
+  title?: string;
+  children: React.ReactNode;
+  previousPage?: DocPageLink;
+  nextPage?: DocPageLink;
+  editPageUrl?: string;
+  footer?: React.ReactNode;
+  sidebarWidth?: number;
+  tocWidth?: number;
+  mobileBreakpoint?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              HELPERS & HOOKS                               */
+/* -------------------------------------------------------------------------- */
+
+function itemsContainActive(items: DocNavItem[]): boolean {
+  return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
+}
+
+/** Labels of every group that has an active descendant, so they render pre-expanded. */
+function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
+  for (const item of items) {
+    if (item.items?.length && itemsContainActive(item.items)) {
+      acc.add(item.label);
+      collectExpandedAncestors(item.items, acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
+ * so the right-hand "On this page" panel can highlight it. Falls back to `null`
+ * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ */
+function useActiveHeading(headings?: TocHeading[]): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!headings || headings.length === 0) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return activeId;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              NAV TREE                                      */
+/* -------------------------------------------------------------------------- */
+
+const DocNavTree: React.FC<{
+  items: DocNavItem[];
+  expanded: Set<string>;
+  onToggle: (label: string) => void;
+  onNavigate?: () => void;
+  depth?: number;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
+    {items.map((item) => {
+      const hasChildren = !!item.items?.length;
+      const isExpanded = hasChildren && expanded.has(item.label);
+
+      return (
+        <li key={item.label}>
+          <div className="flex items-center">
+            {item.href ? (
+              <a
+                href={item.href}
+                aria-current={item.active ? "page" : undefined}
+                onClick={onNavigate}
+                className={cn(
+                  "flex-1 block px-3 py-1.5 rounded-md text-sm transition-colors",
+                  item.active
+                    ? "bg-[var(--primary)]/10 text-[var(--primary)] font-medium"
+                    : "text-[var(--foreground)] hover:bg-[var(--accent)]"
+                )}
+              >
+                {item.label}
+              </a>
+            ) : hasChildren ? (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span className="flex-1 px-3 py-1.5 text-sm font-semibold text-[var(--foreground)]">
+                {item.label}
+              </span>
+            )}
+            {hasChildren && (
+              <button
+                type="button"
+                onClick={() => onToggle(item.label)}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
+                className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              </button>
+            )}
+          </div>
+          {hasChildren && isExpanded && (
+            <DocNavTree
+              items={item.items!}
+              expanded={expanded}
+              onToggle={onToggle}
+              onNavigate={onNavigate}
+              depth={depth + 1}
+            />
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * DocumentationLayout is a full-page shell for documentation/reference sites:
+ * a sticky header, a collapsible-tree left navigation sidebar (a drawer on
+ * mobile), the page content, and a right-hand "On this page" panel whose
+ * active heading tracks scroll position automatically. Breadcrumbs, a page
+ * title, and prev/next page links are optional and rendered around the
+ * content when provided.
+ */
+export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
+  header,
+  searchSlot,
+  actions,
+  navSections,
+  sidebar,
+  tocHeadings,
+  toc,
+  breadcrumbs,
+  title,
+  children,
+  previousPage,
+  nextPage,
+  editPageUrl,
+  footer,
+  sidebarWidth = 280,
+  tocWidth = 240,
+  mobileBreakpoint = "lg",
+  className,
+}) => {
+  const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
+
+  React.useEffect(() => {
+    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [mobileBp]);
+
+  const [expanded, setExpanded] = React.useState<Set<string>>(() =>
+    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+  );
+
+  const toggleExpanded = React.useCallback((label: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  }, []);
+
+  const activeHeadingId = useActiveHeading(tocHeadings);
+
+  const hasLeftNav = !!(sidebar || navSections);
+  const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  const renderNav = (onNavigate?: () => void): React.ReactNode => {
+    if (sidebar) return sidebar;
+    if (!navSections) return null;
+    return (
+      <nav className="space-y-6 p-4" aria-label="Documentation navigation">
+        {navSections.map((section, index) => (
+          <div key={section.label ?? index}>
+            {section.label && (
+              <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                {section.label}
+              </h2>
+            )}
+            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+          </div>
+        ))}
+      </nav>
+    );
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
+    >
+      {/* HEADER */}
+      <header
+        className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+        role="banner"
+      >
+        {hasLeftNav && isMobile && (
+          <button
+            type="button"
+            onClick={() => setIsMobileNavOpen((open) => !open)}
+            aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
+            aria-expanded={isMobileNavOpen}
+            className="shrink-0 rounded-md p-2 text-[var(--foreground)] hover:bg-[var(--accent)]"
+          >
+            {isMobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        )}
+        {header && <div className="flex shrink-0 items-center">{header}</div>}
+        {searchSlot && <div className="min-w-0 flex-1 md:max-w-sm">{searchSlot}</div>}
+        {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+      </header>
+
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1">
+        {/* LEFT SIDEBAR - desktop */}
+        {hasLeftNav && !isMobile && (
+          <aside
+            className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
+            style={{ width: sidebarWidth }}
+            role="complementary"
+            aria-label="Sidebar navigation"
+          >
+            {renderNav()}
+          </aside>
+        )}
+
+        {/* LEFT SIDEBAR - mobile drawer */}
+        {hasLeftNav && isMobile && (
+          <>
+            <AnimatePresence>
+              {isMobileNavOpen && (
+                <motion.div
+                  className="fixed inset-0 z-40 bg-black/50"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  onClick={() => setIsMobileNavOpen(false)}
+                  aria-hidden="true"
+                />
+              )}
+            </AnimatePresence>
+            <motion.aside
+              className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
+              style={{ width: sidebarWidth }}
+              initial={false}
+              animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
+              transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              role="complementary"
+              aria-label="Mobile sidebar navigation"
+              aria-hidden={!isMobileNavOpen}
+            >
+              {renderNav(() => setIsMobileNavOpen(false))}
+            </motion.aside>
+          </>
+        )}
+
+        {/* MAIN CONTENT */}
+        <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
+          <div className="mx-auto max-w-3xl">
+            {breadcrumbs && breadcrumbs.length > 0 && (
+              <nav aria-label="Breadcrumb" className="mb-4">
+                <ol className="flex flex-wrap items-center gap-1.5 text-sm text-[var(--muted-foreground)]">
+                  {breadcrumbs.map((crumb, index) => (
+                    <li key={`${crumb.label}-${index}`} className="flex items-center gap-1.5">
+                      {index > 0 && <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
+                      {index === breadcrumbs.length - 1 ? (
+                        <span aria-current="page" className="text-[var(--foreground)]">
+                          {crumb.label}
+                        </span>
+                      ) : (
+                        <a href={crumb.href} className="hover:text-[var(--foreground)]">
+                          {crumb.label}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            {title && <h1 className="mb-6 text-3xl font-bold tracking-tight text-[var(--foreground)]">{title}</h1>}
+
+            {children}
+
+            {(previousPage || nextPage || editPageUrl) && (
+              <div className="mt-12 border-t border-[var(--border)] pt-6">
+                {editPageUrl && (
+                  <a
+                    href={editPageUrl}
+                    className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                  >
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    Edit this page
+                  </a>
+                )}
+                {(previousPage || nextPage) && (
+                  <nav aria-label="Page navigation" className="flex items-stretch gap-4">
+                    {previousPage ? (
+                      <a
+                        href={previousPage.href}
+                        className="flex flex-1 flex-col items-start gap-1 rounded-lg border border-[var(--border)] p-4 text-left transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                          Previous
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{previousPage.label}</span>
+                      </a>
+                    ) : (
+                      <span className="flex-1" />
+                    )}
+                    {nextPage && (
+                      <a
+                        href={nextPage.href}
+                        className="flex flex-1 flex-col items-end gap-1 rounded-lg border border-[var(--border)] p-4 text-right transition-colors hover:bg-[var(--accent)]"
+                      >
+                        <span className="flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+                          Next
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </span>
+                        <span className="text-sm font-medium text-[var(--foreground)]">{nextPage.label}</span>
+                      </a>
+                    )}
+                  </nav>
+                )}
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* RIGHT SIDEBAR - "On this page" */}
+        {hasToc && !isMobile && (
+          <aside
+            className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
+            style={{ width: tocWidth }}
+            role="complementary"
+            aria-label="Table of contents"
+          >
+            {toc ? (
+              toc
+            ) : tocHeadings ? (
+              <>
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                  On this page
+                </h2>
+                <ul className="space-y-1.5 border-l border-[var(--border)]">
+                  {tocHeadings.map((heading) => {
+                    const isActive = heading.id === activeHeadingId;
+                    return (
+                      <li key={heading.id} style={{ paddingLeft: heading.depth === 3 ? 24 : 12 }}>
+                        <a
+                          href={`#${heading.id}`}
+                          aria-current={isActive ? "location" : undefined}
+                          className={cn(
+                            "-ml-px block border-l-2 pl-3 text-sm transition-colors",
+                            isActive
+                              ? "border-[var(--primary)] font-medium text-[var(--primary)]"
+                              : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                          )}
+                        >
+                          {heading.label}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : null}
+          </aside>
+        )}
+      </div>
+
+      {/* FOOTER */}
+      {footer && (
+        <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
+          {footer}
+        </footer>
+      )}
+    </div>
+  );
+};
+
+DocumentationLayout.displayName = "DocumentationLayout";
+
+export default DocumentationLayout;

--- a/packages/registry/templates/layouts/documentation-layout/index.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/index.tsx
@@ -116,14 +116,9 @@ function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: 
 }
 
 /**
- * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
- * so the right-hand "On this page" panel can highlight it. Falls back to `null`
- * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
- *
- * `root` defaults to the browser viewport, matching the common case where this layout
- * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
- * a scrollable container instead, so headings are measured against that container's
- * visible area rather than the (possibly unrelated) viewport.
+ * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`, so the
+ * right-hand "On this page" panel can highlight it. Falls back to `null` in environments
+ * without `IntersectionObserver` (e.g. tests) instead of throwing.
  */
 function useActiveHeading(
   headings?: TocHeading[],
@@ -148,8 +143,6 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
-    // Read `.current` here (not at render time): refs attach during commit, after this
-    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         // `entries` order reflects browser-specific intersection-change batching, not document
@@ -407,7 +400,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
     <div
       className={cn("flex min-h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}
     >
-      {/* HEADER */}
       <header
         className="sticky top-0 z-40 flex h-16 w-full items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
         role="banner"
@@ -430,7 +422,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       </header>
 
       <div className="mx-auto flex w-full max-w-[1600px] flex-1">
-        {/* LEFT SIDEBAR - desktop */}
         {hasLeftNav && !isMobile && (
           <aside
             className="sticky top-16 h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)]"
@@ -442,7 +433,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </aside>
         )}
 
-        {/* LEFT SIDEBAR - mobile drawer */}
         {hasLeftNav && isMobile && (
           <>
             <AnimatePresence>
@@ -479,7 +469,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </>
         )}
 
-        {/* MAIN CONTENT */}
         <main className="min-w-0 flex-1 px-6 py-8 md:px-10" role="main">
           <div className="mx-auto max-w-3xl">
             {breadcrumbs && breadcrumbs.length > 0 && (
@@ -553,7 +542,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
           </div>
         </main>
 
-        {/* RIGHT SIDEBAR - "On this page" */}
         {hasToc && !isMobile && (
           <aside
             className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4 xl:block"
@@ -595,7 +583,6 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
         )}
       </div>
 
-      {/* FOOTER */}
       {footer && (
         <footer className="w-full border-t border-[var(--border)] bg-[var(--background)]" role="contentinfo">
           {footer}

--- a/packages/registry/templates/layouts/documentation-layout/index.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/index.tsx
@@ -143,14 +143,20 @@ function useActiveHeading(
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Persists across callback invocations rather than being rebuilt from just this batch's
+    // `entries` - IntersectionObserver only reports entries whose intersection state just
+    // changed, so a heading that's still visible without changing wouldn't appear in `entries`
+    // at all, and a fresh-each-time set would incorrectly drop it.
+    const visibleIds = new Set<string>();
     const observer = new IntersectionObserver(
       (entries) => {
-        // `entries` order reflects browser-specific intersection-change batching, not document
-        // order, so when multiple headings cross the threshold in the same batch, pick whichever
-        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
-        const visibleIds = new Set(
-          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
-        );
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        });
+        // `currentHeadings` order (not `entries` order, which reflects browser-specific
+        // intersection-change batching) decides which visible heading wins when more than one
+        // is visible at once.
         const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
         if (firstVisible) {
           setActiveId(firstVisible.id);
@@ -330,6 +336,21 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       mobileDrawerRef.current.inert = !isMobileNavOpen;
     }
   }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Resets eagerly at the start of every open/close transition, not just via
+  // onAnimationComplete below - otherwise closing before the open transition has finished
+  // (isDrawerFullyClosed still `true` from before) would drop visibility to "hidden"
+  // immediately, clipping the close animation instead of letting it slide out. useLayoutEffect
+  // (not useEffect) so this resolves before the browser paints that intermediate state. Skips
+  // the initial mount so the drawer still starts genuinely hidden before it's ever been opened.
+  const hasMountedDrawerRef = React.useRef(false);
+  React.useLayoutEffect(() => {
+    if (!hasMountedDrawerRef.current) {
+      hasMountedDrawerRef.current = true;
+      return;
+    }
+    setIsDrawerFullyClosed(false);
+  }, [isMobileNavOpen]);
 
   // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
   // focus to the hamburger trigger on close. Skips the very first run so mounting with the

--- a/packages/registry/templates/layouts/documentation-layout/index.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/index.tsx
@@ -152,9 +152,15 @@ function useActiveHeading(
     // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length > 0) {
-          setActiveId(visible[0].target.id);
+        // `entries` order reflects browser-specific intersection-change batching, not document
+        // order, so when multiple headings cross the threshold in the same batch, pick whichever
+        // is first in `currentHeadings` (reading order) rather than trusting `entries[0]`.
+        const visibleIds = new Set(
+          entries.filter((entry) => entry.isIntersecting).map((entry) => entry.target.id)
+        );
+        const firstVisible = currentHeadings.find((heading) => visibleIds.has(heading.id));
+        if (firstVisible) {
+          setActiveId(firstVisible.id);
         }
       },
       { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
@@ -287,9 +293,12 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
-  const [isMobile, setIsMobile] = React.useState(() =>
-    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
-  );
+  // Starts `false` unconditionally (not derived from `window.innerWidth`) so server and client
+  // render the same markup on first paint; the mount effect below corrects it via `matchMedia`
+  // right after hydration. Deriving this from `window` would only match on truly client-only
+  // renders - during SSR hydration the client's own first pass already sees `window`, so the
+  // guard doesn't help there and the two renders could still disagree.
+  const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;

--- a/packages/registry/templates/layouts/documentation-layout/index.tsx
+++ b/packages/registry/templates/layouts/documentation-layout/index.tsx
@@ -51,6 +51,10 @@ export interface DocPageLink {
  * @property tocHeadings - Headings for the right "On this page" panel; the active one is
  * tracked automatically via scroll position (`IntersectionObserver`).
  * @property toc - Fully custom right sidebar content; overrides `tocHeadings`.
+ * @property scrollContainerRef - Ref to the scrollable ancestor that actually scrolls the
+ * page content, used as the `IntersectionObserver` root for the scroll-spy. Only needed when
+ * this layout is rendered inside a scrollable container instead of the document itself (e.g.
+ * an embedded preview); omit it when the layout owns page-level scroll.
  * @property breadcrumbs - Optional breadcrumb trail rendered above the title.
  * @property title - Optional page title (rendered as the page's `<h1>`).
  * @property children - Page content.
@@ -72,6 +76,7 @@ export interface DocumentationLayoutProps {
   sidebar?: React.ReactNode;
   tocHeadings?: TocHeading[];
   toc?: React.ReactNode;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
   breadcrumbs?: DocPageLink[];
   title?: string;
   children: React.ReactNode;
@@ -93,14 +98,20 @@ function itemsContainActive(items: DocNavItem[]): boolean {
   return items.some((item) => item.active || (item.items ? itemsContainActive(item.items) : false));
 }
 
-/** Labels of every group that has an active descendant, so they render pre-expanded. */
-function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Set()): Set<string> {
-  for (const item of items) {
+/**
+ * Tree-position paths (not labels) of every group that has an active descendant, so they
+ * render pre-expanded. Paths (e.g. "s0-1-0") are used instead of labels throughout the nav
+ * tree's expand/collapse state so that two groups sharing the same label in different
+ * branches - a common case with a generic name like "Overview" - expand independently.
+ */
+function collectExpandedAncestors(items: DocNavItem[], parentPath: string, acc: Set<string> = new Set()): Set<string> {
+  items.forEach((item, index) => {
+    const path = `${parentPath}-${index}`;
     if (item.items?.length && itemsContainActive(item.items)) {
-      acc.add(item.label);
-      collectExpandedAncestors(item.items, acc);
+      acc.add(path);
+      collectExpandedAncestors(item.items, path, acc);
     }
-  }
+  });
   return acc;
 }
 
@@ -108,19 +119,37 @@ function collectExpandedAncestors(items: DocNavItem[], acc: Set<string> = new Se
  * Tracks which {@link TocHeading} is currently in view via `IntersectionObserver`,
  * so the right-hand "On this page" panel can highlight it. Falls back to `null`
  * in environments without `IntersectionObserver` (e.g. tests) instead of throwing.
+ *
+ * `root` defaults to the browser viewport, matching the common case where this layout
+ * owns page-level scroll. Pass the layout's scrollable ancestor when it's embedded inside
+ * a scrollable container instead, so headings are measured against that container's
+ * visible area rather than the (possibly unrelated) viewport.
  */
-function useActiveHeading(headings?: TocHeading[]): string | null {
+function useActiveHeading(
+  headings?: TocHeading[],
+  scrollContainerRef?: React.RefObject<HTMLElement | null>
+): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
+  // Consumers commonly pass an inline array literal (see the Usage docs), which gets a new
+  // identity every render. Keying the effect on a derived id string - instead of the array
+  // reference - avoids tearing down and recreating the observer on every unrelated re-render.
+  const headingsRef = React.useRef(headings);
+  headingsRef.current = headings;
+  const headingIds = headings?.map((heading) => heading.id).join(",") ?? "";
+
   React.useEffect(() => {
-    if (!headings || headings.length === 0) return;
+    const currentHeadings = headingsRef.current;
+    if (!currentHeadings || currentHeadings.length === 0) return;
     if (typeof IntersectionObserver === "undefined") return;
 
-    const elements = headings
+    const elements = currentHeadings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);
     if (elements.length === 0) return;
 
+    // Read `.current` here (not at render time): refs attach during commit, after this
+    // component's own render but before this effect runs, so it's already populated.
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries.filter((entry) => entry.isIntersecting);
@@ -128,12 +157,12 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
           setActiveId(visible[0].target.id);
         }
       },
-      { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+      { root: scrollContainerRef?.current ?? null, rootMargin: "0px 0px -70% 0px", threshold: 0 }
     );
 
     elements.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [headings]);
+  }, [headingIds, scrollContainerRef]);
 
   return activeId;
 }
@@ -145,17 +174,19 @@ function useActiveHeading(headings?: TocHeading[]): string | null {
 const DocNavTree: React.FC<{
   items: DocNavItem[];
   expanded: Set<string>;
-  onToggle: (label: string) => void;
+  onToggle: (path: string) => void;
   onNavigate?: () => void;
   depth?: number;
-}> = ({ items, expanded, onToggle, onNavigate, depth = 0 }) => (
+  parentPath: string;
+}> = ({ items, expanded, onToggle, onNavigate, depth = 0, parentPath }) => (
   <ul className={cn("space-y-0.5", depth > 0 && "ml-3 mt-0.5 border-l border-[var(--border)] pl-3")}>
-    {items.map((item) => {
+    {items.map((item, index) => {
+      const path = `${parentPath}-${index}`;
       const hasChildren = !!item.items?.length;
-      const isExpanded = hasChildren && expanded.has(item.label);
+      const isExpanded = hasChildren && expanded.has(path);
 
       return (
-        <li key={item.label}>
+        <li key={path}>
           <div className="flex items-center">
             {item.href ? (
               <a
@@ -174,7 +205,7 @@ const DocNavTree: React.FC<{
             ) : hasChildren ? (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 className="flex-1 rounded-md px-3 py-1.5 text-left text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--accent)]"
               >
@@ -188,7 +219,7 @@ const DocNavTree: React.FC<{
             {hasChildren && (
               <button
                 type="button"
-                onClick={() => onToggle(item.label)}
+                onClick={() => onToggle(path)}
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${item.label}`}
                 className="shrink-0 p-1.5 rounded-md text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
@@ -204,6 +235,7 @@ const DocNavTree: React.FC<{
               onToggle={onToggle}
               onNavigate={onNavigate}
               depth={depth + 1}
+              parentPath={path}
             />
           )}
         </li>
@@ -232,6 +264,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   sidebar,
   tocHeadings,
   toc,
+  scrollContainerRef,
   breadcrumbs,
   title,
   children,
@@ -245,34 +278,96 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
   className,
 }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(false);
+  // Tracks whether the close slide-out has actually finished (via onAnimationComplete below),
+  // so `visibility: hidden` only applies once it's done - not the instant `isMobileNavOpen`
+  // flips false, which would clip the exit animation instead of letting it play out.
+  const [isDrawerFullyClosed, setIsDrawerFullyClosed] = React.useState(true);
+  const mobileDrawerRef = React.useRef<HTMLElement>(null);
+  const mobileNavTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   const mobileBp = mobileBreakpoint === "sm" ? 640 : mobileBreakpoint === "md" ? 768 : 1024;
 
+  const [isMobile, setIsMobile] = React.useState(() =>
+    typeof window !== "undefined" ? window.innerWidth < mobileBp : false
+  );
+
   React.useEffect(() => {
-    const check = (): void => setIsMobile(window.innerWidth < mobileBp);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(`(max-width: ${mobileBp - 1}px)`);
+    setIsMobile(mediaQuery.matches);
+    const handleChange = (event: MediaQueryListEvent): void => setIsMobile(event.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [mobileBp]);
 
   const [expanded, setExpanded] = React.useState<Set<string>>(() =>
-    navSections ? navSections.reduce((acc, section) => collectExpandedAncestors(section.items, acc), new Set<string>()) : new Set()
+    navSections
+      ? navSections.reduce((acc, section, index) => collectExpandedAncestors(section.items, `s${index}`, acc), new Set<string>())
+      : new Set()
   );
 
-  const toggleExpanded = React.useCallback((label: string) => {
+  const toggleExpanded = React.useCallback((path: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(label)) next.delete(label);
-      else next.add(label);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
       return next;
     });
   }, []);
 
-  const activeHeadingId = useActiveHeading(tocHeadings);
+  const activeHeadingId = useActiveHeading(tocHeadings, scrollContainerRef);
 
   const hasLeftNav = !!(sidebar || navSections);
   const hasToc = !!(toc || (tocHeadings && tocHeadings.length > 0));
+
+  // `aria-hidden` alone doesn't stop the closed drawer's links from being keyboard-focusable.
+  // `inert` (not yet in framer-motion's HTMLMotionProps types) is set imperatively via the DOM
+  // property instead, so focus/tab order and clicks are actually blocked while it's off-screen.
+  React.useEffect(() => {
+    if (mobileDrawerRef.current) {
+      mobileDrawerRef.current.inert = !isMobileNavOpen;
+    }
+  }, [isMobileNavOpen, isMobile, hasLeftNav]);
+
+  // Dialog-like focus behavior for the mobile drawer: move focus into it on open, restore
+  // focus to the hamburger trigger on close. Skips the very first run so mounting with the
+  // drawer already closed doesn't yank focus onto the (not-yet-clicked) trigger button.
+  const hasOpenedDrawerRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasOpenedDrawerRef.current) {
+      hasOpenedDrawerRef.current = true;
+      return;
+    }
+    if (isMobileNavOpen) {
+      mobileDrawerRef.current?.focus();
+    } else {
+      mobileNavTriggerRef.current?.focus();
+    }
+  }, [isMobileNavOpen]);
+
+  const handleDrawerKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    if (event.key === "Escape") {
+      setIsMobileNavOpen(false);
+      return;
+    }
+    if (event.key !== "Tab" || !mobileDrawerRef.current) return;
+
+    // Trap focus within the open drawer: wrap Tab/Shift+Tab at its edges instead of
+    // letting focus escape into the (inert-but-visually-hidden) rest of the page.
+    const focusable = mobileDrawerRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const renderNav = (onNavigate?: () => void): React.ReactNode => {
     if (sidebar) return sidebar;
@@ -286,7 +381,13 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
                 {section.label}
               </h2>
             )}
-            <DocNavTree items={section.items} expanded={expanded} onToggle={toggleExpanded} onNavigate={onNavigate} />
+            <DocNavTree
+              items={section.items}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onNavigate={onNavigate}
+              parentPath={`s${index}`}
+            />
           </div>
         ))}
       </nav>
@@ -304,6 +405,7 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
       >
         {hasLeftNav && isMobile && (
           <button
+            ref={mobileNavTriggerRef}
             type="button"
             onClick={() => setIsMobileNavOpen((open) => !open)}
             aria-label={isMobileNavOpen ? "Close navigation" : "Open navigation"}
@@ -347,11 +449,18 @@ export const DocumentationLayout: React.FC<DocumentationLayoutProps> = ({
               )}
             </AnimatePresence>
             <motion.aside
+              ref={mobileDrawerRef}
+              tabIndex={-1}
+              onKeyDown={handleDrawerKeyDown}
               className="fixed inset-y-0 left-0 z-50 h-full overflow-y-auto bg-[var(--background)] shadow-2xl"
-              style={{ width: sidebarWidth }}
+              style={{
+                width: sidebarWidth,
+                visibility: isMobileNavOpen || !isDrawerFullyClosed ? "visible" : "hidden",
+              }}
               initial={false}
               animate={{ x: isMobileNavOpen ? 0 : "-100%" }}
               transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
+              onAnimationComplete={() => setIsDrawerFullyClosed(!isMobileNavOpen)}
               role="complementary"
               aria-label="Mobile sidebar navigation"
               aria-hidden={!isMobileNavOpen}


### PR DESCRIPTION
## Description


### What does this PR do?
Adds `DocumentationLayout`, a new production-ready composition template that provides the standard shell for documentation/reference sites: a sticky header with optional search/actions slots, a collapsible-tree left navigation sidebar (collapses into a drawer on mobile, expandable via either the chevron or the label text), page content with breadcrumbs and a title, previous/next page navigation, and a scroll-spy "On this page" panel that highlights the active heading as you scroll.

### Related Issues

- Implements one item from the #876 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

### In local machine
<img width="1901" height="1033" alt="image" src="https://github.com/user-attachments/assets/53de9ff1-900b-417d-95a3-c7b49b1727d2" />

### Docs
<img width="1884" height="1057" alt="image" src="https://github.com/user-attachments/assets/1f337cc2-d870-4ddc-947b-39c167651ab8" />

### Storybook
<img width="1866" height="1036" alt="image" src="https://github.com/user-attachments/assets/0f1bccf6-1a55-49ed-8703-cd6f36d78381" />



## Additional Context

- **Registry component**
  - Added the `DocumentationLayout` template at `packages/registry/templates/layouts/documentation-layout/index.tsx`.
  - Registered the template in `registry.json`.
  - The component is installable via:
    `ignix add component DocumentationLayout`

- **Storybook**
  - Added 8 stories under `Templates/Layouts/DocumentationLayout`, covering:
    - Default layout
    - Layout with actions
    - Nested navigation
    - Custom sidebar and TOC overrides
    - No-sidebar configuration
    - No-header configuration
    - Mobile view

- **Documentation**
  - Added a live interactive demo to the docs site.
  - Added the complete `documentation-layout.mdx` documentation page covering:
    - Installation
    - Usage
    - Props
---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Added the typed React `DocumentationLayout` component.
  - Added navigation, breadcrumbs, table of contents, page links, header, footer, and content slots.
  - Added nested collapsible navigation with configurable dimensions.
  - Added responsive mobile drawer navigation with focus management.
  - Added `IntersectionObserver` scroll-spy support with safe fallbacks.
  - Added custom sidebar and table-of-contents overrides.

- **Bug fixes**
  - Refined scroll-spy behavior.
  - Improved mobile viewport and navigation handling.
  - Added active-ancestor expansion for nested navigation.

- **Tooling / config changes**
  - Registered `DocumentationLayout` in `registry.json`.
  - Added `framer-motion` and `lucide-react` dependencies.
  - Added comprehensive tests for rendering, navigation, responsiveness, accessibility, sizing, overrides, and scroll-spy behavior.

- **Docs / Storybook updates**
  - Added documentation with installation, usage, API reference, and live examples.
  - Added the layout to the versioned documentation sidebar.
  - Added the `DocumentationLayoutDemo` component.
  - Added Storybook stories for default, actions, nested navigation, custom overrides, no-sidebar, no-header, and mobile configurations.

### Breaking changes
None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->