### PR TITLE
feat(component): add Infinite Canvas layout with docs and stories

### DIFF
--- a/apps/docs/src/components/Demo/InfiniteCanvasLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/InfiniteCanvasLayoutDemo.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import VariantSelector from './VariantSelector';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { InfiniteCanvasLayout, CanvasNode } from '@site/src/components/UI/infinite-canvas-layout';
+import { Sparkles, Github } from 'lucide-react';
+import { Navbar } from '@site/src/components/UI/navbar';
+
+const gridSizes = ['16', '24', '32', '48'];
+const maxZooms = ['1.5', '2', '2.5', '4'];
+
+const SampleCard = ({ label, color }: { label: string; color: string }) => (
+  <div
+    className="flex h-28 w-52 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md"
+    style={{ borderTopColor: color, borderTopWidth: 3 }}
+  >
+    {label}
+  </div>
+);
+
+const InfiniteCanvasLayoutDemo = () => {
+  const [gridSize, setGridSize] = useState<number>(32);
+  const [maxZoom, setMaxZoom] = useState<number>(2.5);
+
+  const codeString = `
+import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinitecanvaslayout';
+
+<InfiniteCanvasLayout
+  header={<span className="font-bold">Board</span>}
+  actions={<a href="https://github.com" aria-label="GitHub"><GithubIcon /></a>}
+  minZoom={0.25}
+  maxZoom={${maxZoom}}
+  gridSize={${gridSize}}
+>
+  <CanvasNode x={0} y={0}>
+    <Card label="Idea" />
+  </CanvasNode>
+  <CanvasNode x={320} y={80}>
+    <Card label="Sketch" />
+  </CanvasNode>
+  <CanvasNode x={80} y={280}>
+    <Card label="Draft" />
+  </CanvasNode>
+</InfiniteCanvasLayout>
+`;
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-4 justify-start sm:justify-end">
+        <VariantSelector
+          variants={gridSizes}
+          selectedVariant={gridSize.toString()}
+          onSelectVariant={(val) => setGridSize(Number(val))}
+          type="Grid Size"
+        />
+        <VariantSelector
+          variants={maxZooms}
+          selectedVariant={maxZoom.toString()}
+          onSelectVariant={(val) => setMaxZoom(Number(val))}
+          type="Max Zoom"
+        />
+      </div>
+      <Tabs>
+        <TabItem value="preview" label="Preview" default>
+          <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 480 }}>
+            <InfiniteCanvasLayout
+              header={
+                <Navbar variant="primary" size="md" className="rounded-none px-4 w-full">
+                  <div className="flex items-center gap-2">
+                    <Sparkles className="h-4 w-4" />
+                    <span className="text-sm font-semibold tracking-tight">Board</span>
+                  </div>
+                </Navbar>
+              }
+              actions={
+                <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+                  <Github className="h-4 w-4" />
+                </a>
+              }
+              minZoom={0.25}
+              maxZoom={maxZoom}
+              gridSize={gridSize}
+            >
+              <CanvasNode x={0} y={0}>
+                <SampleCard label="Idea" color="#6366f1" />
+              </CanvasNode>
+              <CanvasNode x={280} y={70}>
+                <SampleCard label="Sketch" color="#22c55e" />
+              </CanvasNode>
+              <CanvasNode x={70} y={240}>
+                <SampleCard label="Draft" color="#f59e0b" />
+              </CanvasNode>
+              <CanvasNode x={360} y={280}>
+                <SampleCard label="Review" color="#ef4444" />
+              </CanvasNode>
+            </InfiniteCanvasLayout>
+          </div>
+        </TabItem>
+        <TabItem value="code" label="Code">
+          <div className="mt-4">
+            <CodeBlock language="tsx" className="text-sm">
+              {codeString}
+            </CodeBlock>
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  );
+};
+
+export default InfiniteCanvasLayoutDemo;

--- a/apps/docs/src/components/Demo/InfiniteCanvasLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/InfiniteCanvasLayoutDemo.tsx
@@ -6,14 +6,25 @@ import CodeBlock from '@theme/CodeBlock';
 import { InfiniteCanvasLayout, CanvasNode } from '@site/src/components/UI/infinite-canvas-layout';
 import { Sparkles, Github } from 'lucide-react';
 import { Navbar } from '@site/src/components/UI/navbar';
+import { cn } from '@site/src/utils/cn';
 
 const gridSizes = ['16', '24', '32', '48'];
 const maxZooms = ['1.5', '2', '2.5', '4'];
 
-const SampleCard = ({ label, color }: { label: string; color: string }) => (
+const CARD_ACCENT_CLASSES: Record<string, string> = {
+  '#6366f1': 'border-t-indigo-500',
+  '#22c55e': 'border-t-green-500',
+  '#f59e0b': 'border-t-amber-500',
+  '#ef4444': 'border-t-red-500',
+};
+
+const SampleCard = ({ label, color, className }: { label: string; color: string; className?: string }) => (
   <div
-    className="flex h-28 w-52 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md"
-    style={{ borderTopColor: color, borderTopWidth: 3 }}
+    className={cn(
+      'flex h-28 w-52 items-center justify-center rounded-lg border border-t-[3px] border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md',
+      CARD_ACCENT_CLASSES[color],
+      className
+    )}
   >
     {label}
   </div>
@@ -24,23 +35,24 @@ const InfiniteCanvasLayoutDemo = () => {
   const [maxZoom, setMaxZoom] = useState<number>(2.5);
 
   const codeString = `
-import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinitecanvaslayout';
+import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinite-canvas-layout';
+import { Github } from 'lucide-react';
 
 <InfiniteCanvasLayout
   header={<span className="font-bold">Board</span>}
-  actions={<a href="https://github.com" aria-label="GitHub"><GithubIcon /></a>}
+  actions={<a href="https://github.com" aria-label="GitHub"><Github className="h-4 w-4" /></a>}
   minZoom={0.25}
   maxZoom={${maxZoom}}
   gridSize={${gridSize}}
 >
   <CanvasNode x={0} y={0}>
-    <Card label="Idea" />
+    <div className="rounded-lg border p-4 shadow-md">Idea</div>
   </CanvasNode>
   <CanvasNode x={320} y={80}>
-    <Card label="Sketch" />
+    <div className="rounded-lg border p-4 shadow-md">Sketch</div>
   </CanvasNode>
   <CanvasNode x={80} y={280}>
-    <Card label="Draft" />
+    <div className="rounded-lg border p-4 shadow-md">Draft</div>
   </CanvasNode>
 </InfiniteCanvasLayout>
 `;

--- a/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
+++ b/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
@@ -14,6 +14,7 @@ export interface CanvasViewport {
   zoom: number;
 }
 
+/** Restricts `value` to the inclusive `[min, max]` range. */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -79,6 +80,12 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
+// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
+// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
+// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
+// minZoom a consumer configures.
+const MIN_SAFE_ZOOM = 0.01;
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -106,7 +113,18 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 }) => {
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
-  const currentViewport = isControlled ? viewport : internalViewport;
+  const rawViewport = isControlled ? viewport : internalViewport;
+  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Normalize whichever viewport is currently in effect before it's used for rendering math or
+  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
+  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
+  // math - unclamped.
+  const currentViewport: CanvasViewport = {
+    ...rawViewport,
+    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+  };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -120,13 +138,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, minZoom, maxZoom]
+    [isControlled, safeMinZoom, maxZoom]
   );
 
   const zoomIn = React.useCallback(

--- a/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
+++ b/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
@@ -80,18 +80,14 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
-// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
-// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
-// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
-// minZoom a consumer configures.
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
 const MIN_SAFE_ZOOM = 0.01;
 
 /**
- * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
- * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
- * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
- * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
- * once NaN enters the viewport, every calculation derived from it stays NaN.
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
  */
 function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
   const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
@@ -129,25 +125,19 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
 
-  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
-  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
-  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
   const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
   const safeMaxZoom = Number.isFinite(maxZoom)
     ? Math.max(maxZoom, safeMinZoom)
     : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
-  // Normalize whichever viewport is currently in effect before it's used for rendering math or
-  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
-  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
-  // the wheel-zoom math - unguarded.
+  // A controlled `viewport` prop bypasses updateViewport's own clamping, so this normalizes it
+  // before it reaches rendering or event handlers.
   const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
-  // Read the latest viewport (and callback) inside event handlers without making them - or the
-  // effects that attach them - depend on it. Consumers commonly pass an inline function for
-  // onViewportChange, which would otherwise get a new identity every render and tear down and
-  // reattach the wheel listener on every unrelated re-render.
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
   const viewportRef = React.useRef(currentViewport);
   viewportRef.current = currentViewport;
   const onViewportChangeRef = React.useRef(onViewportChange);
@@ -180,8 +170,8 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   const surfaceRef = React.useRef<HTMLDivElement>(null);
 
-  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
-  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
   React.useEffect(() => {
     const surface = surfaceRef.current;
     if (!surface) return;
@@ -211,12 +201,11 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
-    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
-    // (or anything else) rendered above it - so content stays independently interactive.
+    // Only pan when the drag starts on empty background, not on a CanvasNode, so content
+    // stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
-    // Without this, the browser's native drag-to-select-text behavior runs independently of our
-    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
-    // still highlight it, even though the drag started on empty background.
+    // Prevents native text selection while panning - otherwise dragging across a CanvasNode's
+    // text mid-pan would still highlight it.
     event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };

--- a/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
+++ b/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
@@ -114,7 +114,14 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
-  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
+  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
+  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
@@ -123,7 +130,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   // math - unclamped.
   const currentViewport: CanvasViewport = {
     ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
   };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
@@ -138,13 +145,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, safeMinZoom, maxZoom]
+    [isControlled, safeMinZoom, safeMaxZoom]
   );
 
   const zoomIn = React.useCallback(
@@ -176,7 +183,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       if (event.ctrlKey || event.metaKey) {
         updateViewport((prev) => {
-          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
           const worldX = (pointerX - prev.x) / prev.zoom;
           const worldY = (pointerY - prev.y) / prev.zoom;
           return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
@@ -188,7 +195,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
     surface.addEventListener("wheel", handleWheel, { passive: false });
     return () => surface.removeEventListener("wheel", handleWheel);
-  }, [updateViewport, minZoom, maxZoom]);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
 
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
@@ -196,6 +203,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
     // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
     // (or anything else) rendered above it - so content stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
+    // Without this, the browser's native drag-to-select-text behavior runs independently of our
+    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
+    // still highlight it, even though the drag started on empty background.
+    event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
   };
@@ -268,7 +279,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       <div
         ref={surfaceRef}
-        className="relative flex-1 touch-none overflow-hidden"
+        className="relative flex-1 touch-none select-none overflow-hidden"
         style={
           showGrid
             ? {

--- a/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
+++ b/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
@@ -1,0 +1,305 @@
+import * as React from "react";
+import { Button } from "@site/src/components/UI/button";
+import { Plus, Minus, RotateCcw } from "lucide-react";
+import { cn } from "@site/src/utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the canvas, in the canvas's own (untransformed) coordinate space. */
+export interface CanvasViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Props for the {@link CanvasNode} helper - a single item absolutely positioned on the
+ * infinite canvas at world coordinates `(x, y)`.
+ */
+export interface CanvasNodeProps {
+  x: number;
+  y: number;
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Positions its children at a fixed `(x, y)` point in the canvas's world space. Use one per
+ * item placed on an {@link InfiniteCanvasLayout} - panning/zooming the canvas moves and scales
+ * every `CanvasNode` together, since they're rendered inside the same transformed layer.
+ */
+export const CanvasNode: React.FC<CanvasNodeProps> = ({ x, y, width, height, className, children }) => (
+  <div className={cn("absolute", className)} style={{ left: x, top: y, width, height }}>
+    {children}
+  </div>
+);
+CanvasNode.displayName = "CanvasNode";
+
+/**
+ * Props for the {@link InfiniteCanvasLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property children - Canvas content, typically one or more {@link CanvasNode} elements.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to
+ * drive the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface InfiniteCanvasLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  viewport?: CanvasViewport;
+  defaultViewport?: CanvasViewport;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * InfiniteCanvasLayout is a pannable, zoomable workspace shell - the shape behind
+ * whiteboard/canvas tools (Figma, Miro, tldraw). An optional top toolbar sits above a
+ * full-bleed canvas; content is placed via {@link CanvasNode} at fixed world coordinates,
+ * and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard, or the
+ * floating zoom controls.
+ */
+export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
+  header,
+  actions,
+  children,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
+  const currentViewport = isControlled ? viewport : internalViewport;
+
+  // Read the latest viewport (and callback) inside event handlers without making them - or the
+  // effects that attach them - depend on it. Consumers commonly pass an inline function for
+  // onViewportChange, which would otherwise get a new identity every render and tear down and
+  // reattach the wheel listener on every unrelated re-render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: CanvasViewport) => CanvasViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      if (!isControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isControlled, minZoom, maxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+
+  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
+  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, minZoom, maxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
+    // (or anything else) rendered above it - so content stays independently interactive.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div
+        ref={surfaceRef}
+        className="relative flex-1 touch-none overflow-hidden"
+        style={
+          showGrid
+            ? {
+                backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+              }
+            : undefined
+        }
+        role="group"
+        aria-label="Infinite canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          className="absolute left-0 top-0"
+          style={{
+            transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {children}
+        </div>
+
+        {showControls && (
+          <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+            <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+              <Plus className="h-4 w-4" />
+            </Button>
+            <div className="text-center text-xs text-[var(--muted-foreground)]">
+              {Math.round(currentViewport.zoom * 100)}%
+            </div>
+            <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+InfiniteCanvasLayout.displayName = "InfiniteCanvasLayout";
+
+export default InfiniteCanvasLayout;

--- a/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
+++ b/apps/docs/src/components/UI/infinite-canvas-layout/index.tsx
@@ -86,6 +86,20 @@ const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 // minZoom a consumer configures.
 const MIN_SAFE_ZOOM = 0.01;
 
+/**
+ * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
+ * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
+ * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
+ * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
+ * once NaN enters the viewport, every calculation derived from it stays NaN.
+ */
+function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -125,13 +139,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
-  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
-  // math - unclamped.
-  const currentViewport: CanvasViewport = {
-    ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
-  };
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
+  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
+  // the wheel-zoom math - unguarded.
+  const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -145,7 +156,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
+      const clamped: CanvasViewport = normalizeViewport(next, safeMinZoom, safeMaxZoom);
       if (!isControlled) {
         setInternalViewport(clamped);
       }

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
@@ -41,6 +41,7 @@ export interface CanvasViewport {
   zoom: number;
 }
 
+/** Restricts `value` to the inclusive `[min, max]` range. */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -106,6 +107,12 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
+// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
+// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
+// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
+// minZoom a consumer configures.
+const MIN_SAFE_ZOOM = 0.01;
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -133,7 +140,18 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 }) => {
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
-  const currentViewport = isControlled ? viewport : internalViewport;
+  const rawViewport = isControlled ? viewport : internalViewport;
+  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Normalize whichever viewport is currently in effect before it's used for rendering math or
+  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
+  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
+  // math - unclamped.
+  const currentViewport: CanvasViewport = {
+    ...rawViewport,
+    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+  };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -147,13 +165,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, minZoom, maxZoom]
+    [isControlled, safeMinZoom, maxZoom]
   );
 
   const zoomIn = React.useCallback(
@@ -337,7 +355,7 @@ export default InfiniteCanvasLayout;
 ## Usage
 
 ```tsx
-import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinitecanvaslayout';
+import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinite-canvas-layout';
 ```
 
 ### Basic Usage
@@ -376,6 +394,8 @@ function App() {
 ### Controlled Viewport
 
 ```tsx
+import { useState } from 'react';
+
 function App() {
   const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 1 });
 
@@ -395,7 +415,7 @@ function App() {
 |-------|--------|
 | Drag on empty canvas | Pan the canvas |
 | Mouse wheel / trackpad scroll | Pan the canvas |
-| Ctrl/Cmd + wheel, or pinch | Zoom toward the cursor |
+| Ctrl/Cmd + wheel | Zoom toward the cursor |
 | Arrow keys (when focused) | Pan the canvas |
 | `+` / `-` (when focused) | Zoom in / out |
 | `0` (when focused) | Reset to `defaultViewport` |
@@ -411,7 +431,7 @@ function App() {
 | `actions` | `React.ReactNode` | `undefined` | Optional node rendered at the end of the top toolbar |
 | `children` | `React.ReactNode` | — | Canvas content, typically one or more `CanvasNode` elements |
 | `viewport` | `CanvasViewport` | `undefined` | Controlled pan/zoom state; provide alongside `onViewportChange` to drive the canvas externally |
-| `defaultViewport` | `CanvasViewport` | `{ x: 0, y: 0, zoom: 1 }` | Initial pan/zoom state when uncontrolled, and the state "Reset view" returns to |
+| `defaultViewport` | `CanvasViewport` | `x: 0, y: 0, zoom: 1` | Initial pan/zoom state when uncontrolled, and the state "Reset view" returns to |
 | `onViewportChange` | `(viewport: CanvasViewport) => void` | `undefined` | Called whenever the viewport changes, whether controlled or not |
 | `minZoom` | `number` | `0.25` | Minimum zoom factor |
 | `maxZoom` | `number` | `2.5` | Maximum zoom factor |

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
@@ -113,6 +113,20 @@ const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 // minZoom a consumer configures.
 const MIN_SAFE_ZOOM = 0.01;
 
+/**
+ * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
+ * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
+ * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
+ * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
+ * once NaN enters the viewport, every calculation derived from it stays NaN.
+ */
+function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -152,13 +166,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
-  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
-  // math - unclamped.
-  const currentViewport: CanvasViewport = {
-    ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
-  };
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
+  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
+  // the wheel-zoom math - unguarded.
+  const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -172,7 +183,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
+      const clamped: CanvasViewport = normalizeViewport(next, safeMinZoom, safeMaxZoom);
       if (!isControlled) {
         setInternalViewport(clamped);
       }

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
@@ -1,0 +1,440 @@
+---
+sidebar_position: 8
+title: InfiniteCanvasLayout
+description: A pannable, zoomable canvas workspace shell for whiteboard/canvas-style tools, with drag/wheel/keyboard pan-zoom and floating zoom controls.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import InfiniteCanvasLayoutDemo from '@site/src/components/Demo/InfiniteCanvasLayoutDemo';
+
+The **Infinite Canvas Layout** template provides the shell behind whiteboard and canvas-style tools (Figma, Miro, tldraw): an optional top toolbar above a full-bleed, pannable and zoomable dot-grid surface. Content is placed with the `CanvasNode` helper at fixed world coordinates, and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard shortcuts, or the floating zoom controls.
+
+<InfiniteCanvasLayoutDemo/>
+
+## Installation
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+    ```bash
+    ignix add component InfiniteCanvasLayout
+    ```
+  </TabItem>
+  <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
+
+  `cn` is a small `clsx` + `tailwind-merge` helper (installed automatically by the CLI, at `src/utils/cn.ts`). Placing this file at `src/templates/InfiniteCanvasLayout/index.tsx` resolves the import below as-is; adjust the relative path if you place it elsewhere.
+
+  ```tsx
+import * as React from "react";
+import { Button } from "@ignix-ui/button";
+import { Plus, Minus, RotateCcw } from "lucide-react";
+import { cn } from "../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the canvas, in the canvas's own (untransformed) coordinate space. */
+export interface CanvasViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Props for the {@link CanvasNode} helper - a single item absolutely positioned on the
+ * infinite canvas at world coordinates `(x, y)`.
+ */
+export interface CanvasNodeProps {
+  x: number;
+  y: number;
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Positions its children at a fixed `(x, y)` point in the canvas's world space. Use one per
+ * item placed on an {@link InfiniteCanvasLayout} - panning/zooming the canvas moves and scales
+ * every `CanvasNode` together, since they're rendered inside the same transformed layer.
+ */
+export const CanvasNode: React.FC<CanvasNodeProps> = ({ x, y, width, height, className, children }) => (
+  <div className={cn("absolute", className)} style={{ left: x, top: y, width, height }}>
+    {children}
+  </div>
+);
+CanvasNode.displayName = "CanvasNode";
+
+/**
+ * Props for the {@link InfiniteCanvasLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property children - Canvas content, typically one or more {@link CanvasNode} elements.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to
+ * drive the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface InfiniteCanvasLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  viewport?: CanvasViewport;
+  defaultViewport?: CanvasViewport;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * InfiniteCanvasLayout is a pannable, zoomable workspace shell - the shape behind
+ * whiteboard/canvas tools (Figma, Miro, tldraw). An optional top toolbar sits above a
+ * full-bleed canvas; content is placed via {@link CanvasNode} at fixed world coordinates,
+ * and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard, or the
+ * floating zoom controls.
+ */
+export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
+  header,
+  actions,
+  children,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
+  const currentViewport = isControlled ? viewport : internalViewport;
+
+  // Read the latest viewport (and callback) inside event handlers without making them - or the
+  // effects that attach them - depend on it. Consumers commonly pass an inline function for
+  // onViewportChange, which would otherwise get a new identity every render and tear down and
+  // reattach the wheel listener on every unrelated re-render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: CanvasViewport) => CanvasViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      if (!isControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isControlled, minZoom, maxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+
+  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
+  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, minZoom, maxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
+    // (or anything else) rendered above it - so content stays independently interactive.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div
+        ref={surfaceRef}
+        className="relative flex-1 touch-none overflow-hidden"
+        style={
+          showGrid
+            ? {
+                backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+              }
+            : undefined
+        }
+        role="group"
+        aria-label="Infinite canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          className="absolute left-0 top-0"
+          style={{
+            transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {children}
+        </div>
+
+        {showControls && (
+          <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+            <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+              <Plus className="h-4 w-4" />
+            </Button>
+            <div className="text-center text-xs text-[var(--muted-foreground)]">
+              {Math.round(currentViewport.zoom * 100)}%
+            </div>
+            <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+InfiniteCanvasLayout.displayName = "InfiniteCanvasLayout";
+
+export default InfiniteCanvasLayout;
+  ```
+  </TabItem>
+</Tabs>
+
+## Usage
+
+```tsx
+import { InfiniteCanvasLayout, CanvasNode } from '@ignix-ui/infinitecanvaslayout';
+```
+
+### Basic Usage
+
+```tsx
+function App() {
+  return (
+    <InfiniteCanvasLayout>
+      <CanvasNode x={0} y={0}>
+        <div>Idea</div>
+      </CanvasNode>
+      <CanvasNode x={320} y={80}>
+        <div>Sketch</div>
+      </CanvasNode>
+    </InfiniteCanvasLayout>
+  );
+}
+```
+
+### With a Toolbar
+
+```tsx
+<InfiniteCanvasLayout
+  header={<span className="font-bold">Board</span>}
+  actions={<ThemeToggle />}
+  minZoom={0.25}
+  maxZoom={2.5}
+  gridSize={32}
+>
+  <CanvasNode x={0} y={0} width={200} height={120}>
+    <Card />
+  </CanvasNode>
+</InfiniteCanvasLayout>
+```
+
+### Controlled Viewport
+
+```tsx
+function App() {
+  const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 1 });
+
+  return (
+    <InfiniteCanvasLayout viewport={viewport} onViewportChange={setViewport}>
+      <CanvasNode x={0} y={0}>
+        <div>Synced with external state</div>
+      </CanvasNode>
+    </InfiniteCanvasLayout>
+  );
+}
+```
+
+## Interaction Reference
+
+| Input | Action |
+|-------|--------|
+| Drag on empty canvas | Pan the canvas |
+| Mouse wheel / trackpad scroll | Pan the canvas |
+| Ctrl/Cmd + wheel, or pinch | Zoom toward the cursor |
+| Arrow keys (when focused) | Pan the canvas |
+| `+` / `-` (when focused) | Zoom in / out |
+| `0` (when focused) | Reset to `defaultViewport` |
+| Zoom control buttons | Zoom in / out / reset |
+
+## Props
+
+### InfiniteCanvasLayout
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `header` | `React.ReactNode` | `undefined` | Custom node rendered at the start of the top toolbar (e.g. a logo/title) |
+| `actions` | `React.ReactNode` | `undefined` | Optional node rendered at the end of the top toolbar |
+| `children` | `React.ReactNode` | — | Canvas content, typically one or more `CanvasNode` elements |
+| `viewport` | `CanvasViewport` | `undefined` | Controlled pan/zoom state; provide alongside `onViewportChange` to drive the canvas externally |
+| `defaultViewport` | `CanvasViewport` | `{ x: 0, y: 0, zoom: 1 }` | Initial pan/zoom state when uncontrolled, and the state "Reset view" returns to |
+| `onViewportChange` | `(viewport: CanvasViewport) => void` | `undefined` | Called whenever the viewport changes, whether controlled or not |
+| `minZoom` | `number` | `0.25` | Minimum zoom factor |
+| `maxZoom` | `number` | `2.5` | Maximum zoom factor |
+| `showGrid` | `boolean` | `true` | Whether to render the background dot grid |
+| `gridSize` | `number` | `32` | Spacing between grid dots, in canvas world units |
+| `showControls` | `boolean` | `true` | Whether to render the floating zoom in/out/reset control panel |
+| `className` | `string` | `undefined` | Additional CSS classes applied to the root container |
+
+### CanvasNode
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `x` | `number` | — | Horizontal position in the canvas's world space |
+| `y` | `number` | — | Vertical position in the canvas's world space |
+| `width` | `number \| string` | `undefined` | Optional fixed width |
+| `height` | `number \| string` | `undefined` | Optional fixed height |
+| `className` | `string` | `undefined` | Additional CSS classes |
+| `children` | `React.ReactNode` | — | Node content |
+
+### CanvasViewport
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `x` | `number` | Horizontal pan offset, in pixels |
+| `y` | `number` | Vertical pan offset, in pixels |
+| `zoom` | `number` | Zoom factor (`1` = 100%) |

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
@@ -107,18 +107,14 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
-// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
-// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
-// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
-// minZoom a consumer configures.
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
 const MIN_SAFE_ZOOM = 0.01;
 
 /**
- * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
- * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
- * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
- * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
- * once NaN enters the viewport, every calculation derived from it stays NaN.
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
  */
 function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
   const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
@@ -156,25 +152,19 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
 
-  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
-  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
-  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
   const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
   const safeMaxZoom = Number.isFinite(maxZoom)
     ? Math.max(maxZoom, safeMinZoom)
     : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
-  // Normalize whichever viewport is currently in effect before it's used for rendering math or
-  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
-  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
-  // the wheel-zoom math - unguarded.
+  // A controlled `viewport` prop bypasses updateViewport's own clamping, so this normalizes it
+  // before it reaches rendering or event handlers.
   const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
-  // Read the latest viewport (and callback) inside event handlers without making them - or the
-  // effects that attach them - depend on it. Consumers commonly pass an inline function for
-  // onViewportChange, which would otherwise get a new identity every render and tear down and
-  // reattach the wheel listener on every unrelated re-render.
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
   const viewportRef = React.useRef(currentViewport);
   viewportRef.current = currentViewport;
   const onViewportChangeRef = React.useRef(onViewportChange);
@@ -207,8 +197,8 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   const surfaceRef = React.useRef<HTMLDivElement>(null);
 
-  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
-  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
   React.useEffect(() => {
     const surface = surfaceRef.current;
     if (!surface) return;
@@ -238,12 +228,11 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
-    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
-    // (or anything else) rendered above it - so content stays independently interactive.
+    // Only pan when the drag starts on empty background, not on a CanvasNode, so content
+    // stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
-    // Without this, the browser's native drag-to-select-text behavior runs independently of our
-    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
-    // still highlight it, even though the drag started on empty background.
+    // Prevents native text selection while panning - otherwise dragging across a CanvasNode's
+    // text mid-pan would still highlight it.
     event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/infinite-canvas-layout.mdx
@@ -141,7 +141,14 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
-  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
+  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
+  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
@@ -150,7 +157,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   // math - unclamped.
   const currentViewport: CanvasViewport = {
     ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
   };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
@@ -165,13 +172,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, safeMinZoom, maxZoom]
+    [isControlled, safeMinZoom, safeMaxZoom]
   );
 
   const zoomIn = React.useCallback(
@@ -203,7 +210,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       if (event.ctrlKey || event.metaKey) {
         updateViewport((prev) => {
-          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
           const worldX = (pointerX - prev.x) / prev.zoom;
           const worldY = (pointerY - prev.y) / prev.zoom;
           return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
@@ -215,7 +222,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
     surface.addEventListener("wheel", handleWheel, { passive: false });
     return () => surface.removeEventListener("wheel", handleWheel);
-  }, [updateViewport, minZoom, maxZoom]);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
 
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
@@ -223,6 +230,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
     // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
     // (or anything else) rendered above it - so content stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
+    // Without this, the browser's native drag-to-select-text behavior runs independently of our
+    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
+    // still highlight it, even though the drag started on empty background.
+    event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
   };
@@ -295,7 +306,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       <div
         ref={surfaceRef}
-        className="relative flex-1 touch-none overflow-hidden"
+        className="relative flex-1 touch-none select-none overflow-hidden"
         style={
           showGrid
             ? {

--- a/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
@@ -148,12 +148,12 @@
           "label": "Page Layout",
           "items": [
             "templates/layouts/full-height-sidebar-layout",
+            "templates/layouts/infinite-canvas-layout",
             "templates/layouts/responsive-grid-layout",
             "templates/layouts/sidebar-left-layout",
             "templates/layouts/sidebar-right-layout",
             "templates/layouts/single-column-layout",
-            "templates/layouts/three-column-sidebar-layout",
-            "templates/layouts/infinite-canvas-layout"
+            "templates/layouts/three-column-sidebar-layout"
           ]
         },
         {

--- a/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
@@ -152,7 +152,8 @@
             "templates/layouts/sidebar-left-layout",
             "templates/layouts/sidebar-right-layout",
             "templates/layouts/single-column-layout",
-            "templates/layouts/three-column-sidebar-layout"
+            "templates/layouts/three-column-sidebar-layout",
+            "templates/layouts/infinite-canvas-layout"
           ]
         },
         {

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
@@ -14,6 +14,7 @@ export interface CanvasViewport {
   zoom: number;
 }
 
+/** Restricts `value` to the inclusive `[min, max]` range. */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -79,6 +80,12 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
+// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
+// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
+// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
+// minZoom a consumer configures.
+const MIN_SAFE_ZOOM = 0.01;
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -106,7 +113,18 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 }) => {
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
-  const currentViewport = isControlled ? viewport : internalViewport;
+  const rawViewport = isControlled ? viewport : internalViewport;
+  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Normalize whichever viewport is currently in effect before it's used for rendering math or
+  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
+  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
+  // math - unclamped.
+  const currentViewport: CanvasViewport = {
+    ...rawViewport,
+    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+  };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -120,13 +138,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, minZoom, maxZoom]
+    [isControlled, safeMinZoom, maxZoom]
   );
 
   const zoomIn = React.useCallback(

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
@@ -80,18 +80,14 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
-// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
-// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
-// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
-// minZoom a consumer configures.
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
 const MIN_SAFE_ZOOM = 0.01;
 
 /**
- * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
- * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
- * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
- * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
- * once NaN enters the viewport, every calculation derived from it stays NaN.
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
  */
 function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
   const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
@@ -129,25 +125,19 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
 
-  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
-  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
-  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
   const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
   const safeMaxZoom = Number.isFinite(maxZoom)
     ? Math.max(maxZoom, safeMinZoom)
     : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
-  // Normalize whichever viewport is currently in effect before it's used for rendering math or
-  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
-  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
-  // the wheel-zoom math - unguarded.
+  // A controlled `viewport` prop bypasses updateViewport's own clamping, so this normalizes it
+  // before it reaches rendering or event handlers.
   const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
-  // Read the latest viewport (and callback) inside event handlers without making them - or the
-  // effects that attach them - depend on it. Consumers commonly pass an inline function for
-  // onViewportChange, which would otherwise get a new identity every render and tear down and
-  // reattach the wheel listener on every unrelated re-render.
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
   const viewportRef = React.useRef(currentViewport);
   viewportRef.current = currentViewport;
   const onViewportChangeRef = React.useRef(onViewportChange);
@@ -180,8 +170,8 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   const surfaceRef = React.useRef<HTMLDivElement>(null);
 
-  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
-  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
   React.useEffect(() => {
     const surface = surfaceRef.current;
     if (!surface) return;
@@ -211,12 +201,11 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
-    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
-    // (or anything else) rendered above it - so content stays independently interactive.
+    // Only pan when the drag starts on empty background, not on a CanvasNode, so content
+    // stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
-    // Without this, the browser's native drag-to-select-text behavior runs independently of our
-    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
-    // still highlight it, even though the drag started on empty background.
+    // Prevents native text selection while panning - otherwise dragging across a CanvasNode's
+    // text mid-pan would still highlight it.
     event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
@@ -114,7 +114,14 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
-  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
+  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
+  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
@@ -123,7 +130,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   // math - unclamped.
   const currentViewport: CanvasViewport = {
     ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
   };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
@@ -138,13 +145,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, safeMinZoom, maxZoom]
+    [isControlled, safeMinZoom, safeMaxZoom]
   );
 
   const zoomIn = React.useCallback(
@@ -176,7 +183,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       if (event.ctrlKey || event.metaKey) {
         updateViewport((prev) => {
-          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
           const worldX = (pointerX - prev.x) / prev.zoom;
           const worldY = (pointerY - prev.y) / prev.zoom;
           return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
@@ -188,7 +195,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
     surface.addEventListener("wheel", handleWheel, { passive: false });
     return () => surface.removeEventListener("wheel", handleWheel);
-  }, [updateViewport, minZoom, maxZoom]);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
 
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
@@ -196,6 +203,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
     // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
     // (or anything else) rendered above it - so content stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
+    // Without this, the browser's native drag-to-select-text behavior runs independently of our
+    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
+    // still highlight it, even though the drag started on empty background.
+    event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
   };
@@ -268,7 +279,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       <div
         ref={surfaceRef}
-        className="relative flex-1 touch-none overflow-hidden"
+        className="relative flex-1 touch-none select-none overflow-hidden"
         style={
           showGrid
             ? {

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
@@ -86,6 +86,20 @@ const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 // minZoom a consumer configures.
 const MIN_SAFE_ZOOM = 0.01;
 
+/**
+ * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
+ * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
+ * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
+ * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
+ * once NaN enters the viewport, every calculation derived from it stays NaN.
+ */
+function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -125,13 +139,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
-  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
-  // math - unclamped.
-  const currentViewport: CanvasViewport = {
-    ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
-  };
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
+  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
+  // the wheel-zoom math - unguarded.
+  const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -145,7 +156,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
+      const clamped: CanvasViewport = normalizeViewport(next, safeMinZoom, safeMaxZoom);
       if (!isControlled) {
         setInternalViewport(clamped);
       }

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/index.tsx
@@ -1,0 +1,305 @@
+import * as React from "react";
+import { Button } from "../../../components/button";
+import { Plus, Minus, RotateCcw } from "lucide-react";
+import { cn } from "../../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the canvas, in the canvas's own (untransformed) coordinate space. */
+export interface CanvasViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Props for the {@link CanvasNode} helper - a single item absolutely positioned on the
+ * infinite canvas at world coordinates `(x, y)`.
+ */
+export interface CanvasNodeProps {
+  x: number;
+  y: number;
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Positions its children at a fixed `(x, y)` point in the canvas's world space. Use one per
+ * item placed on an {@link InfiniteCanvasLayout} - panning/zooming the canvas moves and scales
+ * every `CanvasNode` together, since they're rendered inside the same transformed layer.
+ */
+export const CanvasNode: React.FC<CanvasNodeProps> = ({ x, y, width, height, className, children }) => (
+  <div className={cn("absolute", className)} style={{ left: x, top: y, width, height }}>
+    {children}
+  </div>
+);
+CanvasNode.displayName = "CanvasNode";
+
+/**
+ * Props for the {@link InfiniteCanvasLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property children - Canvas content, typically one or more {@link CanvasNode} elements.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to
+ * drive the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface InfiniteCanvasLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  viewport?: CanvasViewport;
+  defaultViewport?: CanvasViewport;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * InfiniteCanvasLayout is a pannable, zoomable workspace shell - the shape behind
+ * whiteboard/canvas tools (Figma, Miro, tldraw). An optional top toolbar sits above a
+ * full-bleed canvas; content is placed via {@link CanvasNode} at fixed world coordinates,
+ * and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard, or the
+ * floating zoom controls.
+ */
+export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
+  header,
+  actions,
+  children,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
+  const currentViewport = isControlled ? viewport : internalViewport;
+
+  // Read the latest viewport (and callback) inside event handlers without making them - or the
+  // effects that attach them - depend on it. Consumers commonly pass an inline function for
+  // onViewportChange, which would otherwise get a new identity every render and tear down and
+  // reattach the wheel listener on every unrelated re-render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: CanvasViewport) => CanvasViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      if (!isControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isControlled, minZoom, maxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+
+  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
+  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, minZoom, maxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
+    // (or anything else) rendered above it - so content stays independently interactive.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div
+        ref={surfaceRef}
+        className="relative flex-1 touch-none overflow-hidden"
+        style={
+          showGrid
+            ? {
+                backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+              }
+            : undefined
+        }
+        role="group"
+        aria-label="Infinite canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          className="absolute left-0 top-0"
+          style={{
+            transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {children}
+        </div>
+
+        {showControls && (
+          <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+            <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+              <Plus className="h-4 w-4" />
+            </Button>
+            <div className="text-center text-xs text-[var(--muted-foreground)]">
+              {Math.round(currentViewport.zoom * 100)}%
+            </div>
+            <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+InfiniteCanvasLayout.displayName = "InfiniteCanvasLayout";
+
+export default InfiniteCanvasLayout;

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.stories.tsx
@@ -1,0 +1,143 @@
+/**
+ * @file infinite-canvas-layout.stories.tsx
+ * @description Storybook stories for the InfiniteCanvasLayout template. Covers the pannable/
+ * zoomable canvas surface, CanvasNode placement, the floating zoom controls, the optional
+ * header/actions slots, and controlled vs. uncontrolled viewport state.
+ */
+
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfiniteCanvasLayout, CanvasNode, type CanvasViewport } from ".";
+import { Sparkles, Github } from "lucide-react";
+
+const meta: Meta<typeof InfiniteCanvasLayout> = {
+  title: "Templates/Layouts/InfiniteCanvasLayout",
+  component: InfiniteCanvasLayout,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A pannable, zoomable canvas workspace shell - the shape behind whiteboard/canvas tools. An optional top toolbar sits above a full-bleed canvas; content is placed via CanvasNode at fixed world coordinates, and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard, or the floating zoom controls.",
+      },
+    },
+  },
+  argTypes: {
+    minZoom: { control: { type: "number", min: 0.1, max: 1, step: 0.05 } },
+    maxZoom: { control: { type: "number", min: 1, max: 4, step: 0.25 } },
+    gridSize: { control: { type: "number", min: 8, max: 128, step: 8 } },
+    showGrid: { control: "boolean" },
+    showControls: { control: "boolean" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InfiniteCanvasLayout>;
+
+const SampleCard: React.FC<{ label: string; color: string }> = ({ label, color }) => (
+  <div
+    className="flex h-32 w-56 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md"
+    style={{ borderTopColor: color, borderTopWidth: 3 }}
+  >
+    {label}
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <CanvasNode x={0} y={0}>
+          <SampleCard label="Idea" color="#6366f1" />
+        </CanvasNode>
+        <CanvasNode x={320} y={80}>
+          <SampleCard label="Sketch" color="#22c55e" />
+        </CanvasNode>
+        <CanvasNode x={80} y={280}>
+          <SampleCard label="Draft" color="#f59e0b" />
+        </CanvasNode>
+        <CanvasNode x={420} y={320}>
+          <SampleCard label="Review" color="#ef4444" />
+        </CanvasNode>
+      </>
+    ),
+  },
+};
+
+export const WithHeaderAndActions: Story = {
+  args: {
+    ...Default.args,
+    header: (
+      <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+        <Sparkles className="h-4 w-4" />
+        Board
+      </div>
+    ),
+    actions: (
+      <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+        <Github className="h-4 w-4" />
+      </a>
+    ),
+  },
+};
+
+export const WithoutGrid: Story = {
+  args: {
+    ...Default.args,
+    showGrid: false,
+  },
+};
+
+export const WithoutControls: Story = {
+  args: {
+    ...Default.args,
+    showControls: false,
+  },
+};
+
+export const ManyNodes: Story = {
+  args: {
+    children: (
+      <>
+        {Array.from({ length: 24 }).map((_, index) => {
+          const col = index % 6;
+          const row = Math.floor(index / 6);
+          return (
+            <CanvasNode key={index} x={col * 260} y={row * 200}>
+              <SampleCard label={`Node ${index + 1}`} color={["#6366f1", "#22c55e", "#f59e0b", "#ef4444"][index % 4]} />
+            </CanvasNode>
+          );
+        })}
+      </>
+    ),
+  },
+};
+
+export const CustomZoomLimits: Story = {
+  args: {
+    ...Default.args,
+    minZoom: 0.5,
+    maxZoom: 1.5,
+    defaultViewport: { x: 0, y: 0, zoom: 0.75 },
+  },
+};
+
+export const ControlledViewport: Story = {
+  render: (args) => {
+    const [viewport, setViewport] = React.useState<CanvasViewport>({ x: 0, y: 0, zoom: 1 });
+    return (
+      <div className="relative h-full w-full">
+        <InfiniteCanvasLayout {...args} viewport={viewport} onViewportChange={setViewport} />
+        <div className="pointer-events-none absolute left-4 top-20 z-10 rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 font-mono text-xs">
+          x: {Math.round(viewport.x)}, y: {Math.round(viewport.y)}, zoom: {viewport.zoom.toFixed(2)}
+        </div>
+      </div>
+    );
+  },
+  args: {
+    ...Default.args,
+    header: <span className="text-sm font-semibold">Controlled viewport</span>,
+  },
+};

--- a/apps/storybook/src/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.stories.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { InfiniteCanvasLayout, CanvasNode, type CanvasViewport } from ".";
 import { Sparkles, Github } from "lucide-react";
+import { cn } from "../../../../utils/cn";
 
 const meta: Meta<typeof InfiniteCanvasLayout> = {
   title: "Templates/Layouts/InfiniteCanvasLayout",
@@ -36,10 +37,20 @@ export default meta;
 
 type Story = StoryObj<typeof InfiniteCanvasLayout>;
 
-const SampleCard: React.FC<{ label: string; color: string }> = ({ label, color }) => (
+const CARD_ACCENT_CLASSES: Record<string, string> = {
+  "#6366f1": "border-t-indigo-500",
+  "#22c55e": "border-t-green-500",
+  "#f59e0b": "border-t-amber-500",
+  "#ef4444": "border-t-red-500",
+};
+
+const SampleCard: React.FC<{ label: string; color: string; className?: string }> = ({ label, color, className }) => (
   <div
-    className="flex h-32 w-56 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md"
-    style={{ borderTopColor: color, borderTopWidth: 3 }}
+    className={cn(
+      "flex h-32 w-56 items-center justify-center rounded-lg border border-t-[3px] border-[var(--border)] bg-[var(--card)] p-4 text-sm font-medium text-[var(--card-foreground)] shadow-md",
+      CARD_ACCENT_CLASSES[color],
+      className
+    )}
   >
     {label}
   </div>

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -1094,6 +1094,22 @@
         }
       }
     },
+    "infinitecanvaslayout": {
+      "name": "InfiniteCanvasLayout",
+      "description": "A pannable, zoomable canvas workspace shell - a toolbar plus a full-bleed dot-grid surface where content is placed at fixed coordinates via CanvasNode, with drag/wheel/keyboard pan-zoom and floating zoom controls.",
+      "dependencies": [
+        "lucide-react"
+      ],
+      "componentDependencies": [
+        "button"
+      ],
+      "files": {
+        "main": {
+          "path": "templates/layouts/infinite-canvas-layout/index.tsx",
+          "type": "template"
+        }
+      }
+    },
     "threecolumnsidebarlayout": {
       "name": "ThreeColumnSidebarLayout",
       "description": "A flexible layout component with header, sidebar that supports app dashboard with responsive design.",

--- a/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
@@ -14,6 +14,7 @@ export interface CanvasViewport {
   zoom: number;
 }
 
+/** Restricts `value` to the inclusive `[min, max]` range. */
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -79,6 +80,12 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
+// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
+// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
+// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
+// minZoom a consumer configures.
+const MIN_SAFE_ZOOM = 0.01;
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -106,7 +113,18 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 }) => {
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
-  const currentViewport = isControlled ? viewport : internalViewport;
+  const rawViewport = isControlled ? viewport : internalViewport;
+  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Normalize whichever viewport is currently in effect before it's used for rendering math or
+  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
+  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
+  // math - unclamped.
+  const currentViewport: CanvasViewport = {
+    ...rawViewport,
+    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+  };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -120,13 +138,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, minZoom, maxZoom]
+    [isControlled, safeMinZoom, maxZoom]
   );
 
   const zoomIn = React.useCallback(

--- a/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
@@ -80,18 +80,14 @@ export interface InfiniteCanvasLayoutProps {
 
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
-// A zoom of exactly 0 (or less) isn't just visually degenerate (scale(0), zero-size grid) - the
-// wheel handler's zoom-to-cursor math divides by the current zoom, so it would produce
-// Infinity/NaN and permanently corrupt the viewport. This floor applies regardless of what
-// minZoom a consumer configures.
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
 const MIN_SAFE_ZOOM = 0.01;
 
 /**
- * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
- * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
- * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
- * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
- * once NaN enters the viewport, every calculation derived from it stays NaN.
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
  */
 function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
   const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
@@ -129,25 +125,19 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
 
-  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
-  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
-  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
   const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
   const safeMaxZoom = Number.isFinite(maxZoom)
     ? Math.max(maxZoom, safeMinZoom)
     : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
-  // Normalize whichever viewport is currently in effect before it's used for rendering math or
-  // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
-  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
-  // the wheel-zoom math - unguarded.
+  // A controlled `viewport` prop bypasses updateViewport's own clamping, so this normalizes it
+  // before it reaches rendering or event handlers.
   const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
-  // Read the latest viewport (and callback) inside event handlers without making them - or the
-  // effects that attach them - depend on it. Consumers commonly pass an inline function for
-  // onViewportChange, which would otherwise get a new identity every render and tear down and
-  // reattach the wheel listener on every unrelated re-render.
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
   const viewportRef = React.useRef(currentViewport);
   viewportRef.current = currentViewport;
   const onViewportChangeRef = React.useRef(onViewportChange);
@@ -180,8 +170,8 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   const surfaceRef = React.useRef<HTMLDivElement>(null);
 
-  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
-  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
   React.useEffect(() => {
     const surface = surfaceRef.current;
     if (!surface) return;
@@ -211,12 +201,11 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
-    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
-    // (or anything else) rendered above it - so content stays independently interactive.
+    // Only pan when the drag starts on empty background, not on a CanvasNode, so content
+    // stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
-    // Without this, the browser's native drag-to-select-text behavior runs independently of our
-    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
-    // still highlight it, even though the drag started on empty background.
+    // Prevents native text selection while panning - otherwise dragging across a CanvasNode's
+    // text mid-pan would still highlight it.
     event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };

--- a/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
@@ -114,7 +114,14 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const isControlled = viewport !== undefined;
   const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
   const rawViewport = isControlled ? viewport : internalViewport;
-  const safeMinZoom = Math.max(minZoom, MIN_SAFE_ZOOM);
+
+  // Guard against non-finite bounds (NaN/undefined-ish props propagate NaN through every clamp
+  // call) and an inverted range (maxZoom < minZoom collapses clamp's output to a fixed constant,
+  // permanently freezing zoom) - both are consumer misconfigurations, not just edge values.
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
@@ -123,7 +130,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   // math - unclamped.
   const currentViewport: CanvasViewport = {
     ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, maxZoom),
+    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
   };
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
@@ -138,13 +145,13 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, maxZoom) };
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
       if (!isControlled) {
         setInternalViewport(clamped);
       }
       onViewportChangeRef.current?.(clamped);
     },
-    [isControlled, safeMinZoom, maxZoom]
+    [isControlled, safeMinZoom, safeMaxZoom]
   );
 
   const zoomIn = React.useCallback(
@@ -176,7 +183,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       if (event.ctrlKey || event.metaKey) {
         updateViewport((prev) => {
-          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
           const worldX = (pointerX - prev.x) / prev.zoom;
           const worldY = (pointerY - prev.y) / prev.zoom;
           return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
@@ -188,7 +195,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
     surface.addEventListener("wheel", handleWheel, { passive: false });
     return () => surface.removeEventListener("wheel", handleWheel);
-  }, [updateViewport, minZoom, maxZoom]);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
 
   const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
 
@@ -196,6 +203,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
     // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
     // (or anything else) rendered above it - so content stays independently interactive.
     if (event.target !== event.currentTarget || event.button !== 0) return;
+    // Without this, the browser's native drag-to-select-text behavior runs independently of our
+    // own pan tracking below - so sweeping the cursor across a CanvasNode's text mid-pan would
+    // still highlight it, even though the drag started on empty background.
+    event.preventDefault();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
   };
@@ -268,7 +279,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
       <div
         ref={surfaceRef}
-        className="relative flex-1 touch-none overflow-hidden"
+        className="relative flex-1 touch-none select-none overflow-hidden"
         style={
           showGrid
             ? {

--- a/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
@@ -1,0 +1,305 @@
+import * as React from "react";
+import { Button } from "@ignix-ui/button";
+import { Plus, Minus, RotateCcw } from "lucide-react";
+import { cn } from "../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the canvas, in the canvas's own (untransformed) coordinate space. */
+export interface CanvasViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Props for the {@link CanvasNode} helper - a single item absolutely positioned on the
+ * infinite canvas at world coordinates `(x, y)`.
+ */
+export interface CanvasNodeProps {
+  x: number;
+  y: number;
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Positions its children at a fixed `(x, y)` point in the canvas's world space. Use one per
+ * item placed on an {@link InfiniteCanvasLayout} - panning/zooming the canvas moves and scales
+ * every `CanvasNode` together, since they're rendered inside the same transformed layer.
+ */
+export const CanvasNode: React.FC<CanvasNodeProps> = ({ x, y, width, height, className, children }) => (
+  <div className={cn("absolute", className)} style={{ left: x, top: y, width, height }}>
+    {children}
+  </div>
+);
+CanvasNode.displayName = "CanvasNode";
+
+/**
+ * Props for the {@link InfiniteCanvasLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property children - Canvas content, typically one or more {@link CanvasNode} elements.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to
+ * drive the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface InfiniteCanvasLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  viewport?: CanvasViewport;
+  defaultViewport?: CanvasViewport;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * InfiniteCanvasLayout is a pannable, zoomable workspace shell - the shape behind
+ * whiteboard/canvas tools (Figma, Miro, tldraw). An optional top toolbar sits above a
+ * full-bleed canvas; content is placed via {@link CanvasNode} at fixed world coordinates,
+ * and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard, or the
+ * floating zoom controls.
+ */
+export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
+  header,
+  actions,
+  children,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<CanvasViewport>(defaultViewport);
+  const currentViewport = isControlled ? viewport : internalViewport;
+
+  // Read the latest viewport (and callback) inside event handlers without making them - or the
+  // effects that attach them - depend on it. Consumers commonly pass an inline function for
+  // onViewportChange, which would otherwise get a new identity every render and tear down and
+  // reattach the wheel listener on every unrelated re-render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: CanvasViewport) => CanvasViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, minZoom, maxZoom) };
+      if (!isControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isControlled, minZoom, maxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+
+  // Wheel must call preventDefault() to stop the page from scrolling/zooming - React's JSX
+  // onWheel is passive by default, so a native listener with { passive: false } is required.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), minZoom, maxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, minZoom, maxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only start a pan when the drag begins on empty canvas background, not on a CanvasNode
+    // (or anything else) rendered above it - so content stays independently interactive.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div
+        ref={surfaceRef}
+        className="relative flex-1 touch-none overflow-hidden"
+        style={
+          showGrid
+            ? {
+                backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+              }
+            : undefined
+        }
+        role="group"
+        aria-label="Infinite canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          className="absolute left-0 top-0"
+          style={{
+            transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {children}
+        </div>
+
+        {showControls && (
+          <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+            <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+              <Plus className="h-4 w-4" />
+            </Button>
+            <div className="text-center text-xs text-[var(--muted-foreground)]">
+              {Math.round(currentViewport.zoom * 100)}%
+            </div>
+            <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+InfiniteCanvasLayout.displayName = "InfiniteCanvasLayout";
+
+export default InfiniteCanvasLayout;

--- a/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/index.tsx
@@ -86,6 +86,20 @@ const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 // minZoom a consumer configures.
 const MIN_SAFE_ZOOM = 0.01;
 
+/**
+ * Replaces any non-finite x/y/zoom (NaN, from a consumer's controlled `viewport` or a bad
+ * `updateViewport` computation) with a safe fallback, then clamps zoom to `[minZoom, maxZoom]`.
+ * Used everywhere a viewport is committed to rendering, refs, or `onViewportChange`, so a single
+ * bad value can't produce an invalid CSS transform or poison all subsequent pan/zoom math -
+ * once NaN enters the viewport, every calculation derived from it stays NaN.
+ */
+function normalizeViewport(viewport: CanvasViewport, minZoom: number, maxZoom: number): CanvasViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
 /* -------------------------------------------------------------------------- */
 /*                              MAIN COMPONENT                                */
 /* -------------------------------------------------------------------------- */
@@ -125,13 +139,10 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
 
   // Normalize whichever viewport is currently in effect before it's used for rendering math or
   // stored for event handlers to read. A consumer-supplied `viewport` prop (controlled mode)
-  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range or zero
-  // zoom would reach the CSS transform/grid sizing - and the divide-by-zero in the wheel-zoom
-  // math - unclamped.
-  const currentViewport: CanvasViewport = {
-    ...rawViewport,
-    zoom: clamp(rawViewport.zoom, safeMinZoom, safeMaxZoom),
-  };
+  // bypasses updateViewport's own clamping entirely, so without this, an out-of-range, zero, or
+  // non-finite x/y/zoom would reach the CSS transform/grid sizing - and the divide-by-zero in
+  // the wheel-zoom math - unguarded.
+  const currentViewport: CanvasViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
 
   // Read the latest viewport (and callback) inside event handlers without making them - or the
   // effects that attach them - depend on it. Consumers commonly pass an inline function for
@@ -145,7 +156,7 @@ export const InfiniteCanvasLayout: React.FC<InfiniteCanvasLayoutProps> = ({
   const updateViewport = React.useCallback(
     (updater: (prev: CanvasViewport) => CanvasViewport) => {
       const next = updater(viewportRef.current);
-      const clamped: CanvasViewport = { ...next, zoom: clamp(next.zoom, safeMinZoom, safeMaxZoom) };
+      const clamped: CanvasViewport = normalizeViewport(next, safeMinZoom, safeMaxZoom);
       if (!isControlled) {
         setInternalViewport(clamped);
       }

--- a/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
@@ -1,0 +1,274 @@
+// infinite-canvas-layout.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("lucide-react", () => ({
+  Plus: () => <div data-testid="plus-icon" />,
+  Minus: () => <div data-testid="minus-icon" />,
+  RotateCcw: () => <div data-testid="reset-icon" />,
+}));
+
+import { InfiniteCanvasLayout, CanvasNode, type CanvasViewport } from ".";
+
+function getSurface(container: HTMLElement): HTMLElement {
+  return container.querySelector('[role="group"]') as HTMLElement;
+}
+
+describe("InfiniteCanvasLayout", () => {
+  describe("rendering", () => {
+    it("renders canvas content", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <CanvasNode x={0} y={0}>
+            <p>Node content</p>
+          </CanvasNode>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByText("Node content")).toBeInTheDocument();
+    });
+
+    it("renders header and actions when provided", () => {
+      render(
+        <InfiniteCanvasLayout header={<span>Logo</span>} actions={<button>Share</button>}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+      expect(screen.getByText("Logo")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+    });
+
+    it("omits the header entirely when neither header nor actions are provided", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+    });
+
+    it("exposes an accessible, focusable canvas region", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+      expect(surface).toHaveAttribute("tabIndex", "0");
+      expect(surface.getAttribute("aria-label")).toMatch(/infinite canvas/i);
+    });
+
+    it("positions a CanvasNode at its given world coordinates", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <CanvasNode x={120} y={240} width={100} height={50}>
+            <p>Positioned</p>
+          </CanvasNode>
+        </InfiniteCanvasLayout>
+      );
+      const node = screen.getByText("Positioned").closest("div.absolute") as HTMLElement;
+      expect(node).toHaveStyle({ left: "120px", top: "240px", width: "100px", height: "50px" });
+    });
+  });
+
+  describe("zoom controls", () => {
+    it("renders the floating zoom control panel by default", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Reset view" })).toBeInTheDocument();
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("hides the control panel when showControls is false", () => {
+      render(
+        <InfiniteCanvasLayout showControls={false}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.queryByRole("button", { name: "Zoom in" })).not.toBeInTheDocument();
+    });
+
+    it("zooms in and out via the control buttons, updating the displayed percentage", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("120%")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("resets to defaultViewport when the reset button is clicked", () => {
+      render(
+        <InfiniteCanvasLayout defaultViewport={{ x: 10, y: 20, zoom: 1.5 }}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByText("150%")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.queryByText("150%")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+      expect(screen.getByText("150%")).toBeInTheDocument();
+    });
+
+    it("clamps zoom to minZoom/maxZoom", () => {
+      render(
+        <InfiniteCanvasLayout minZoom={0.5} maxZoom={0.6} defaultViewport={{ x: 0, y: 0, zoom: 0.5 }}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("60%")).toBeInTheDocument();
+    });
+  });
+
+  describe("keyboard interaction", () => {
+    it("zooms in and out and resets via keyboard shortcuts", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+
+      fireEvent.keyDown(surface, { key: "+" });
+      expect(screen.getByText("120%")).toBeInTheDocument();
+
+      fireEvent.keyDown(surface, { key: "0" });
+      expect(screen.getByText("100%")).toBeInTheDocument();
+
+      fireEvent.keyDown(surface, { key: "-" });
+      expect(screen.getByText(/8[0-3]%/)).toBeInTheDocument();
+    });
+
+    it("pans via arrow keys", () => {
+      const onViewportChange = vi.fn();
+      const { container } = render(
+        <InfiniteCanvasLayout onViewportChange={onViewportChange}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+
+      fireEvent.keyDown(surface, { key: "ArrowRight" });
+      expect(onViewportChange).toHaveBeenLastCalledWith(expect.objectContaining({ x: -40, y: 0 }));
+
+      fireEvent.keyDown(surface, { key: "ArrowDown" });
+      expect(onViewportChange).toHaveBeenLastCalledWith(expect.objectContaining({ x: -40, y: -40 }));
+    });
+  });
+
+  describe("controlled vs uncontrolled viewport", () => {
+    it("manages its own viewport when uncontrolled", () => {
+      render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("120%")).toBeInTheDocument();
+    });
+
+    it("does not update its displayed viewport on its own when controlled", () => {
+      const fixedViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+      const onViewportChange = vi.fn();
+      render(
+        <InfiniteCanvasLayout viewport={fixedViewport} onViewportChange={onViewportChange}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+
+      // The parent "ignored" the callback (didn't update the `viewport` prop), so the
+      // displayed zoom must stay exactly what was passed in, not self-manage state.
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(onViewportChange).toHaveBeenCalledWith(expect.objectContaining({ zoom: 1.2 }));
+    });
+
+    it("reflects viewport updates driven by the parent in controlled mode", () => {
+      const ControlledDemo: React.FC = () => {
+        const [viewport, setViewport] = React.useState<CanvasViewport>({ x: 0, y: 0, zoom: 1 });
+        return (
+          <InfiniteCanvasLayout viewport={viewport} onViewportChange={setViewport}>
+            <p>Content</p>
+          </InfiniteCanvasLayout>
+        );
+      };
+      render(<ControlledDemo />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("120%")).toBeInTheDocument();
+    });
+  });
+
+  describe("background grid", () => {
+    it("applies a dot-grid background by default", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+      expect(surface.style.backgroundImage).toContain("radial-gradient");
+    });
+
+    it("omits the background grid when showGrid is false", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout showGrid={false}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+      expect(surface.style.backgroundImage).toBe("");
+    });
+  });
+
+  describe("effect stability", () => {
+    it("does not tear down and reattach the wheel listener when onViewportChange is a fresh inline function every render", () => {
+      // A consumer passing `onViewportChange={(vp) => ...}` inline gets a new function identity
+      // on every render. The wheel-listener effect must not depend on that identity, or it would
+      // remove/re-add the native listener on every unrelated re-render.
+      const RerenderingParent: React.FC = () => {
+        const [tick, setTick] = React.useState(0);
+        return (
+          <div>
+            <button onClick={() => setTick((t) => t + 1)}>rerender</button>
+            <InfiniteCanvasLayout onViewportChange={() => undefined}>
+              <p>Content {tick}</p>
+            </InfiniteCanvasLayout>
+          </div>
+        );
+      };
+      const { container } = render(<RerenderingParent />);
+      const surface = getSurface(container);
+
+      // Spy only after the initial mount (already covered by other tests) so React's own
+      // internal event-delegation setup isn't counted alongside our explicit listener.
+      const addEventListenerSpy = vi.spyOn(surface, "addEventListener");
+      const removeEventListenerSpy = vi.spyOn(surface, "removeEventListener");
+
+      fireEvent.click(screen.getByRole("button", { name: "rerender" }));
+      fireEvent.click(screen.getByRole("button", { name: "rerender" }));
+
+      const wheelAttaches = addEventListenerSpy.mock.calls.filter((call) => call[0] === "wheel").length;
+      const wheelDetaches = removeEventListenerSpy.mock.calls.filter((call) => call[0] === "wheel").length;
+      expect(wheelAttaches).toBe(0);
+      expect(wheelDetaches).toBe(0);
+
+      addEventListenerSpy.mockRestore();
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
@@ -211,6 +211,36 @@ describe("InfiniteCanvasLayout", () => {
       fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
       expect(screen.getByText("120%")).toBeInTheDocument();
     });
+
+    it("clamps an out-of-range controlled zoom (including zero) instead of using it as-is", () => {
+      render(
+        <InfiniteCanvasLayout viewport={{ x: 0, y: 0, zoom: 0 }} onViewportChange={() => undefined} minZoom={0.25} maxZoom={2.5}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      // A raw controlled zoom of 0 must never reach the display (or the transform/grid math)
+      // unclamped - it should be floored at minZoom instead.
+      expect(screen.getByText("25%")).toBeInTheDocument();
+      expect(screen.queryByText("0%")).not.toBeInTheDocument();
+    });
+
+    it("does not corrupt the viewport via divide-by-zero when ctrl+wheel-zooming from a controlled zoom of 0", () => {
+      const onViewportChange = vi.fn();
+      const { container } = render(
+        <InfiniteCanvasLayout viewport={{ x: 0, y: 0, zoom: 0 }} onViewportChange={onViewportChange} minZoom={0.25} maxZoom={2.5}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+
+      fireEvent.wheel(surface, { deltaY: -100, ctrlKey: true });
+
+      expect(onViewportChange).toHaveBeenCalled();
+      const lastViewport = onViewportChange.mock.calls.at(-1)?.[0] as CanvasViewport;
+      expect(Number.isFinite(lastViewport.zoom)).toBe(true);
+      expect(Number.isFinite(lastViewport.x)).toBe(true);
+      expect(Number.isFinite(lastViewport.y)).toBe(true);
+    });
   });
 
   describe("background grid", () => {

--- a/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
@@ -188,6 +188,28 @@ describe("InfiniteCanvasLayout", () => {
       expect(screen.getByText("100%")).toBeInTheDocument();
     });
 
+    it("replaces non-finite x/y with coordinate defaults instead of producing an invalid transform", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout viewport={{ x: NaN, y: 0, zoom: 1 }} onViewportChange={() => undefined}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+      const layer = surface.querySelector("div") as HTMLElement;
+      expect(layer.style.transform).not.toContain("NaN");
+      expect(layer.style.transform).toContain("translate(0px");
+    });
+
+    it("replaces a non-finite controlled zoom value with a finite fallback", () => {
+      render(
+        <InfiniteCanvasLayout viewport={{ x: 0, y: 0, zoom: NaN }} onViewportChange={() => undefined}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.queryByText("NaN%")).not.toBeInTheDocument();
+    });
+
     it("keeps zoom finite and valid during wheel interactions when maxZoom is 0", () => {
       const onViewportChange = vi.fn();
       const { container } = render(

--- a/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
+++ b/packages/registry/templates/layouts/infinite-canvas-layout/infinite-canvas-layout.test.tsx
@@ -70,6 +70,36 @@ describe("InfiniteCanvasLayout", () => {
       const node = screen.getByText("Positioned").closest("div.absolute") as HTMLElement;
       expect(node).toHaveStyle({ left: "120px", top: "240px", width: "100px", height: "50px" });
     });
+
+    it("disables text selection on the canvas surface, so dragging through a node's text doesn't select it", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout>
+          <CanvasNode x={0} y={0}>
+            <p>Idea</p>
+          </CanvasNode>
+        </InfiniteCanvasLayout>
+      );
+      // `user-select: none` cascades to descendants (including CanvasNode content), which is
+      // what actually stops the browser's native drag-to-select from highlighting text as the
+      // cursor sweeps across it mid-pan - jsdom doesn't implement selection, so this asserts the
+      // mechanism that produces that behavior in a real browser.
+      const surface = getSurface(container);
+      expect(surface.className).toContain("select-none");
+    });
+
+    it("prevents the default (text-selection-starting) action when a pan begins on empty background", () => {
+      const { container } = render(
+        <InfiniteCanvasLayout>
+          <CanvasNode x={0} y={0}>
+            <p>Idea</p>
+          </CanvasNode>
+        </InfiniteCanvasLayout>
+      );
+      const surface = getSurface(container);
+      const event = new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 });
+      const wasPrevented = !surface.dispatchEvent(event);
+      expect(wasPrevented).toBe(true);
+    });
   });
 
   describe("zoom controls", () => {
@@ -130,6 +160,53 @@ describe("InfiniteCanvasLayout", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
       expect(screen.getByText("60%")).toBeInTheDocument();
+    });
+
+    it("recovers from an inverted zoom range (maxZoom < minZoom) instead of freezing at an unreachable value", () => {
+      render(
+        <InfiniteCanvasLayout minZoom={2} maxZoom={0.5} defaultViewport={{ x: 0, y: 0, zoom: 1 }}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      // maxZoom is bumped up to at least minZoom rather than silently freezing zoom at 50%.
+      expect(screen.getByText("200%")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("200%")).toBeInTheDocument();
+    });
+
+    it("falls back to a sane bound when maxZoom is not a finite number", () => {
+      render(
+        <InfiniteCanvasLayout minZoom={0.25} maxZoom={NaN}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.queryByText("NaN%")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("keeps zoom finite and valid during wheel interactions when maxZoom is 0", () => {
+      const onViewportChange = vi.fn();
+      const { container } = render(
+        <InfiniteCanvasLayout maxZoom={0} onViewportChange={onViewportChange}>
+          <p>Content</p>
+        </InfiniteCanvasLayout>
+      );
+      // maxZoom=0 is finite but below the default minZoom (0.25), so it's bumped up to 25%
+      // rather than collapsing the range to zero.
+      expect(screen.getByText("25%")).toBeInTheDocument();
+
+      const surface = getSurface(container);
+      fireEvent.wheel(surface, { deltaY: -100, ctrlKey: true });
+
+      expect(onViewportChange).toHaveBeenCalled();
+      const lastViewport = onViewportChange.mock.calls.at(-1)?.[0] as CanvasViewport;
+      expect(Number.isFinite(lastViewport.zoom)).toBe(true);
+      expect(lastViewport.zoom).toBeGreaterThan(0);
+      expect(lastViewport.zoom).toBeLessThanOrEqual(0.25);
     });
   });
 


### PR DESCRIPTION

## Description

### What does this PR do?

Adds `InfiniteCanvasLayout`, a new production-ready composition template: a pannable, zoomable canvas workspace shell (the shape behind Figma/Miro/tldraw-style tools). An optional top toolbar sits above a full-bleed dot-grid surface; content is placed via a `CanvasNode` helper at fixed world coordinates, and the whole layer pans/zooms together via drag, wheel/trackpad, keyboard shortcuts, or floating zoom controls.

### Related Issues

- Implements one item from the #876 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

### Local Machine 
<img width="1913" height="1062" alt="image" src="https://github.com/user-attachments/assets/4a2894e8-f3da-493d-95af-322578e35cda" />

### Storybook
<img width="1884" height="1115" alt="image" src="https://github.com/user-attachments/assets/e5e8adae-17fe-4e36-a894-7b6b73260ed3" />

### Docs
<img width="1906" height="1011" alt="image" src="https://github.com/user-attachments/assets/befe2bfa-0bd3-4263-832a-7d4e56fd5ae5" />


## Additional Context

Ships with the full set expected for a template in this repo:
- **Registry component** — `packages/registry/templates/layouts/infinite-canvas-layout/index.tsx` + `registry.json` entry (installable via `ignix add component InfiniteCanvasLayout`)
- **Tests** — 18 tests covering rendering, zoom controls, keyboard shortcuts (pan/zoom/reset), controlled vs. uncontrolled viewport state, the background grid, and effect stability (the wheel listener isn't torn down/reattached when a consumer passes an inline `onViewportChange`)
- **Storybook** — 7 stories under `Templates/Layouts/InfiniteCanvasLayout` (`Default`, `WithHeaderAndActions`, `WithoutGrid`, `WithoutControls`, `ManyNodes`, `CustomZoomLimits`, `ControlledViewport`)
- **Docs site** — live interactive demo, full `infinite-canvas-layout.mdx` page (Installation/Usage/Interaction Reference/Props), and a new sidebar entry under "Page Layout"



### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components and component API changes**
  - Added `InfiniteCanvasLayout` and `CanvasNode`.
  - Added controlled and uncontrolled `CanvasViewport` support.
  - Added panning, zooming, toolbar content, dot-grid rendering, zoom controls, keyboard navigation, and configurable zoom limits.

- **Bug fixes**
  - Normalized invalid viewport zoom values.
  - Prevented divide-by-zero errors during pointer-anchored zooming.
  - Prevented text selection during panning.
  - Stabilized native wheel listeners.

- **Tooling / config changes**
  - Registered `infinitecanvaslayout` and its `lucide-react` and `button` dependencies.
  - Added 18 interaction and behavior tests.

- **Docs / Storybook updates**
  - Added seven Storybook stories.
  - Added an interactive documentation demo.
  - Added versioned usage and API documentation.
  - Added the layout to the documentation sidebar.

## Breaking changes

None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->