### PR TITLE
feat(component): add ai-response-action component

### DIFF
--- a/apps/docs/docs/components/ai-response-actions.mdx
+++ b/apps/docs/docs/components/ai-response-actions.mdx
@@ -1,0 +1,374 @@
+---
+sidebar_position: 10
+title: AIResponseActions
+description: An interactive actions toolbar for AI responses with animated thumbs, copy tooltips, and regeneration controls.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import { AIResponseActions } from '@site/src/components/UI/ai-response-actions';
+import AIResponseActionsDemo from '@site/src/components/Demo/AIResponseActionsDemo';
+
+The AIResponseActions toolbar is designed for placement at the bottom of messages in AI interfaces. It provides pre-styled actions for feedback (Thumbs Up / Down), regeneration, copying response contents, sharing, and bookmarking. It integrates seamlessly with `<Tooltip>` descriptions and utilizes spring physics for interactive feedback.
+
+<AIResponseActionsDemo />
+
+## Installation
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+
+```bash
+ignix add component ai-response-actions
+```
+
+  </TabItem>
+
+  <TabItem
+    value="manual"
+    label="Manual"
+    className="max-h-[500px] overflow-y-auto"
+  >
+
+```tsx
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, RotateCcw, ThumbsUp, ThumbsDown, Share2, Bookmark } from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Button } from "../button";
+import { Tooltip } from "../tooltip";
+
+const actionsVariants = cva(
+  "inline-flex items-center gap-1 p-1 rounded-xl transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        dark: "bg-neutral-900 border border-neutral-800 text-white",
+        glass: "bg-white/10 border border-white/20 backdrop-blur-xl text-white",
+        minimal: "p-0 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AIResponseActionsProps extends VariantProps<typeof actionsVariants> {
+  content: string;
+  className?: string;
+  size?: "sm" | "md";
+  
+  // Callbacks
+  onCopy?: (text: string) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onFeedback?: (type: "up" | "down") => void;
+  onShare?: () => void;
+  onBookmark?: () => void;
+  
+  // Controlled States
+  feedback?: "up" | "down" | null;
+  isBookmarked?: boolean;
+  
+  // Custom elements
+  children?: React.ReactNode;
+}
+
+export const AIResponseActions = React.forwardRef<HTMLDivElement, AIResponseActionsProps>(
+  (
+    {
+      content,
+      className,
+      size = "sm",
+      variant = "default",
+      onCopy,
+      onRegenerate,
+      onFeedback,
+      onShare,
+      onBookmark,
+      feedback,
+      isBookmarked,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = React.useState(false);
+    const [localFeedback, setLocalFeedback] = React.useState<"up" | "down" | null>(null);
+    const [localBookmarked, setLocalBookmarked] = React.useState(false);
+
+    // Sync controlled props
+    React.useEffect(() => {
+      if (feedback !== undefined) {
+        setLocalFeedback(feedback);
+      }
+    }, [feedback]);
+
+    React.useEffect(() => {
+      if (isBookmarked !== undefined) {
+        setLocalBookmarked(isBookmarked);
+      }
+    }, [isBookmarked]);
+
+    const handleCopy = async () => {
+      if (copied) return;
+      try {
+        if (onCopy) {
+          await onCopy(content);
+        } else {
+          await navigator.clipboard.writeText(content);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    };
+
+    const handleFeedback = (type: "up" | "down") => {
+      const nextFeedback = localFeedback === type ? null : type;
+      if (feedback === undefined) {
+        setLocalFeedback(nextFeedback);
+      }
+      onFeedback?.(type);
+    };
+
+    const handleBookmark = () => {
+      const nextBookmarked = !localBookmarked;
+      if (isBookmarked === undefined) {
+        setLocalBookmarked(nextBookmarked);
+      }
+      onBookmark?.();
+    };
+
+    const getButtonClass = (isActive: boolean = false) => {
+      return cn(
+        "rounded-lg p-1.5 transition-all focus-visible:ring-1 focus-visible:ring-offset-0 cursor-pointer active:scale-95",
+        variant === "glass" && (isActive ? "bg-white/15 text-white" : "text-white/70 hover:text-white hover:bg-white/10"),
+        variant === "dark" && (isActive ? "bg-neutral-800 text-white" : "text-neutral-400 hover:text-white hover:bg-neutral-800"),
+        variant === "default" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-50 dark:hover:text-neutral-200 dark:hover:bg-neutral-800/50"),
+        variant === "minimal" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200")
+      );
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(actionsVariants({ variant }), className)}
+        {...props}
+      >
+        {/* Copy Action */}
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <Button
+            type="button"
+            variant="none"
+            size={size === "sm" ? "compact" : "sm"}
+            className={getButtonClass(copied)}
+            onClick={handleCopy}
+            aria-label="Copy message"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Check size={size === "sm" ? 14 : 16} className="text-emerald-500" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Copy size={size === "sm" ? 14 : 16} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+        </Tooltip>
+
+        {/* Regenerate Action */}
+        {onRegenerate && (
+          <Tooltip content="Regenerate response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <motion.div whileTap={{ rotate: 180 }} transition={{ duration: 0.3 }}>
+                <RotateCcw size={size === "sm" ? 14 : 16} />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Feedback: Up */}
+        {onFeedback && (
+          <Tooltip content="Helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "up")}
+              onClick={() => handleFeedback("up")}
+              aria-label="Helpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "up" ? { scale: [1, 1.25, 1], rotate: [0, -10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsUp
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "up" && "fill-current text-blue-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Feedback: Down */}
+        {onFeedback && (
+          <Tooltip content="Not helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "down")}
+              onClick={() => handleFeedback("down")}
+              aria-label="Unhelpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "down" ? { scale: [1, 1.25, 1], rotate: [0, 10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsDown
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "down" && "fill-current text-red-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Bookmark Action */}
+        {onBookmark && (
+          <Tooltip content={localBookmarked ? "Remove bookmark" : "Bookmark response"}>
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localBookmarked)}
+              onClick={handleBookmark}
+              aria-label="Bookmark response"
+            >
+              <motion.div
+                animate={localBookmarked ? { scale: [1, 1.2, 1] } : {}}
+                transition={{ duration: 0.2 }}
+              >
+                <Bookmark
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localBookmarked && "fill-current text-amber-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Share Action */}
+        {onShare && (
+          <Tooltip content="Share response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onShare}
+              aria-label="Share response"
+            >
+              <Share2 size={size === "sm" ? 14 : 16} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {children}
+      </div>
+    );
+  }
+);
+
+AIResponseActions.displayName = "AIResponseActions";
+export { actionsVariants };
+```
+
+  </TabItem>
+</Tabs>
+
+## Usage
+
+```tsx
+import { AIResponseActions } from '@mindfiredigital/ignix-ui';```
+
+### Basic Example
+
+Choose which callbacks to enable. Action buttons are dynamically rendered based on the presence of callback properties:
+
+```tsx
+
+function MinimalActions() {
+  return (
+    <AIResponseActions
+      content="Response text to copy"
+      // Only copy (default) and feedback will render
+      onFeedback={(type) => console.log('Feedback submitted:', type)}
+    />
+  );
+}
+```
+
+### Variants
+
+Customize the surrounding container border styles with the `variant` property:
+
+```tsx
+{/* Glassmorphic border variant for visual gradients */}
+<AIResponseActions
+  content="Content text"
+  variant="glass"
+  onFeedback={(type) => {}}
+/>
+
+{/* Dark variant for darker layout wrappers */}
+<AIResponseActions
+  content="Content text"
+  variant="dark"
+  onFeedback={(type) => {}}
+/>
+```
+
+
+## Props
+
+| Porp | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `content` | `string` | - | **(Required)** The textual response content to copy or share. |
+| `variant` | `'default' \| 'dark' \| 'glass' \| 'minimal'` | `'default'` | Surrounding toolbar card variants. |
+| `size` | `'sm' \| 'md'` | `'sm'` | Size adjustment parameter for action buttons. |
+| `onFeedback` | `(type: 'up' \| 'down') => void` | - | Callback when thumbs up/down is toggled. |
+| `onRegenerate` | `() => void` | - | Callback when regenerate action is clicked. |
+| `onShare` | `() => void` | - | Callback when share action is clicked. |
+| `onBookmark` | `() => void` | - | Callback when bookmark saving is clicked. |
+| `feedback` | `'up' \| 'down' \| null` | - | Controlled state parameter for feedback buttons. |
+| `isBookmarked` | `boolean` | - | Controlled state parameter for bookmark active fills. |

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -59,7 +59,7 @@ const sidebars: SidebarsConfig = {
             'components/ai-suggested-actions',
             'components/ai-chat',
             'components/ai-conversation-history',
-            'components/ai-code-block'
+            'components/ai-response-actions'
            
           ],
         },

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
             'components/ai-suggested-actions',
             'components/ai-chat',
             'components/ai-conversation-history',
+            'components/ai-code-block',
             'components/ai-response-actions'
            
           ],

--- a/apps/docs/src/components/Demo/AIResponseActionsDemo.tsx
+++ b/apps/docs/src/components/Demo/AIResponseActionsDemo.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from "react";
+import { AIResponseActions } from "../UI/ai-response-actions";
+import VariantSelector from "./VariantSelector";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+
+const AIResponseActionsDemo: React.FC = () => {
+  const [variant, setVariant] = useState<"default" | "dark" | "glass" | "minimal">("default");
+  const [size, setSize] = useState<"sm" | "md">("sm");
+
+
+  const [hasRegenerate, setHasRegenerate] = useState(true);
+  const [hasFeedback, setHasFeedback] = useState(true);
+  const [hasShare, setHasShare] = useState(true);
+  const [hasBookmark, setHasBookmark] = useState(true);
+
+
+  const [feedbackVal, setFeedbackVal] = useState<"up" | "down" | null>(null);
+  const [bookmarkedVal, setBookmarkedVal] = useState(false);
+
+  const responseText = `Here is a custom React hook that synchronizes component state with your router:
+
+\`\`\`typescript
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+export function useUrlState<T>(key: string, initialValue: T) {
+  const router = useRouter();
+  // State synchronization logic...
+}
+\`\`\``;
+
+  const codeString = `
+import { AIResponseActions } from '@mindfiredigital/ignix-ui';
+
+function MessageActions() {
+  return (
+    <AIResponseActions
+      content={\`\${responseText}\`}
+      variant="${variant}"
+      size="${size}"
+      ${hasRegenerate ? "onRegenerate={() => regenerate()}" : ""}
+      ${hasFeedback ? `feedback={feedback}\n      onFeedback={(type) => setFeedback(type)}` : ""}
+      ${hasShare ? "onShare={() => share()}" : ""}
+      ${hasBookmark ? `isBookmarked={bookmarked}\n      onBookmark={() => toggleBookmark()}` : ""}
+    />
+  );
+}
+`;
+
+  return (
+    <div className="flex flex-col space-y-4 mb-8">
+      {/* Configuration Panel */}
+      <div className="flex flex-wrap gap-4 justify-start md:justify-end">
+        <VariantSelector
+          type="Variant"
+          variants={["default", "dark", "glass", "minimal"]}
+          selectedVariant={variant}
+          onSelectVariant={(v) => setVariant(v as any)}
+          variantLabels={{
+            default: "Default",
+            dark: "Dark",
+            glass: "Glass",
+            minimal: "Minimal",
+          }}
+        />
+
+        <VariantSelector
+          type="Size"
+          variants={["sm", "md"]}
+          selectedVariant={size}
+          onSelectVariant={(v) => setSize(v as any)}
+          variantLabels={{
+            sm: "Small (Compact)",
+            md: "Medium",
+          }}
+        />
+
+        {/* Feature Switches */}
+        <div className="flex flex-wrap gap-4 text-xs font-semibold text-neutral-500">
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={hasRegenerate}
+              onChange={(e) => setHasRegenerate(e.target.checked)}
+              className="cursor-pointer"
+            />
+            Regenerate
+          </label>
+
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={hasFeedback}
+              onChange={(e) => setHasFeedback(e.target.checked)}
+              className="cursor-pointer"
+            />
+            Feedback
+          </label>
+
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={hasShare}
+              onChange={(e) => setHasShare(e.target.checked)}
+              className="cursor-pointer"
+            />
+            Share
+          </label>
+
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={hasBookmark}
+              onChange={(e) => setHasBookmark(e.target.checked)}
+              className="cursor-pointer"
+            />
+            Bookmark
+          </label>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs>
+        <TabItem value="preview" label="Preview">
+          <div
+            className={`p-6 border rounded-xl min-h-[220px] flex items-center justify-center transition-all ${variant === "dark"
+              ? "bg-neutral-950 border-neutral-900"
+              : variant === "glass"
+                ? "bg-gradient-to-br from-black via-red-950 to-neutral-900 border-transparent text-white"
+                : "bg-white dark:bg-neutral-950 dark:border-neutral-800"
+              }`}
+          >
+            <div
+              className={`max-w-lg w-full p-5 border rounded-2xl shadow-sm space-y-4 ${variant === "dark"
+                ? "bg-neutral-900 border-neutral-800 text-white"
+                : variant === "glass"
+                  ? "bg-white/10 border-white/20 backdrop-blur-xl text-white"
+                  : "bg-neutral-50/50 border-neutral-100 dark:bg-neutral-900/50 dark:border-neutral-800 text-neutral-800 dark:text-neutral-200"
+                }`}
+            >
+              {/* Message header */}
+              <div className="flex items-center gap-2 select-none">
+                <div className="w-6 h-6 rounded-full bg-indigo-500 flex items-center justify-center text-[10px] text-white font-bold">
+                  AI
+                </div>
+                <span className={`text-[11px] font-bold uppercase tracking-wider ${variant === "glass" ? "text-white/80" : "text-neutral-400 dark:text-neutral-550"
+                  }`}>
+                  Code Assistant
+                </span>
+              </div>
+
+              
+              <div className="text-sm leading-relaxed whitespace-pre-wrap font-medium">
+                {responseText}
+              </div>
+
+              
+              <div className={`flex justify-between items-center border-t pt-3 select-none ${variant === "glass" ? "border-white/10" : "border-neutral-100 dark:border-neutral-800"
+                }`}>
+                <span className={`text-[10px] font-semibold ${variant === "glass" ? "text-white/60" : "text-neutral-400 dark:text-neutral-500"
+                  }`}>
+                  Helpful?
+                </span>
+                <AIResponseActions
+                  content={responseText}
+                  variant={variant}
+                  size={size}
+                  onRegenerate={hasRegenerate ? () => alert("Regenerating response...") : undefined}
+                  onFeedback={hasFeedback ? (type) => setFeedbackVal((prev) => (prev === type ? null : type)) : undefined}
+                  feedback={hasFeedback ? feedbackVal : undefined}
+                  onBookmark={hasBookmark ? () => setBookmarkedVal((prev) => !prev) : undefined}
+                  isBookmarked={hasBookmark ? bookmarkedVal : undefined}
+                  onShare={hasShare ? () => alert("Link copied to clipboard!") : undefined}
+                />
+              </div>
+            </div>
+          </div>
+        </TabItem>
+        <TabItem value="code" label="Code">
+          <CodeBlock language="tsx">{codeString}</CodeBlock>
+        </TabItem>
+      </Tabs>
+    </div >
+  );
+};
+
+export default AIResponseActionsDemo;

--- a/apps/docs/src/components/UI/ai-response-actions/index.tsx
+++ b/apps/docs/src/components/UI/ai-response-actions/index.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, RotateCcw, ThumbsUp, ThumbsDown, Share2, Bookmark } from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Button } from "../button";
+import { Tooltip } from "../tooltip";
+
+const actionsVariants = cva(
+  "inline-flex items-center gap-1 p-1 rounded-xl transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        dark: "bg-neutral-900 border border-neutral-800 text-white",
+        glass: "bg-white/10 border border-white/20 backdrop-blur-xl text-whit",
+        minimal: "p-0 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AIResponseActionsProps extends VariantProps<typeof actionsVariants> {
+  content: string;
+  className?: string;
+  size?: "sm" | "md";
+
+  onCopy?: (text: string) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onFeedback?: (type: "up" | "down") => void;
+  onShare?: () => void;
+  onBookmark?: () => void;
+  feedback?: "up" | "down" | null;
+  isBookmarked?: boolean;
+  children?: React.ReactNode;
+}
+
+export const AIResponseActions = React.forwardRef<HTMLDivElement, AIResponseActionsProps>(
+  (
+    {
+      content,
+      className,
+      size = "sm",
+      variant = "default",
+      onCopy,
+      onRegenerate,
+      onFeedback,
+      onShare,
+      onBookmark,
+      feedback,
+      isBookmarked,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = React.useState(false);
+    const [localFeedback, setLocalFeedback] = React.useState<"up" | "down" | null>(null);
+    const [localBookmarked, setLocalBookmarked] = React.useState(false);
+
+    React.useEffect(() => {
+      if (feedback !== undefined) {
+        setLocalFeedback(feedback);
+      }
+    }, [feedback]);
+
+    React.useEffect(() => {
+      if (isBookmarked !== undefined) {
+        setLocalBookmarked(isBookmarked);
+      }
+    }, [isBookmarked]);
+
+    const handleCopy = async () => {
+      if (copied) return;
+      try {
+        if (onCopy) {
+          await onCopy(content);
+        } else {
+          await navigator.clipboard.writeText(content);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    };
+
+    const handleFeedback = (type: "up" | "down") => {
+      const nextFeedback = localFeedback === type ? null : type;
+      if (feedback === undefined) {
+        setLocalFeedback(nextFeedback);
+      }
+      onFeedback?.(type);
+    };
+
+    const handleBookmark = () => {
+      const nextBookmarked = !localBookmarked;
+      if (isBookmarked === undefined) {
+        setLocalBookmarked(nextBookmarked);
+      }
+      onBookmark?.();
+    };
+
+    const getButtonClass = (isActive = false) => {
+      return cn(
+        "rounded-lg p-1.5 transition-all focus-visible:ring-1 focus-visible:ring-offset-0 cursor-pointer active:scale-95",
+        variant === "glass" && (isActive ? "bg-white/15 text-white" : "text-white/70 hover:text-white hover:bg-white/10"),
+        variant === "dark" && (isActive ? "bg-neutral-800 text-white" : "text-neutral-400 hover:text-white hover:bg-neutral-800"),
+        variant === "default" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-50 dark:hover:text-neutral-200 dark:hover:bg-neutral-800/50"),
+        variant === "minimal" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200")
+      );
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(actionsVariants({ variant }), className)}
+        {...props}
+      >
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <Button
+            type="button"
+            variant="none"
+            size={size === "sm" ? "compact" : "sm"}
+            className={getButtonClass(copied)}
+            onClick={handleCopy}
+            aria-label="Copy message"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Check size={size === "sm" ? 14 : 16} className="text-emerald-500" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Copy size={size === "sm" ? 14 : 16} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+        </Tooltip>
+
+        {onRegenerate && (
+          <Tooltip content="Regenerate response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <motion.div whileTap={{ rotate: 180 }} transition={{ duration: 0.3 }}>
+                <RotateCcw size={size === "sm" ? 14 : 16} />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "up")}
+              onClick={() => handleFeedback("up")}
+              aria-label="Helpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "up" ? { scale: [1, 1.25, 1], rotate: [0, -10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsUp
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "up" && "fill-current text-blue-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Not helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "down")}
+              onClick={() => handleFeedback("down")}
+              aria-label="Unhelpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "down" ? { scale: [1, 1.25, 1], rotate: [0, 10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsDown
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "down" && "fill-current text-red-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onBookmark && (
+          <Tooltip content={localBookmarked ? "Remove bookmark" : "Bookmark response"}>
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localBookmarked)}
+              onClick={handleBookmark}
+              aria-label="Bookmark response"
+            >
+              <motion.div
+                animate={localBookmarked ? { scale: [1, 1.2, 1] } : {}}
+                transition={{ duration: 0.2 }}
+              >
+                <Bookmark
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localBookmarked && "fill-current text-amber-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onShare && (
+          <Tooltip content="Share response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onShare}
+              aria-label="Share response"
+            >
+              <Share2 size={size === "sm" ? 14 : 16} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {children}
+      </div>
+    );
+  }
+);
+
+AIResponseActions.displayName = "AIResponseActions";
+export { actionsVariants };

--- a/apps/docs/versioned_docs/version-1.0.3/components/ai-response-actions.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/ai-response-actions.mdx
@@ -1,0 +1,374 @@
+---
+sidebar_position: 10
+title: AIResponseActions
+description: An interactive actions toolbar for AI responses with animated thumbs, copy tooltips, and regeneration controls.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import { AIResponseActions } from '@site/src/components/UI/ai-response-actions';
+import AIResponseActionsDemo from '@site/src/components/Demo/AIResponseActionsDemo';
+
+The AIResponseActions toolbar is designed for placement at the bottom of messages in AI interfaces. It provides pre-styled actions for feedback (Thumbs Up / Down), regeneration, copying response contents, sharing, and bookmarking. It integrates seamlessly with `<Tooltip>` descriptions and utilizes spring physics for interactive feedback.
+
+<AIResponseActionsDemo />
+
+## Installation
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+
+```bash
+ignix add component ai-response-actions
+```
+
+  </TabItem>
+
+  <TabItem
+    value="manual"
+    label="Manual"
+    className="max-h-[500px] overflow-y-auto"
+  >
+
+```tsx
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, RotateCcw, ThumbsUp, ThumbsDown, Share2, Bookmark } from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Button } from "../button";
+import { Tooltip } from "../tooltip";
+
+const actionsVariants = cva(
+  "inline-flex items-center gap-1 p-1 rounded-xl transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        dark: "bg-neutral-900 border border-neutral-800 text-white",
+        glass: "bg-white/10 border border-white/20 backdrop-blur-xl text-white",
+        minimal: "p-0 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AIResponseActionsProps extends VariantProps<typeof actionsVariants> {
+  content: string;
+  className?: string;
+  size?: "sm" | "md";
+  
+  // Callbacks
+  onCopy?: (text: string) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onFeedback?: (type: "up" | "down") => void;
+  onShare?: () => void;
+  onBookmark?: () => void;
+  
+  // Controlled States
+  feedback?: "up" | "down" | null;
+  isBookmarked?: boolean;
+  
+  // Custom elements
+  children?: React.ReactNode;
+}
+
+export const AIResponseActions = React.forwardRef<HTMLDivElement, AIResponseActionsProps>(
+  (
+    {
+      content,
+      className,
+      size = "sm",
+      variant = "default",
+      onCopy,
+      onRegenerate,
+      onFeedback,
+      onShare,
+      onBookmark,
+      feedback,
+      isBookmarked,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = React.useState(false);
+    const [localFeedback, setLocalFeedback] = React.useState<"up" | "down" | null>(null);
+    const [localBookmarked, setLocalBookmarked] = React.useState(false);
+
+    // Sync controlled props
+    React.useEffect(() => {
+      if (feedback !== undefined) {
+        setLocalFeedback(feedback);
+      }
+    }, [feedback]);
+
+    React.useEffect(() => {
+      if (isBookmarked !== undefined) {
+        setLocalBookmarked(isBookmarked);
+      }
+    }, [isBookmarked]);
+
+    const handleCopy = async () => {
+      if (copied) return;
+      try {
+        if (onCopy) {
+          await onCopy(content);
+        } else {
+          await navigator.clipboard.writeText(content);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    };
+
+    const handleFeedback = (type: "up" | "down") => {
+      const nextFeedback = localFeedback === type ? null : type;
+      if (feedback === undefined) {
+        setLocalFeedback(nextFeedback);
+      }
+      onFeedback?.(type);
+    };
+
+    const handleBookmark = () => {
+      const nextBookmarked = !localBookmarked;
+      if (isBookmarked === undefined) {
+        setLocalBookmarked(nextBookmarked);
+      }
+      onBookmark?.();
+    };
+
+    const getButtonClass = (isActive: boolean = false) => {
+      return cn(
+        "rounded-lg p-1.5 transition-all focus-visible:ring-1 focus-visible:ring-offset-0 cursor-pointer active:scale-95",
+        variant === "glass" && (isActive ? "bg-white/15 text-white" : "text-white/70 hover:text-white hover:bg-white/10"),
+        variant === "dark" && (isActive ? "bg-neutral-800 text-white" : "text-neutral-400 hover:text-white hover:bg-neutral-800"),
+        variant === "default" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-50 dark:hover:text-neutral-200 dark:hover:bg-neutral-800/50"),
+        variant === "minimal" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200")
+      );
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(actionsVariants({ variant }), className)}
+        {...props}
+      >
+        {/* Copy Action */}
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <Button
+            type="button"
+            variant="none"
+            size={size === "sm" ? "compact" : "sm"}
+            className={getButtonClass(copied)}
+            onClick={handleCopy}
+            aria-label="Copy message"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Check size={size === "sm" ? 14 : 16} className="text-emerald-500" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Copy size={size === "sm" ? 14 : 16} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+        </Tooltip>
+
+        {/* Regenerate Action */}
+        {onRegenerate && (
+          <Tooltip content="Regenerate response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <motion.div whileTap={{ rotate: 180 }} transition={{ duration: 0.3 }}>
+                <RotateCcw size={size === "sm" ? 14 : 16} />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Feedback: Up */}
+        {onFeedback && (
+          <Tooltip content="Helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "up")}
+              onClick={() => handleFeedback("up")}
+              aria-label="Helpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "up" ? { scale: [1, 1.25, 1], rotate: [0, -10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsUp
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "up" && "fill-current text-blue-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Feedback: Down */}
+        {onFeedback && (
+          <Tooltip content="Not helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "down")}
+              onClick={() => handleFeedback("down")}
+              aria-label="Unhelpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "down" ? { scale: [1, 1.25, 1], rotate: [0, 10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsDown
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "down" && "fill-current text-red-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Bookmark Action */}
+        {onBookmark && (
+          <Tooltip content={localBookmarked ? "Remove bookmark" : "Bookmark response"}>
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localBookmarked)}
+              onClick={handleBookmark}
+              aria-label="Bookmark response"
+            >
+              <motion.div
+                animate={localBookmarked ? { scale: [1, 1.2, 1] } : {}}
+                transition={{ duration: 0.2 }}
+              >
+                <Bookmark
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localBookmarked && "fill-current text-amber-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {/* Share Action */}
+        {onShare && (
+          <Tooltip content="Share response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onShare}
+              aria-label="Share response"
+            >
+              <Share2 size={size === "sm" ? 14 : 16} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {children}
+      </div>
+    );
+  }
+);
+
+AIResponseActions.displayName = "AIResponseActions";
+export { actionsVariants };
+```
+
+  </TabItem>
+</Tabs>
+
+## Usage
+
+```tsx
+import { AIResponseActions } from '@mindfiredigital/ignix-ui';```
+
+### Basic Example
+
+Choose which callbacks to enable. Action buttons are dynamically rendered based on the presence of callback properties:
+
+```tsx
+
+function MinimalActions() {
+  return (
+    <AIResponseActions
+      content="Response text to copy"
+      // Only copy (default) and feedback will render
+      onFeedback={(type) => console.log('Feedback submitted:', type)}
+    />
+  );
+}
+```
+
+### Variants
+
+Customize the surrounding container border styles with the `variant` property:
+
+```tsx
+{/* Glassmorphic border variant for visual gradients */}
+<AIResponseActions
+  content="Content text"
+  variant="glass"
+  onFeedback={(type) => {}}
+/>
+
+{/* Dark variant for darker layout wrappers */}
+<AIResponseActions
+  content="Content text"
+  variant="dark"
+  onFeedback={(type) => {}}
+/>
+```
+
+
+## Props
+
+| Porp | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `content` | `string` | - | **(Required)** The textual response content to copy or share. |
+| `variant` | `'default' \| 'dark' \| 'glass' \| 'minimal'` | `'default'` | Surrounding toolbar card variants. |
+| `size` | `'sm' \| 'md'` | `'sm'` | Size adjustment parameter for action buttons. |
+| `onFeedback` | `(type: 'up' \| 'down') => void` | - | Callback when thumbs up/down is toggled. |
+| `onRegenerate` | `() => void` | - | Callback when regenerate action is clicked. |
+| `onShare` | `() => void` | - | Callback when share action is clicked. |
+| `onBookmark` | `() => void` | - | Callback when bookmark saving is clicked. |
+| `feedback` | `'up' \| 'down' \| null` | - | Controlled state parameter for feedback buttons. |
+| `isBookmarked` | `boolean` | - | Controlled state parameter for bookmark active fills. |

--- a/apps/storybook/src/components/ai-response-actions/ai-response-actions.stories.tsx
+++ b/apps/storybook/src/components/ai-response-actions/ai-response-actions.stories.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AIResponseActions } from "./index";
+
+const meta: Meta<typeof AIResponseActions> = {
+  title: "Components/AI/AIResponseActions",
+  component: AIResponseActions,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The **AIResponseActions** toolbar provides a premium, micro-animated set of quick actions for AI responses. It includes native hooks for **copying text**, **thumbs up/down feedback**, **response regeneration**, **sharing**, and **bookmarking**, each wrapped in design system tooltips.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "dark", "glass", "minimal"],
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AIResponseActions>;
+
+export const Default: Story = {
+  args: {
+    content: "This is a sample AI assistant response with useful insights.",
+    onFeedback: (type) => console.log("Feedback: ", type),
+    onRegenerate: () => console.log("Regenerate response clicked"),
+  },
+};
+
+export const FullActions: Story = {
+  args: {
+    content: "Check out this comprehensive response. Share it or bookmark it for later reference!",
+    onFeedback: (type) => console.log("Feedback: ", type),
+    onRegenerate: () => console.log("Regenerate response clicked"),
+    onBookmark: () => console.log("Bookmark clicked"),
+    onShare: () => console.log("Share clicked"),
+  },
+};
+
+export const DarkTheme: Story = {
+  args: {
+    content: "Llama 3 response rendered in custom dark metrics overlay.",
+    variant: "dark",
+    onFeedback: (type) => console.log("Feedback: ", type),
+    onRegenerate: () => console.log("Regenerate response clicked"),
+    onBookmark: () => console.log("Bookmark clicked"),
+    onShare: () => console.log("Share clicked"),
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-6 rounded-2xl bg-neutral-950 max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Glassmorphic: Story = {
+  args: {
+    content: "Ultra-premium glassmorphism actions on high-contrast gradients.",
+    variant: "glass",
+    onFeedback: (type) => console.log("Feedback: ", type),
+    onRegenerate: () => console.log("Regenerate response clicked"),
+    onBookmark: () => console.log("Bookmark clicked"),
+    onShare: () => console.log("Share clicked"),
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8 rounded-2xl bg-gradient-to-br from-black via-red-950 to-neutral-900 max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Minimal: Story = {
+  args: {
+    content: "A minimal, borderless, overlay button group for clean messaging views.",
+    variant: "minimal",
+    onFeedback: (type) => console.log("Feedback: ", type),
+    onRegenerate: () => console.log("Regenerate response clicked"),
+    onBookmark: () => console.log("Bookmark clicked"),
+  },
+};
+
+const InteractiveDemoComponent = () => {
+  const [feedbackState, setFeedbackState] = useState<"up" | "down" | null>(null);
+  const [bookmarked, setBookmarked] = useState(false);
+  const responseText = "Here is your completed code snippet! Let me know if you need help styling this card further.";
+
+  return (
+    <div className="p-5 border dark:border-neutral-800 rounded-2xl max-w-md bg-white dark:bg-neutral-900 shadow-sm space-y-4">
+      <div className="text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed whitespace-pre-wrap">
+        {responseText}
+      </div>
+      <div className="border-t dark:border-neutral-800 pt-3 flex justify-between items-center">
+        <span className="text-[10px] text-neutral-400 font-semibold uppercase tracking-wider">
+          AI Assistant
+        </span>
+        <AIResponseActions
+          content={responseText}
+          feedback={feedbackState}
+          onFeedback={(type) => setFeedbackState((prev) => (prev === type ? null : type))}
+          isBookmarked={bookmarked}
+          onBookmark={() => setBookmarked((prev) => !prev)}
+          onRegenerate={() => alert("Regenerating response...")}
+          onShare={() => alert("Sharing link copied!")}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const InteractiveMessageBubble: Story = {
+  render: () => <InteractiveDemoComponent />,
+};

--- a/apps/storybook/src/components/ai-response-actions/index.tsx
+++ b/apps/storybook/src/components/ai-response-actions/index.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, RotateCcw, ThumbsUp, ThumbsDown, Share2, Bookmark } from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Button } from "../button";
+import { Tooltip } from "../tooltip";
+
+const actionsVariants = cva(
+  "inline-flex items-center gap-1 p-1 rounded-xl transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        dark: "bg-neutral-900 border border-neutral-800 text-white",
+        glass: "bg-white/10 border border-white/20 backdrop-blur-xl text-whit",
+        minimal: "p-0 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AIResponseActionsProps extends VariantProps<typeof actionsVariants> {
+  content: string;
+  className?: string;
+  size?: "sm" | "md";
+
+  onCopy?: (text: string) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onFeedback?: (type: "up" | "down") => void;
+  onShare?: () => void;
+  onBookmark?: () => void;
+
+  feedback?: "up" | "down" | null;
+  isBookmarked?: boolean;
+  children?: React.ReactNode;
+}
+
+export const AIResponseActions = React.forwardRef<HTMLDivElement, AIResponseActionsProps>(
+  (
+    {
+      content,
+      className,
+      size = "sm",
+      variant = "default",
+      onCopy,
+      onRegenerate,
+      onFeedback,
+      onShare,
+      onBookmark,
+      feedback,
+      isBookmarked,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = React.useState(false);
+    const [localFeedback, setLocalFeedback] = React.useState<"up" | "down" | null>(null);
+    const [localBookmarked, setLocalBookmarked] = React.useState(false);
+
+    React.useEffect(() => {
+      if (feedback !== undefined) {
+        setLocalFeedback(feedback);
+      }
+    }, [feedback]);
+
+    React.useEffect(() => {
+      if (isBookmarked !== undefined) {
+        setLocalBookmarked(isBookmarked);
+      }
+    }, [isBookmarked]);
+
+    const handleCopy = async () => {
+      if (copied) return;
+      try {
+        if (onCopy) {
+          await onCopy(content);
+        } else {
+          await navigator.clipboard.writeText(content);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    };
+
+    const handleFeedback = (type: "up" | "down") => {
+      const nextFeedback = localFeedback === type ? null : type;
+      if (feedback === undefined) {
+        setLocalFeedback(nextFeedback);
+      }
+      onFeedback?.(type);
+    };
+
+    const handleBookmark = () => {
+      const nextBookmarked = !localBookmarked;
+      if (isBookmarked === undefined) {
+        setLocalBookmarked(nextBookmarked);
+      }
+      onBookmark?.();
+    };
+
+    const getButtonClass = (isActive = false) => {
+      return cn(
+        "rounded-lg p-1.5 transition-all focus-visible:ring-1 focus-visible:ring-offset-0 cursor-pointer active:scale-95",
+        variant === "glass" && (isActive ? "bg-white/15 text-white" : "text-white/70 hover:text-white hover:bg-white/10"),
+        variant === "dark" && (isActive ? "bg-neutral-800 text-white" : "text-neutral-400 hover:text-white hover:bg-neutral-800"),
+        variant === "default" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-50 dark:hover:text-neutral-200 dark:hover:bg-neutral-800/50"),
+        variant === "minimal" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200")
+      );
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(actionsVariants({ variant }), className)}
+        {...props}
+      >
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <Button
+            type="button"
+            variant="none"
+            size={size === "sm" ? "compact" : "sm"}
+            className={getButtonClass(copied)}
+            onClick={handleCopy}
+            aria-label="Copy message"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Check size={size === "sm" ? 14 : 16} className="text-emerald-500" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Copy size={size === "sm" ? 14 : 16} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+        </Tooltip>
+
+        {onRegenerate && (
+          <Tooltip content="Regenerate response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <motion.div whileTap={{ rotate: 180 }} transition={{ duration: 0.3 }}>
+                <RotateCcw size={size === "sm" ? 14 : 16} />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "up")}
+              onClick={() => handleFeedback("up")}
+              aria-label="Helpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "up" ? { scale: [1, 1.25, 1], rotate: [0, -10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsUp
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "up" && "fill-current text-blue-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Not helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "down")}
+              onClick={() => handleFeedback("down")}
+              aria-label="Unhelpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "down" ? { scale: [1, 1.25, 1], rotate: [0, 10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsDown
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "down" && "fill-current text-red-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onBookmark && (
+          <Tooltip content={localBookmarked ? "Remove bookmark" : "Bookmark response"}>
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localBookmarked)}
+              onClick={handleBookmark}
+              aria-label="Bookmark response"
+            >
+              <motion.div
+                animate={localBookmarked ? { scale: [1, 1.2, 1] } : {}}
+                transition={{ duration: 0.2 }}
+              >
+                <Bookmark
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localBookmarked && "fill-current text-amber-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onShare && (
+          <Tooltip content="Share response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onShare}
+              aria-label="Share response"
+            >
+              <Share2 size={size === "sm" ? 14 : 16} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {children}
+      </div>
+    );
+  }
+);
+
+AIResponseActions.displayName = "AIResponseActions";
+export { actionsVariants };

--- a/packages/registry/components/ai-response-actions/ai-response-actions.test.tsx
+++ b/packages/registry/components/ai-response-actions/ai-response-actions.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AIResponseActions } from "./index";
+import React from "react";
+
+// Mock Tooltip component to simplify DOM queries
+vi.mock("../tooltip", () => ({
+  Tooltip: ({ children, content }: any) => (
+    <div data-testid="tooltip-wrapper" data-content={content}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("AIResponseActions component test suite", () => {
+  it("triggers callbacks when copy and regenerate buttons are clicked", () => {
+    const handleCopy = vi.fn();
+    const handleRegenerate = vi.fn();
+
+    render(
+      <AIResponseActions
+        content="Response data"
+        onCopy={handleCopy}
+        onRegenerate={handleRegenerate}
+      />
+    );
+
+    const copyBtn = screen.getByRole("button", { name: "Copy message" });
+    fireEvent.click(copyBtn);
+    expect(handleCopy).toHaveBeenCalled();
+
+    const regenerateBtn = screen.getByRole("button", { name: "Regenerate response" });
+    fireEvent.click(regenerateBtn);
+    expect(handleRegenerate).toHaveBeenCalled();
+  });
+
+  it("handles feedback up/down selections correctly", () => {
+    const handleFeedback = vi.fn();
+    render(<AIResponseActions content="Response data" onFeedback={handleFeedback} />);
+
+    const upBtn = screen.getByRole("button", { name: "Helpful feedback" });
+    fireEvent.click(upBtn);
+    expect(handleFeedback).toHaveBeenCalledWith("up");
+
+    const downBtn = screen.getByRole("button", { name: "Unhelpful feedback" });
+    fireEvent.click(downBtn);
+    expect(handleFeedback).toHaveBeenCalledWith("down");
+  });
+
+  it("fires bookmark toggle callback successfully", () => {
+    const handleBookmark = vi.fn();
+    render(<AIResponseActions content="Response data" onBookmark={handleBookmark} isBookmarked={false} />);
+
+    const bookmarkBtn = screen.getByRole("button", { name: "Bookmark response" });
+    fireEvent.click(bookmarkBtn);
+    expect(handleBookmark).toHaveBeenCalled();
+  });
+});

--- a/packages/registry/components/ai-response-actions/index.tsx
+++ b/packages/registry/components/ai-response-actions/index.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, RotateCcw, ThumbsUp, ThumbsDown, Share2, Bookmark } from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Button } from "../button";
+import { Tooltip } from "../tooltip";
+
+const actionsVariants = cva(
+  "inline-flex items-center gap-1 p-1 rounded-xl transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        dark: "bg-neutral-900 border border-neutral-800 text-white",
+        glass: "bg-white/10 border border-white/20 backdrop-blur-xl text-whit",
+        minimal: "p-0 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AIResponseActionsProps extends VariantProps<typeof actionsVariants> {
+  content: string;
+  className?: string;
+  size?: "sm" | "md";
+
+  onCopy?: (text: string) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onFeedback?: (type: "up" | "down") => void;
+  onShare?: () => void;
+  onBookmark?: () => void;
+
+  feedback?: "up" | "down" | null;
+  isBookmarked?: boolean;
+  children?: React.ReactNode;
+}
+
+export const AIResponseActions = React.forwardRef<HTMLDivElement, AIResponseActionsProps>(
+  (
+    {
+      content,
+      className,
+      size = "sm",
+      variant = "default",
+      onCopy,
+      onRegenerate,
+      onFeedback,
+      onShare,
+      onBookmark,
+      feedback,
+      isBookmarked,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [copied, setCopied] = React.useState(false);
+    const [localFeedback, setLocalFeedback] = React.useState<"up" | "down" | null>(null);
+    const [localBookmarked, setLocalBookmarked] = React.useState(false);
+
+    React.useEffect(() => {
+      if (feedback !== undefined) {
+        setLocalFeedback(feedback);
+      }
+    }, [feedback]);
+
+    React.useEffect(() => {
+      if (isBookmarked !== undefined) {
+        setLocalBookmarked(isBookmarked);
+      }
+    }, [isBookmarked]);
+
+    const handleCopy = async () => {
+      if (copied) return;
+      try {
+        if (onCopy) {
+          await onCopy(content);
+        } else {
+          await navigator.clipboard.writeText(content);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    };
+
+    const handleFeedback = (type: "up" | "down") => {
+      const nextFeedback = localFeedback === type ? null : type;
+      if (feedback === undefined) {
+        setLocalFeedback(nextFeedback);
+      }
+      onFeedback?.(type);
+    };
+
+    const handleBookmark = () => {
+      const nextBookmarked = !localBookmarked;
+      if (isBookmarked === undefined) {
+        setLocalBookmarked(nextBookmarked);
+      }
+      onBookmark?.();
+    };
+
+    const getButtonClass = (isActive = false) => {
+      return cn(
+        "rounded-lg p-1.5 transition-all focus-visible:ring-1 focus-visible:ring-offset-0 cursor-pointer active:scale-95",
+        variant === "glass" && (isActive ? "bg-white/15 text-white" : "text-white/70 hover:text-white hover:bg-white/10"),
+        variant === "dark" && (isActive ? "bg-neutral-800 text-white" : "text-neutral-400 hover:text-white hover:bg-neutral-800"),
+        variant === "default" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-50 dark:hover:text-neutral-200 dark:hover:bg-neutral-800/50"),
+        variant === "minimal" && (isActive ? "text-neutral-900 dark:text-neutral-100" : "text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200")
+      );
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(actionsVariants({ variant }), className)}
+        {...props}
+      >
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <Button
+            type="button"
+            variant="none"
+            size={size === "sm" ? "compact" : "sm"}
+            className={getButtonClass(copied)}
+            onClick={handleCopy}
+            aria-label="Copy message"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Check size={size === "sm" ? 14 : 16} className="text-emerald-500" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <Copy size={size === "sm" ? 14 : 16} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+        </Tooltip>
+
+        {onRegenerate && (
+          <Tooltip content="Regenerate response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <motion.div whileTap={{ rotate: 180 }} transition={{ duration: 0.3 }}>
+                <RotateCcw size={size === "sm" ? 14 : 16} />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "up")}
+              onClick={() => handleFeedback("up")}
+              aria-label="Helpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "up" ? { scale: [1, 1.25, 1], rotate: [0, -10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsUp
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "up" && "fill-current text-blue-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onFeedback && (
+          <Tooltip content="Not helpful">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localFeedback === "down")}
+              onClick={() => handleFeedback("down")}
+              aria-label="Unhelpful feedback"
+            >
+              <motion.div
+                animate={localFeedback === "down" ? { scale: [1, 1.25, 1], rotate: [0, 10, 0] } : {}}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                <ThumbsDown
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localFeedback === "down" && "fill-current text-red-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onBookmark && (
+          <Tooltip content={localBookmarked ? "Remove bookmark" : "Bookmark response"}>
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass(localBookmarked)}
+              onClick={handleBookmark}
+              aria-label="Bookmark response"
+            >
+              <motion.div
+                animate={localBookmarked ? { scale: [1, 1.2, 1] } : {}}
+                transition={{ duration: 0.2 }}
+              >
+                <Bookmark
+                  size={size === "sm" ? 14 : 16}
+                  className={cn(localBookmarked && "fill-current text-amber-500")}
+                />
+              </motion.div>
+            </Button>
+          </Tooltip>
+        )}
+
+        {onShare && (
+          <Tooltip content="Share response">
+            <Button
+              type="button"
+              variant="none"
+              size={size === "sm" ? "compact" : "sm"}
+              className={getButtonClass()}
+              onClick={onShare}
+              aria-label="Share response"
+            >
+              <Share2 size={size === "sm" ? 14 : 16} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {children}
+      </div>
+    );
+  }
+);
+
+AIResponseActions.displayName = "AIResponseActions";
+export { actionsVariants };


### PR DESCRIPTION
## Pull Request Title

feat(component): add ai-response-action component

---

## Description

### What does this PR do?

Added AI-Response-Action component.

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #ISSUE_NUMBER (if applicable)

## Type of Change

- [ ] 🐛 Bug fix
- [X] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [X] I have linted my code using `npm run lint`.
- [X] I have updated the documentation as needed.
- [X] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Added the `AIResponseActions` React component to the registry, docs, and Storybook.
  - Added copy, regenerate, feedback, bookmark, share, tooltip, animation, and custom-child support.
  - Added controlled and uncontrolled feedback and bookmark state.
  - Exported `AIResponseActionsProps` and `actionsVariants` with four style variants.
  - Added tests for copy, regenerate, feedback, and bookmark callbacks.

- **Bug fixes**
  - Added Clipboard API fallback handling.
  - Added controlled-state synchronization for feedback and bookmark values.

- **Tooling / config changes**
  - Updated the docs sidebar with the new component page.
  - Linted the code with `npm run lint`.

- **Docs / Storybook updates**
  - Added current and versioned documentation with installation, usage, variants, callbacks, and props.
  - Added an interactive documentation demo.
  - Added Storybook stories for default, full-action, themed, minimal, and interactive states.

## Breaking changes

None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->