### PR TITLE
feat(component): add Workflow Builder layout with docs and stories

### DIFF
--- a/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
@@ -1,0 +1,167 @@
+import React, { useState, useCallback } from 'react';
+import VariantSelector from './VariantSelector';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import {
+  WorkflowBuilderLayout,
+  type WorkflowNodeData,
+  type WorkflowEdgeData,
+  type WorkflowPaletteItem,
+} from '@site/src/components/UI/workflow-builder-layout';
+import { Sparkles, Github, Webhook, Mail, Filter, Clock, Play } from 'lucide-react';
+
+const gridSizes = ['16', '24', '32', '48'];
+const maxZooms = ['1.5', '2', '2.5', '4'];
+
+const PALETTE_ITEMS: WorkflowPaletteItem[] = [
+  { type: 'webhook', label: 'Webhook', icon: <Webhook className="h-4 w-4" />, description: 'Start on an HTTP call' },
+  { type: 'filter', label: 'Filter', icon: <Filter className="h-4 w-4" />, description: 'Keep matching items only' },
+  { type: 'delay', label: 'Delay', icon: <Clock className="h-4 w-4" />, description: 'Wait before continuing' },
+  { type: 'email', label: 'Send Email', icon: <Mail className="h-4 w-4" />, description: 'Send a templated email' },
+];
+
+const INITIAL_NODES: WorkflowNodeData[] = [
+  { id: 'trigger', x: 20, y: 90, title: 'New Signup', icon: <Play className="h-4 w-4" />, status: 'success' },
+  { id: 'filter', x: 280, y: 20, title: 'Filter: Verified', icon: <Filter className="h-4 w-4" />, status: 'idle' },
+  { id: 'email', x: 540, y: 90, title: 'Send Welcome Email', icon: <Mail className="h-4 w-4" />, status: 'running' },
+];
+
+const INITIAL_EDGES: WorkflowEdgeData[] = [
+  { id: 'trigger-filter', source: 'trigger', target: 'filter' },
+  { id: 'filter-email', source: 'filter', target: 'email', label: 'verified' },
+];
+
+const codeString = `
+import {
+  WorkflowBuilderLayout,
+  type WorkflowNodeData,
+  type WorkflowEdgeData,
+} from '@ignix-ui/workflow-builder-layout';
+import { Play, Filter, Mail } from 'lucide-react';
+
+const [nodes, setNodes] = useState<WorkflowNodeData[]>([
+  { id: 'trigger', x: 20, y: 90, title: 'New Signup', icon: <Play className="h-4 w-4" />, status: 'success' },
+  { id: 'filter', x: 280, y: 20, title: 'Filter: Verified', icon: <Filter className="h-4 w-4" /> },
+  { id: 'email', x: 540, y: 90, title: 'Send Welcome Email', icon: <Mail className="h-4 w-4" />, status: 'running' },
+]);
+const [edges, setEdges] = useState<WorkflowEdgeData[]>([
+  { id: 'trigger-filter', source: 'trigger', target: 'filter' },
+  { id: 'filter-email', source: 'filter', target: 'email', label: 'verified' },
+]);
+
+<WorkflowBuilderLayout
+  nodes={nodes}
+  edges={edges}
+  onNodesChange={setNodes}
+  onConnect={(edge) => setEdges((prev) => [...prev, { id: \`\${edge.source}-\${edge.target}\`, ...edge }])}
+  paletteItems={[{ type: 'webhook', label: 'Webhook' }]}
+/>
+`;
+
+const WorkflowBuilderLayoutDemo = () => {
+  const [gridSize, setGridSize] = useState<number>(32);
+  const [maxZoom, setMaxZoom] = useState<number>(2.5);
+  const [nodes, setNodes] = useState<WorkflowNodeData[]>(INITIAL_NODES);
+  const [edges, setEdges] = useState<WorkflowEdgeData[]>(INITIAL_EDGES);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const onConnect = useCallback((connection: { source: string; target: string }) => {
+    setEdges((prev) => [...prev, { id: `${connection.source}-${connection.target}-${prev.length}`, ...connection }]);
+  }, []);
+
+  const onNodeDelete = useCallback((id: string) => {
+    setNodes((prev) => prev.filter((node) => node.id !== id));
+    setEdges((prev) => prev.filter((edge) => edge.source !== id && edge.target !== id));
+    setSelectedNodeId((prev) => (prev === id ? null : prev));
+  }, []);
+
+  const onPaletteItemDrop = useCallback((item: WorkflowPaletteItem, position: { x: number; y: number }) => {
+    setNodes((prev) => [
+      ...prev,
+      { id: `${item.type}-${prev.length}`, x: position.x, y: position.y, title: item.label, icon: item.icon, status: 'idle' },
+    ]);
+  }, []);
+
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId) ?? null;
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-4 justify-start sm:justify-end">
+        <VariantSelector
+          variants={gridSizes}
+          selectedVariant={gridSize.toString()}
+          onSelectVariant={(val) => setGridSize(Number(val))}
+          type="Grid Size"
+        />
+        <VariantSelector
+          variants={maxZooms}
+          selectedVariant={maxZoom.toString()}
+          onSelectVariant={(val) => setMaxZoom(Number(val))}
+          type="Max Zoom"
+        />
+      </div>
+      <Tabs>
+        <TabItem value="preview" label="Preview" default>
+          <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 480 }}>
+            <WorkflowBuilderLayout
+              header={
+                <div className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold tracking-tight text-primary-foreground">
+                  <Sparkles className="h-4 w-4" />
+                  Onboarding Flow
+                </div>
+              }
+              actions={
+                <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+                  <Github className="h-4 w-4" />
+                </a>
+              }
+              minZoom={0.25}
+              maxZoom={maxZoom}
+              gridSize={gridSize}
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={setNodes}
+              onConnect={onConnect}
+              onNodeDelete={onNodeDelete}
+              selectedNodeId={selectedNodeId}
+              onNodeSelect={setSelectedNodeId}
+              paletteItems={PALETTE_ITEMS}
+              onPaletteItemDrop={onPaletteItemDrop}
+              inspector={
+                selectedNode && (
+                  <div className="flex flex-col gap-3">
+                    <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+                      Node title
+                      <input
+                        className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+                        value={selectedNode.title}
+                        onChange={(event) =>
+                          setNodes((prev) =>
+                            prev.map((node) =>
+                              node.id === selectedNode.id ? { ...node, title: event.target.value } : node
+                            )
+                          )
+                        }
+                      />
+                    </label>
+                    <p className="text-xs text-[var(--muted-foreground)]">Node id: {selectedNode.id}</p>
+                  </div>
+                )
+              }
+            />
+          </div>
+        </TabItem>
+        <TabItem value="code" label="Code">
+          <div className="mt-4">
+            <CodeBlock language="tsx" className="text-sm">
+              {codeString}
+            </CodeBlock>
+          </div>
+        </TabItem>
+      </Tabs>
+    </div>
+  );
+};
+
+export default WorkflowBuilderLayoutDemo;

--- a/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import VariantSelector from './VariantSelector';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -66,8 +66,18 @@ const WorkflowBuilderLayoutDemo = () => {
   const [edges, setEdges] = useState<WorkflowEdgeData[]>(INITIAL_EDGES);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
+  // `prev.length` isn't monotonic - deleting a node/edge shrinks the array, so a later drop or
+  // connection can land on the same length again and collide with an earlier id.
+  const nextIdRef = useRef(0);
+
   const onConnect = useCallback((connection: { source: string; target: string }) => {
-    setEdges((prev) => [...prev, { id: `${connection.source}-${connection.target}-${prev.length}`, ...connection }]);
+    const id = `edge-${nextIdRef.current++}`;
+    setEdges((prev) => {
+      const alreadyConnected = prev.some(
+        (edge) => edge.source === connection.source && edge.target === connection.target
+      );
+      return alreadyConnected ? prev : [...prev, { id, ...connection }];
+    });
   }, []);
 
   const onNodeDelete = useCallback((id: string) => {
@@ -77,9 +87,10 @@ const WorkflowBuilderLayoutDemo = () => {
   }, []);
 
   const onPaletteItemDrop = useCallback((item: WorkflowPaletteItem, position: { x: number; y: number }) => {
+    const id = `${item.type}-${nextIdRef.current++}`;
     setNodes((prev) => [
       ...prev,
-      { id: `${item.type}-${prev.length}`, x: position.x, y: position.y, title: item.label, icon: item.icon, status: 'idle' },
+      { id, x: position.x, y: position.y, title: item.label, icon: item.icon, status: 'idle' },
     ]);
   }, []);
 
@@ -105,6 +116,7 @@ const WorkflowBuilderLayoutDemo = () => {
         <TabItem value="preview" label="Preview" default>
           <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 480 }}>
             <WorkflowBuilderLayout
+              className="h-full"
               header={
                 <div className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold tracking-tight text-primary-foreground">
                   <Sparkles className="h-4 w-4" />

--- a/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
@@ -117,7 +117,6 @@ const WorkflowBuilderLayoutDemo = () => {
         <TabItem value="preview" label="Preview" default>
           <div className="border border-gray-300 rounded-lg overflow-hidden mt-4" style={{ height: 480 }}>
             <WorkflowBuilderLayout
-              className="h-full"
               header={
                 <div className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold tracking-tight text-primary-foreground">
                   <Sparkles className="h-4 w-4" />

--- a/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
+++ b/apps/docs/src/components/Demo/WorkflowBuilderLayoutDemo.tsx
@@ -33,6 +33,7 @@ const INITIAL_EDGES: WorkflowEdgeData[] = [
 ];
 
 const codeString = `
+import { useState } from 'react';
 import {
   WorkflowBuilderLayout,
   type WorkflowNodeData,

--- a/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
+++ b/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
@@ -1,0 +1,789 @@
+import * as React from "react";
+import { Button } from "@site/src/components/UI/button";
+import { Plus, Minus, RotateCcw, X, Pencil } from "lucide-react";
+import { cn } from "@site/src/utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the workflow canvas, in the canvas's own (untransformed) coordinate space. */
+export interface WorkflowViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Restricts `value` to the inclusive `[min, max]` range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export type WorkflowNodeStatus = "idle" | "running" | "success" | "error";
+
+/**
+ * A single node placed on the workflow canvas at world coordinates `(x, y)`. Ports render at a
+ * fixed vertical offset from the top edge (matching the header row's height), so edge geometry
+ * never depends on a node's rendered content height.
+ */
+export interface WorkflowNodeData {
+  id: string;
+  x: number;
+  y: number;
+  width?: number;
+  title: string;
+  icon?: React.ReactNode;
+  status?: WorkflowNodeStatus;
+  content?: React.ReactNode;
+  hasInput?: boolean;
+  hasOutput?: boolean;
+}
+
+/** A directed connection between one node's output port and another node's input port. */
+export interface WorkflowEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+/** An entry in the node palette sidebar - a node type consumers can add to the canvas. */
+export interface WorkflowPaletteItem {
+  type: string;
+  label: string;
+  icon?: React.ReactNode;
+  description?: string;
+}
+
+/**
+ * Props for the {@link WorkflowBuilderLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property paletteItems - Node types listed in the left sidebar. Omit (or pass an empty array)
+ * to hide the sidebar entirely.
+ * @property onPaletteItemSelect - Called when a palette item is clicked (accessible alternative
+ * to dragging it onto the canvas).
+ * @property onPaletteItemDrop - Called with the dropped item and the world-space drop position
+ * when a palette item is dragged onto the canvas.
+ * @property showPalette - Whether to render the palette sidebar when `paletteItems` is non-empty.
+ * Default `true`.
+ * @property nodes - The nodes currently on the canvas. This component is fully controlled: wire
+ * `onNodesChange` to persist moves, or nodes won't visually update while dragged.
+ * @property edges - Connections between nodes, rendered as curved lines between ports.
+ * @property onNodesChange - Called with the next `nodes` array after a drag or keyboard nudge.
+ * @property onNodeDelete - Called with a node's id when Delete/Backspace is pressed while it's
+ * focused.
+ * @property onConnect - Called when a drag from one node's output port is released over another
+ * node's input port.
+ * @property selectedNodeId - Controlled selected node id. Provide alongside `onNodeSelect` to
+ * drive selection externally; omit to let the layout manage its own state.
+ * @property onNodeSelect - Called whenever the selected node changes, whether controlled or not.
+ * @property inspector - Content rendered in the right panel while a node is selected (e.g. a
+ * form for editing the selected node).
+ * @property showNodeEditButton - Whether each node renders a pencil icon that selects it (and
+ * thus opens `inspector`) without starting a drag. Default `true`; set to `false` when no
+ * `inspector` is wired up, so nodes don't show an icon that has nothing to open.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to drive
+ * the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface WorkflowBuilderLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  paletteItems?: WorkflowPaletteItem[];
+  onPaletteItemSelect?: (item: WorkflowPaletteItem) => void;
+  onPaletteItemDrop?: (item: WorkflowPaletteItem, position: { x: number; y: number }) => void;
+  showPalette?: boolean;
+  nodes: WorkflowNodeData[];
+  edges?: WorkflowEdgeData[];
+  onNodesChange?: (nodes: WorkflowNodeData[]) => void;
+  onNodeDelete?: (id: string) => void;
+  onConnect?: (connection: { source: string; target: string }) => void;
+  selectedNodeId?: string | null;
+  onNodeSelect?: (id: string | null) => void;
+  inspector?: React.ReactNode;
+  showNodeEditButton?: boolean;
+  viewport?: WorkflowViewport;
+  defaultViewport?: WorkflowViewport;
+  onViewportChange?: (viewport: WorkflowViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: WorkflowViewport = { x: 0, y: 0, zoom: 1 };
+
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
+const MIN_SAFE_ZOOM = 0.01;
+
+const DEFAULT_NODE_WIDTH = 220;
+const NODE_HEADER_HEIGHT = 40;
+const PORT_HIT_RADIUS = 24;
+const NODE_KEYBOARD_STEP = 10;
+const NODE_KEYBOARD_STEP_LARGE = 40;
+const PALETTE_DRAG_MIME = "application/workflow-node-type";
+
+/**
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
+ */
+function normalizeViewport(viewport: WorkflowViewport, minZoom: number, maxZoom: number): WorkflowViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
+const STATUS_DOT_CLASSES: Record<WorkflowNodeStatus, string> = {
+  idle: "bg-[var(--muted-foreground)]",
+  running: "bg-[var(--primary)] animate-pulse",
+  success: "bg-[var(--success)]",
+  error: "bg-[var(--destructive)]",
+};
+
+/** World-space position of a node's input (left edge) or output (right edge) port. */
+function getPortPosition(node: WorkflowNodeData, side: "input" | "output"): { x: number; y: number } {
+  const width = node.width ?? DEFAULT_NODE_WIDTH;
+  return { x: side === "input" ? node.x : node.x + width, y: node.y + NODE_HEADER_HEIGHT / 2 };
+}
+
+/** A horizontal cubic-bezier path between two ports, curved outward proportionally to distance. */
+function buildEdgePath(source: { x: number; y: number }, target: { x: number; y: number }): string {
+  const curvature = Math.max(Math.abs(target.x - source.x) / 2, 40);
+  return `M ${source.x},${source.y} C ${source.x + curvature},${source.y} ${target.x - curvature},${target.y} ${target.x},${target.y}`;
+}
+
+interface DragState {
+  nodeId: string;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+}
+
+interface ConnectingState {
+  sourceId: string;
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * WorkflowBuilderLayout is a node-and-connection workspace shell - the shape behind visual
+ * automation/workflow tools (n8n, Zapier, Node-RED). A node palette sits on the left, an
+ * optional inspector panel on the right, and a pannable/zoomable canvas in between where nodes
+ * are placed, dragged, and wired together by dragging from an output port to an input port.
+ */
+export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
+  header,
+  actions,
+  paletteItems,
+  onPaletteItemSelect,
+  onPaletteItemDrop,
+  showPalette = true,
+  nodes,
+  edges = [],
+  onNodesChange,
+  onNodeDelete,
+  onConnect,
+  selectedNodeId,
+  onNodeSelect,
+  inspector,
+  showNodeEditButton = true,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isViewportControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<WorkflowViewport>(defaultViewport);
+  const rawViewport = isViewportControlled ? viewport : internalViewport;
+
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
+
+  const currentViewport: WorkflowViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
+
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: WorkflowViewport) => WorkflowViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped = normalizeViewport(next, safeMinZoom, safeMaxZoom);
+      if (!isViewportControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isViewportControlled, safeMinZoom, safeMaxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const isSelectionControlled = selectedNodeId !== undefined;
+  const [internalSelectedId, setInternalSelectedId] = React.useState<string | null>(null);
+  const currentSelectedId = isSelectionControlled ? selectedNodeId : internalSelectedId;
+  const selectNode = React.useCallback(
+    (id: string | null) => {
+      if (!isSelectionControlled) setInternalSelectedId(id);
+      onNodeSelect?.(id);
+    },
+    [isSelectionControlled, onNodeSelect]
+  );
+
+  const nodeById = React.useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const selectedNode = currentSelectedId ? (nodeById.get(currentSelectedId) ?? null) : null;
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  const inputPortRefs = React.useRef(new Map<string, HTMLDivElement>());
+  const [connecting, setConnecting] = React.useState<ConnectingState | null>(null);
+
+  // Colons from useId() are stripped since this feeds an SVG url(#id) reference, where they're
+  // unreliable across browsers.
+  const arrowMarkerId = `workflow-arrow-${React.useId().replace(/:/g, "")}`;
+
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handleSurfacePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only pan when the drag starts on empty background, not a node, so nodes stay
+    // independently draggable/connectable.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus, so this restores it for
+    // keyboard pan/zoom.
+    event.currentTarget.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handleSurfacePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handleSurfacePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
+    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
+    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
+    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    if (event.target !== event.currentTarget && event.key !== "Escape") return;
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      case "Escape":
+        if (connecting) {
+          setConnecting(null);
+          event.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
+    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
+    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
+    // or further up to the host app, still works.
+    const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
+    const move = (dx: number, dy: number): void => {
+      onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
+    };
+    switch (event.key) {
+      case "ArrowUp":
+        move(0, -step);
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        move(0, step);
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        move(-step, 0);
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        move(step, 0);
+        event.preventDefault();
+        break;
+      case "Enter":
+      case " ":
+        selectNode(node.id);
+        event.preventDefault();
+        break;
+      case "Delete":
+      case "Backspace":
+        onNodeDelete?.(node.id);
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeHeaderPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus; the header itself isn't
+    // focusable, so this focuses the node (closest ancestor role="group") instead.
+    (event.currentTarget.closest('[role="group"]') as HTMLElement | null)?.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStateRef.current = {
+      nodeId: node.id,
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: node.x,
+      startY: node.y,
+    };
+  };
+
+  const handleNodeHeaderPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const zoom = currentViewport.zoom || 1;
+    const dx = (event.clientX - state.startClientX) / zoom;
+    const dy = (event.clientY - state.startClientY) / zoom;
+    onNodesChange?.(
+      nodes.map((n) => (n.id === state.nodeId ? { ...n, x: state.startX + dx, y: state.startY + dy } : n))
+    );
+  };
+
+  const handleNodeHeaderPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (dragStateRef.current?.pointerId === event.pointerId) {
+      dragStateRef.current = null;
+    }
+  };
+
+  const handleOutputPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const outputPos = getPortPosition(node, "output");
+    setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
+  };
+
+  const handleOutputPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    setConnecting((prev) => (prev && prev.pointerId === event.pointerId ? { ...prev, x: worldX, y: worldY } : prev));
+  };
+
+  const handleOutputPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    // Finds the nearest input port within range via geometry (rect centers) rather than
+    // document.elementFromPoint, since the pointer capture on the output port means the
+    // release target is always the output port itself, never whatever's underneath it.
+    let targetId: string | null = null;
+    let closestDistance = PORT_HIT_RADIUS;
+    inputPortRefs.current.forEach((el, nodeId) => {
+      if (nodeId === connecting.sourceId) return;
+      const rect = el.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (distance <= closestDistance) {
+        closestDistance = distance;
+        targetId = nodeId;
+      }
+    });
+    if (targetId) {
+      onConnect?.({ source: connecting.sourceId, target: targetId });
+    }
+    setConnecting(null);
+  };
+
+  const handleCanvasDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop || !event.dataTransfer.types.includes(PALETTE_DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleCanvasDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop) return;
+    const type = event.dataTransfer.getData(PALETTE_DRAG_MIME);
+    const item = paletteItems?.find((candidate) => candidate.type === type);
+    const surface = surfaceRef.current;
+    if (!type || !item || !surface) return;
+    event.preventDefault();
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    onPaletteItemDrop(item, { x: worldX, y: worldY });
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {showPalette && paletteItems && paletteItems.length > 0 && (
+          <aside
+            className="w-64 shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)] p-2"
+            aria-label="Node palette"
+          >
+            <ul className="flex flex-col gap-1">
+              {paletteItems.map((item) => (
+                <li key={item.type}>
+                  <button
+                    type="button"
+                    draggable={Boolean(onPaletteItemDrop)}
+                    onDragStart={(event) => {
+                      event.dataTransfer.setData(PALETTE_DRAG_MIME, item.type);
+                      event.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onClick={() => onPaletteItemSelect?.(item)}
+                    className="flex w-full items-center gap-2 rounded-md p-2 text-left text-sm hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                  >
+                    {item.icon && <span className="shrink-0">{item.icon}</span>}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{item.label}</span>
+                      {item.description && (
+                        <span className="block truncate text-xs text-[var(--muted-foreground)]">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
+        <div
+          ref={surfaceRef}
+          className="relative flex-1 touch-none select-none overflow-hidden"
+          style={
+            showGrid
+              ? {
+                  backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                  backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                  backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+                }
+              : undefined
+          }
+          role="group"
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          tabIndex={0}
+          onPointerDown={handleSurfacePointerDown}
+          onPointerMove={handleSurfacePointerMove}
+          onPointerUp={handleSurfacePointerUp}
+          onPointerCancel={handleSurfacePointerUp}
+          onKeyDown={handleSurfaceKeyDown}
+          onDragOver={handleCanvasDragOver}
+          onDrop={handleCanvasDrop}
+        >
+          <div
+            className="absolute left-0 top-0"
+            style={{
+              transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+              transformOrigin: "0 0",
+            }}
+          >
+            <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={1} height={1}>
+              <defs>
+                <marker
+                  id={arrowMarkerId}
+                  viewBox="0 0 10 10"
+                  refX={9}
+                  refY={5}
+                  markerWidth={7}
+                  markerHeight={7}
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border)" />
+                </marker>
+              </defs>
+              {edges.map((edge) => {
+                const sourceNode = nodeById.get(edge.source);
+                const targetNode = nodeById.get(edge.target);
+                if (!sourceNode || !targetNode) return null;
+                const sourcePos = getPortPosition(sourceNode, "output");
+                const targetPos = getPortPosition(targetNode, "input");
+                return (
+                  <g key={edge.id}>
+                    <path
+                      d={buildEdgePath(sourcePos, targetPos)}
+                      stroke="var(--border)"
+                      strokeWidth={2}
+                      fill="none"
+                      markerEnd={`url(#${arrowMarkerId})`}
+                    />
+                    {edge.label && (
+                      <text
+                        x={(sourcePos.x + targetPos.x) / 2}
+                        y={(sourcePos.y + targetPos.y) / 2 - 6}
+                        textAnchor="middle"
+                        fontSize={11}
+                        fill="var(--muted-foreground)"
+                      >
+                        {edge.label}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+              {connecting &&
+                (() => {
+                  const sourceNode = nodeById.get(connecting.sourceId);
+                  if (!sourceNode) return null;
+                  const sourcePos = getPortPosition(sourceNode, "output");
+                  return (
+                    <path
+                      d={buildEdgePath(sourcePos, { x: connecting.x, y: connecting.y })}
+                      stroke="var(--primary)"
+                      strokeWidth={2}
+                      strokeDasharray="4 4"
+                      fill="none"
+                    />
+                  );
+                })()}
+            </svg>
+
+            {nodes.map((node) => {
+              const isSelected = node.id === currentSelectedId;
+              const width = node.width ?? DEFAULT_NODE_WIDTH;
+              return (
+                <div
+                  key={node.id}
+                  role="group"
+                  aria-label={`${node.title} node${node.status ? `, status ${node.status}` : ""}${isSelected ? ", selected" : ""}`}
+                  tabIndex={0}
+                  className={cn(
+                    "absolute rounded-lg border bg-[var(--background)] shadow-sm",
+                    isSelected ? "border-[var(--primary)] ring-2 ring-[var(--primary)]" : "border-[var(--border)]"
+                  )}
+                  style={{ left: node.x, top: node.y, width }}
+                  onKeyDown={(event) => handleNodeKeyDown(event, node)}
+                >
+                  {node.hasInput !== false && (
+                    <div
+                      ref={(el) => {
+                        if (el) inputPortRefs.current.set(node.id, el);
+                        else inputPortRefs.current.delete(node.id);
+                      }}
+                      aria-hidden="true"
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                    />
+                  )}
+
+                  <div
+                    className="flex h-10 cursor-grab items-center gap-2 rounded-t-lg border-b border-[var(--border)] px-3 active:cursor-grabbing"
+                    onPointerDown={(event) => handleNodeHeaderPointerDown(event, node)}
+                    onPointerMove={handleNodeHeaderPointerMove}
+                    onPointerUp={handleNodeHeaderPointerUp}
+                    onPointerCancel={handleNodeHeaderPointerUp}
+                  >
+                    {node.icon && <span className="shrink-0">{node.icon}</span>}
+                    <span className="flex-1 truncate text-sm font-medium">{node.title}</span>
+                    {node.status && (
+                      <span
+                        className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT_CLASSES[node.status])}
+                        aria-hidden="true"
+                      />
+                    )}
+                    {showNodeEditButton && (
+                      <button
+                        type="button"
+                        aria-label={`Edit ${node.title}`}
+                        className="shrink-0 rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          selectNode(node.id);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+
+                  {node.content && <div className="p-3 text-sm text-[var(--muted-foreground)]">{node.content}</div>}
+
+                  {node.hasOutput !== false && (
+                    <div
+                      aria-hidden="true"
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onPointerDown={(event) => handleOutputPointerDown(event, node)}
+                      onPointerMove={handleOutputPointerMove}
+                      onPointerUp={handleOutputPointerUp}
+                      onPointerCancel={() => setConnecting(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {showControls && (
+            <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+              <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+                <Plus className="h-4 w-4" />
+              </Button>
+              <div className="text-center text-xs text-[var(--muted-foreground)]">
+                {Math.round(currentViewport.zoom * 100)}%
+              </div>
+              <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {selectedNode && inspector && (
+          <aside
+            className="w-80 shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4"
+            aria-label={`Inspector for ${selectedNode.title}`}
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="truncate text-sm font-semibold">{selectedNode.title}</h3>
+              <Button variant="ghost" size="icon" aria-label="Close inspector" onClick={() => selectNode(null)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            {inspector}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+};
+
+WorkflowBuilderLayout.displayName = "WorkflowBuilderLayout";
+
+export default WorkflowBuilderLayout;

--- a/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
+++ b/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
@@ -95,7 +95,9 @@ export interface WorkflowPaletteItem {
  * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
  * @property showControls - Whether to render the floating zoom in/out/reset control panel.
  * Default `true`.
- * @property className - Class name for the root container.
+ * @property className - Class name for the root container. The root fills its parent's height
+ * (`h-full`), not the viewport - give it a sized ancestor, or pass a height utility here (e.g.
+ * `h-screen`) to make it fill the viewport directly.
  */
 export interface WorkflowBuilderLayoutProps {
   header?: React.ReactNode;
@@ -179,9 +181,8 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
-  // handlers compare against a real pointerId, so they naturally no-op against this instead of
-  // needing a separate keyboard-vs-pointer branch.
+  // `null` marks a keyboard-initiated connection - pointer move/up handlers compare against a
+  // real pointerId, so they naturally no-op against this without a separate branch.
   pointerId: number | null;
   x: number;
   y: number;
@@ -541,7 +542,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   return (
-    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+    <div className={cn("flex h-full min-h-0 w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
       {(header || actions) && (
         <header
           className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"

--- a/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
+++ b/apps/docs/src/components/UI/workflow-builder-layout/index.tsx
@@ -179,7 +179,10 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  pointerId: number;
+  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
+  // handlers compare against a real pointerId, so they naturally no-op against this instead of
+  // needing a separate keyboard-vs-pointer branch.
+  pointerId: number | null;
   x: number;
   y: number;
 }
@@ -347,10 +350,9 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
-    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
-    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
-    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    // Ignores bubbled key events from a focused node (handled separately), except Escape -
+    // cancelling a connection (started by a pointer drag, which never moves focus) shouldn't
+    // depend on what currently has focus.
     if (event.target !== event.currentTarget && event.key !== "Escape") return;
     const step = 40;
     switch (event.key) {
@@ -396,10 +398,8 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
-    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
-    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
-    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
-    // or further up to the host app, still works.
+    // Does not stopPropagation - handleSurfaceKeyDown's own target check already prevents
+    // double-handling arrow keys, and letting other keys (e.g. Escape) bubble up still works.
     const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
     const move = (dx: number, dy: number): void => {
       onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
@@ -475,6 +475,10 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     if (event.button !== 0) return;
     event.stopPropagation();
     event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus. A port itself isn't focusable,
+    // and a connection isn't owned by either node, so this focuses the canvas - otherwise
+    // whatever had focus before (or nothing) would stay focused through and after the drag.
+    surfaceRef.current?.focus();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     const outputPos = getPortPosition(node, "output");
     setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
@@ -496,14 +500,17 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     // document.elementFromPoint, since the pointer capture on the output port means the
     // release target is always the output port itself, never whatever's underneath it.
     let targetId: string | null = null;
-    let closestDistance = PORT_HIT_RADIUS;
+    // Strict `<` against the running minimum (not the fixed radius) so the first port
+    // encountered wins an exact tie, while a port sitting exactly at PORT_HIT_RADIUS is still
+    // selectable as the sole candidate.
+    let closestDistance = Infinity;
     inputPortRefs.current.forEach((el, nodeId) => {
       if (nodeId === connecting.sourceId) return;
       const rect = el.getBoundingClientRect();
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-      if (distance <= closestDistance) {
+      if (distance <= PORT_HIT_RADIUS && distance < closestDistance) {
         closestDistance = distance;
         targetId = nodeId;
       }
@@ -593,7 +600,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
               : undefined
           }
           role="group"
-          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes, or press Enter on an output port then Enter on an input port. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
           tabIndex={0}
           onPointerDown={handleSurfacePointerDown}
           onPointerMove={handleSurfacePointerMove}
@@ -692,9 +699,18 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
                         if (el) inputPortRefs.current.set(node.id, el);
                         else inputPortRefs.current.delete(node.id);
                       }}
-                      aria-hidden="true"
-                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect to ${node.title} input`}
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        if (!connecting || connecting.sourceId === node.id) return;
+                        event.preventDefault();
+                        onConnect?.({ source: connecting.sourceId, target: node.id });
+                        setConnecting(null);
+                      }}
                     />
                   )}
 
@@ -733,13 +749,21 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
 
                   {node.hasOutput !== false && (
                     <div
-                      aria-hidden="true"
-                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect ${node.title} to another node`}
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
                       onPointerDown={(event) => handleOutputPointerDown(event, node)}
                       onPointerMove={handleOutputPointerMove}
                       onPointerUp={handleOutputPointerUp}
                       onPointerCancel={() => setConnecting(null)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
+                        const outputPos = getPortPosition(node, "output");
+                        setConnecting({ sourceId: node.id, pointerId: null, x: outputPos.x, y: outputPos.y });
+                      }}
                     />
                   )}
                 </div>

--- a/apps/docs/versioned_docs/version-1.0.3/components/all-layouts/index.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/all-layouts/index.mdx
@@ -41,7 +41,8 @@ import {
   List,
   BetweenVerticalStart,
   Ruler,
-  Code2
+  Code2,
+  Workflow
 } from 'lucide-react';
 
 ## App Structure
@@ -117,6 +118,12 @@ import {
     href="/docs/templates/layouts/three-column-sidebar-layout"
     description="Three-column layout with sidebar navigation."
     icon={Columns3}
+  />
+  <Card 
+    title="Workflow Builder" 
+    href="/docs/templates/layouts/workflow-builder-layout"
+    description="Node-and-connection workspace shell for visual workflow tools."
+    icon={Workflow}
   />
 </div>
 

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
@@ -28,7 +28,7 @@ The **Workflow Builder Layout** template provides the shell behind visual automa
 import * as React from "react";
 import { Button } from "@ignix-ui/button";
 import { Plus, Minus, RotateCcw, X, Pencil } from "lucide-react";
-import { cn } from "../../../utils/cn";
+import { cn } from "../../utils/cn";
 
 /* -------------------------------------------------------------------------- */
 /*                              TYPES & INTERFACES                            */
@@ -206,7 +206,10 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  pointerId: number;
+  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
+  // handlers compare against a real pointerId, so they naturally no-op against this instead of
+  // needing a separate keyboard-vs-pointer branch.
+  pointerId: number | null;
   x: number;
   y: number;
 }
@@ -374,10 +377,9 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
-    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
-    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
-    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    // Ignores bubbled key events from a focused node (handled separately), except Escape -
+    // cancelling a connection (started by a pointer drag, which never moves focus) shouldn't
+    // depend on what currently has focus.
     if (event.target !== event.currentTarget && event.key !== "Escape") return;
     const step = 40;
     switch (event.key) {
@@ -423,10 +425,8 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
-    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
-    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
-    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
-    // or further up to the host app, still works.
+    // Does not stopPropagation - handleSurfaceKeyDown's own target check already prevents
+    // double-handling arrow keys, and letting other keys (e.g. Escape) bubble up still works.
     const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
     const move = (dx: number, dy: number): void => {
       onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
@@ -502,6 +502,10 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     if (event.button !== 0) return;
     event.stopPropagation();
     event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus. A port itself isn't focusable,
+    // and a connection isn't owned by either node, so this focuses the canvas - otherwise
+    // whatever had focus before (or nothing) would stay focused through and after the drag.
+    surfaceRef.current?.focus();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     const outputPos = getPortPosition(node, "output");
     setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
@@ -523,14 +527,17 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     // document.elementFromPoint, since the pointer capture on the output port means the
     // release target is always the output port itself, never whatever's underneath it.
     let targetId: string | null = null;
-    let closestDistance = PORT_HIT_RADIUS;
+    // Strict `<` against the running minimum (not the fixed radius) so the first port
+    // encountered wins an exact tie, while a port sitting exactly at PORT_HIT_RADIUS is still
+    // selectable as the sole candidate.
+    let closestDistance = Infinity;
     inputPortRefs.current.forEach((el, nodeId) => {
       if (nodeId === connecting.sourceId) return;
       const rect = el.getBoundingClientRect();
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-      if (distance <= closestDistance) {
+      if (distance <= PORT_HIT_RADIUS && distance < closestDistance) {
         closestDistance = distance;
         targetId = nodeId;
       }
@@ -620,7 +627,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
               : undefined
           }
           role="group"
-          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes, or press Enter on an output port then Enter on an input port. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
           tabIndex={0}
           onPointerDown={handleSurfacePointerDown}
           onPointerMove={handleSurfacePointerMove}
@@ -719,9 +726,18 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
                         if (el) inputPortRefs.current.set(node.id, el);
                         else inputPortRefs.current.delete(node.id);
                       }}
-                      aria-hidden="true"
-                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect to ${node.title} input`}
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        if (!connecting || connecting.sourceId === node.id) return;
+                        event.preventDefault();
+                        onConnect?.({ source: connecting.sourceId, target: node.id });
+                        setConnecting(null);
+                      }}
                     />
                   )}
 
@@ -760,13 +776,21 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
 
                   {node.hasOutput !== false && (
                     <div
-                      aria-hidden="true"
-                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect ${node.title} to another node`}
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
                       onPointerDown={(event) => handleOutputPointerDown(event, node)}
                       onPointerMove={handleOutputPointerMove}
                       onPointerUp={handleOutputPointerUp}
                       onPointerCancel={() => setConnecting(null)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
+                        const outputPos = getPortPosition(node, "output");
+                        setConnecting({ sourceId: node.id, pointerId: null, x: outputPos.x, y: outputPos.y });
+                      }}
                     />
                   )}
                 </div>
@@ -934,6 +958,7 @@ function App() {
 | `selectedNodeId` | `string \| null` | `undefined` | Controlled selected node id; provide alongside `onNodeSelect` to drive selection externally |
 | `onNodeSelect` | `(id: string \| null) => void` | `undefined` | Called whenever the selected node changes, whether controlled or not |
 | `inspector` | `React.ReactNode` | `undefined` | Content rendered in the right panel while a node is selected |
+| `showNodeEditButton` | `boolean` | `true` | Whether each node renders a pencil icon that selects it (opening `inspector`) without starting a drag; set to `false` when no `inspector` is wired up |
 | `viewport` | `WorkflowViewport` | `undefined` | Controlled pan/zoom state; provide alongside `onViewportChange` to drive the canvas externally |
 | `defaultViewport` | `WorkflowViewport` | `x: 0, y: 0, zoom: 1` | Initial pan/zoom state when uncontrolled, and the state "Reset view" returns to |
 | `onViewportChange` | `(viewport: WorkflowViewport) => void` | `undefined` | Called whenever the viewport changes, whether controlled or not |

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
@@ -122,7 +122,9 @@ export interface WorkflowPaletteItem {
  * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
  * @property showControls - Whether to render the floating zoom in/out/reset control panel.
  * Default `true`.
- * @property className - Class name for the root container.
+ * @property className - Class name for the root container. The root fills its parent's height
+ * (`h-full`), not the viewport - give it a sized ancestor, or pass a height utility here (e.g.
+ * `h-screen`) to make it fill the viewport directly.
  */
 export interface WorkflowBuilderLayoutProps {
   header?: React.ReactNode;
@@ -206,9 +208,8 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
-  // handlers compare against a real pointerId, so they naturally no-op against this instead of
-  // needing a separate keyboard-vs-pointer branch.
+  // `null` marks a keyboard-initiated connection - pointer move/up handlers compare against a
+  // real pointerId, so they naturally no-op against this without a separate branch.
   pointerId: number | null;
   x: number;
   y: number;
@@ -568,7 +569,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   return (
-    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+    <div className={cn("flex h-full min-h-0 w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
       {(header || actions) && (
         <header
           className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"

--- a/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/templates/layouts/workflow-builder-layout.mdx
@@ -1,0 +1,986 @@
+---
+sidebar_position: 9
+title: WorkflowBuilderLayout
+description: A node-and-connection workspace shell for visual automation/workflow tools, with a node palette, draggable nodes, port-to-port connections, and an optional inspector panel.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import WorkflowBuilderLayoutDemo from '@site/src/components/Demo/WorkflowBuilderLayoutDemo';
+
+The **Workflow Builder Layout** template provides the shell behind visual automation/workflow tools (n8n, Zapier, Node-RED): a node palette on the left, an optional inspector panel on the right, and a pannable, zoomable canvas in between. Nodes are placed via the `nodes` array, dragged by their header, and wired together by dragging from one node's output port to another node's input port.
+
+<WorkflowBuilderLayoutDemo/>
+
+## Installation
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+    ```bash
+    ignix add component WorkflowBuilderLayout
+    ```
+  </TabItem>
+  <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
+
+  `cn` is a small `clsx` + `tailwind-merge` helper (installed automatically by the CLI, at `src/utils/cn.ts`). Placing this file at `src/templates/WorkflowBuilderLayout/index.tsx` resolves the import below as-is; adjust the relative path if you place it elsewhere.
+
+  ```tsx
+import * as React from "react";
+import { Button } from "@ignix-ui/button";
+import { Plus, Minus, RotateCcw, X, Pencil } from "lucide-react";
+import { cn } from "../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the workflow canvas, in the canvas's own (untransformed) coordinate space. */
+export interface WorkflowViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Restricts `value` to the inclusive `[min, max]` range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export type WorkflowNodeStatus = "idle" | "running" | "success" | "error";
+
+/**
+ * A single node placed on the workflow canvas at world coordinates `(x, y)`. Ports render at a
+ * fixed vertical offset from the top edge (matching the header row's height), so edge geometry
+ * never depends on a node's rendered content height.
+ */
+export interface WorkflowNodeData {
+  id: string;
+  x: number;
+  y: number;
+  width?: number;
+  title: string;
+  icon?: React.ReactNode;
+  status?: WorkflowNodeStatus;
+  content?: React.ReactNode;
+  hasInput?: boolean;
+  hasOutput?: boolean;
+}
+
+/** A directed connection between one node's output port and another node's input port. */
+export interface WorkflowEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+/** An entry in the node palette sidebar - a node type consumers can add to the canvas. */
+export interface WorkflowPaletteItem {
+  type: string;
+  label: string;
+  icon?: React.ReactNode;
+  description?: string;
+}
+
+/**
+ * Props for the {@link WorkflowBuilderLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property paletteItems - Node types listed in the left sidebar. Omit (or pass an empty array)
+ * to hide the sidebar entirely.
+ * @property onPaletteItemSelect - Called when a palette item is clicked (accessible alternative
+ * to dragging it onto the canvas).
+ * @property onPaletteItemDrop - Called with the dropped item and the world-space drop position
+ * when a palette item is dragged onto the canvas.
+ * @property showPalette - Whether to render the palette sidebar when `paletteItems` is non-empty.
+ * Default `true`.
+ * @property nodes - The nodes currently on the canvas. This component is fully controlled: wire
+ * `onNodesChange` to persist moves, or nodes won't visually update while dragged.
+ * @property edges - Connections between nodes, rendered as curved lines between ports.
+ * @property onNodesChange - Called with the next `nodes` array after a drag or keyboard nudge.
+ * @property onNodeDelete - Called with a node's id when Delete/Backspace is pressed while it's
+ * focused.
+ * @property onConnect - Called when a drag from one node's output port is released over another
+ * node's input port.
+ * @property selectedNodeId - Controlled selected node id. Provide alongside `onNodeSelect` to
+ * drive selection externally; omit to let the layout manage its own state.
+ * @property onNodeSelect - Called whenever the selected node changes, whether controlled or not.
+ * @property inspector - Content rendered in the right panel while a node is selected (e.g. a
+ * form for editing the selected node).
+ * @property showNodeEditButton - Whether each node renders a pencil icon that selects it (and
+ * thus opens `inspector`) without starting a drag. Default `true`; set to `false` when no
+ * `inspector` is wired up, so nodes don't show an icon that has nothing to open.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to drive
+ * the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface WorkflowBuilderLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  paletteItems?: WorkflowPaletteItem[];
+  onPaletteItemSelect?: (item: WorkflowPaletteItem) => void;
+  onPaletteItemDrop?: (item: WorkflowPaletteItem, position: { x: number; y: number }) => void;
+  showPalette?: boolean;
+  nodes: WorkflowNodeData[];
+  edges?: WorkflowEdgeData[];
+  onNodesChange?: (nodes: WorkflowNodeData[]) => void;
+  onNodeDelete?: (id: string) => void;
+  onConnect?: (connection: { source: string; target: string }) => void;
+  selectedNodeId?: string | null;
+  onNodeSelect?: (id: string | null) => void;
+  inspector?: React.ReactNode;
+  showNodeEditButton?: boolean;
+  viewport?: WorkflowViewport;
+  defaultViewport?: WorkflowViewport;
+  onViewportChange?: (viewport: WorkflowViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: WorkflowViewport = { x: 0, y: 0, zoom: 1 };
+
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
+const MIN_SAFE_ZOOM = 0.01;
+
+const DEFAULT_NODE_WIDTH = 220;
+const NODE_HEADER_HEIGHT = 40;
+const PORT_HIT_RADIUS = 24;
+const NODE_KEYBOARD_STEP = 10;
+const NODE_KEYBOARD_STEP_LARGE = 40;
+const PALETTE_DRAG_MIME = "application/workflow-node-type";
+
+/**
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
+ */
+function normalizeViewport(viewport: WorkflowViewport, minZoom: number, maxZoom: number): WorkflowViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
+const STATUS_DOT_CLASSES: Record<WorkflowNodeStatus, string> = {
+  idle: "bg-[var(--muted-foreground)]",
+  running: "bg-[var(--primary)] animate-pulse",
+  success: "bg-[var(--success)]",
+  error: "bg-[var(--destructive)]",
+};
+
+/** World-space position of a node's input (left edge) or output (right edge) port. */
+function getPortPosition(node: WorkflowNodeData, side: "input" | "output"): { x: number; y: number } {
+  const width = node.width ?? DEFAULT_NODE_WIDTH;
+  return { x: side === "input" ? node.x : node.x + width, y: node.y + NODE_HEADER_HEIGHT / 2 };
+}
+
+/** A horizontal cubic-bezier path between two ports, curved outward proportionally to distance. */
+function buildEdgePath(source: { x: number; y: number }, target: { x: number; y: number }): string {
+  const curvature = Math.max(Math.abs(target.x - source.x) / 2, 40);
+  return `M ${source.x},${source.y} C ${source.x + curvature},${source.y} ${target.x - curvature},${target.y} ${target.x},${target.y}`;
+}
+
+interface DragState {
+  nodeId: string;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+}
+
+interface ConnectingState {
+  sourceId: string;
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * WorkflowBuilderLayout is a node-and-connection workspace shell - the shape behind visual
+ * automation/workflow tools (n8n, Zapier, Node-RED). A node palette sits on the left, an
+ * optional inspector panel on the right, and a pannable/zoomable canvas in between where nodes
+ * are placed, dragged, and wired together by dragging from an output port to an input port.
+ */
+export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
+  header,
+  actions,
+  paletteItems,
+  onPaletteItemSelect,
+  onPaletteItemDrop,
+  showPalette = true,
+  nodes,
+  edges = [],
+  onNodesChange,
+  onNodeDelete,
+  onConnect,
+  selectedNodeId,
+  onNodeSelect,
+  inspector,
+  showNodeEditButton = true,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isViewportControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<WorkflowViewport>(defaultViewport);
+  const rawViewport = isViewportControlled ? viewport : internalViewport;
+
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
+
+  const currentViewport: WorkflowViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
+
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: WorkflowViewport) => WorkflowViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped = normalizeViewport(next, safeMinZoom, safeMaxZoom);
+      if (!isViewportControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isViewportControlled, safeMinZoom, safeMaxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const isSelectionControlled = selectedNodeId !== undefined;
+  const [internalSelectedId, setInternalSelectedId] = React.useState<string | null>(null);
+  const currentSelectedId = isSelectionControlled ? selectedNodeId : internalSelectedId;
+  const selectNode = React.useCallback(
+    (id: string | null) => {
+      if (!isSelectionControlled) setInternalSelectedId(id);
+      onNodeSelect?.(id);
+    },
+    [isSelectionControlled, onNodeSelect]
+  );
+
+  const nodeById = React.useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const selectedNode = currentSelectedId ? (nodeById.get(currentSelectedId) ?? null) : null;
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  const inputPortRefs = React.useRef(new Map<string, HTMLDivElement>());
+  const [connecting, setConnecting] = React.useState<ConnectingState | null>(null);
+
+  // Colons from useId() are stripped since this feeds an SVG url(#id) reference, where they're
+  // unreliable across browsers.
+  const arrowMarkerId = `workflow-arrow-${React.useId().replace(/:/g, "")}`;
+
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handleSurfacePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only pan when the drag starts on empty background, not a node, so nodes stay
+    // independently draggable/connectable.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus, so this restores it for
+    // keyboard pan/zoom.
+    event.currentTarget.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handleSurfacePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handleSurfacePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
+    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
+    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
+    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    if (event.target !== event.currentTarget && event.key !== "Escape") return;
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      case "Escape":
+        if (connecting) {
+          setConnecting(null);
+          event.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
+    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
+    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
+    // or further up to the host app, still works.
+    const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
+    const move = (dx: number, dy: number): void => {
+      onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
+    };
+    switch (event.key) {
+      case "ArrowUp":
+        move(0, -step);
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        move(0, step);
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        move(-step, 0);
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        move(step, 0);
+        event.preventDefault();
+        break;
+      case "Enter":
+      case " ":
+        selectNode(node.id);
+        event.preventDefault();
+        break;
+      case "Delete":
+      case "Backspace":
+        onNodeDelete?.(node.id);
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeHeaderPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus; the header itself isn't
+    // focusable, so this focuses the node (closest ancestor role="group") instead.
+    (event.currentTarget.closest('[role="group"]') as HTMLElement | null)?.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStateRef.current = {
+      nodeId: node.id,
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: node.x,
+      startY: node.y,
+    };
+  };
+
+  const handleNodeHeaderPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const zoom = currentViewport.zoom || 1;
+    const dx = (event.clientX - state.startClientX) / zoom;
+    const dy = (event.clientY - state.startClientY) / zoom;
+    onNodesChange?.(
+      nodes.map((n) => (n.id === state.nodeId ? { ...n, x: state.startX + dx, y: state.startY + dy } : n))
+    );
+  };
+
+  const handleNodeHeaderPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (dragStateRef.current?.pointerId === event.pointerId) {
+      dragStateRef.current = null;
+    }
+  };
+
+  const handleOutputPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const outputPos = getPortPosition(node, "output");
+    setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
+  };
+
+  const handleOutputPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    setConnecting((prev) => (prev && prev.pointerId === event.pointerId ? { ...prev, x: worldX, y: worldY } : prev));
+  };
+
+  const handleOutputPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    // Finds the nearest input port within range via geometry (rect centers) rather than
+    // document.elementFromPoint, since the pointer capture on the output port means the
+    // release target is always the output port itself, never whatever's underneath it.
+    let targetId: string | null = null;
+    let closestDistance = PORT_HIT_RADIUS;
+    inputPortRefs.current.forEach((el, nodeId) => {
+      if (nodeId === connecting.sourceId) return;
+      const rect = el.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (distance <= closestDistance) {
+        closestDistance = distance;
+        targetId = nodeId;
+      }
+    });
+    if (targetId) {
+      onConnect?.({ source: connecting.sourceId, target: targetId });
+    }
+    setConnecting(null);
+  };
+
+  const handleCanvasDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop || !event.dataTransfer.types.includes(PALETTE_DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleCanvasDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop) return;
+    const type = event.dataTransfer.getData(PALETTE_DRAG_MIME);
+    const item = paletteItems?.find((candidate) => candidate.type === type);
+    const surface = surfaceRef.current;
+    if (!type || !item || !surface) return;
+    event.preventDefault();
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    onPaletteItemDrop(item, { x: worldX, y: worldY });
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {showPalette && paletteItems && paletteItems.length > 0 && (
+          <aside
+            className="w-64 shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)] p-2"
+            aria-label="Node palette"
+          >
+            <ul className="flex flex-col gap-1">
+              {paletteItems.map((item) => (
+                <li key={item.type}>
+                  <button
+                    type="button"
+                    draggable={Boolean(onPaletteItemDrop)}
+                    onDragStart={(event) => {
+                      event.dataTransfer.setData(PALETTE_DRAG_MIME, item.type);
+                      event.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onClick={() => onPaletteItemSelect?.(item)}
+                    className="flex w-full items-center gap-2 rounded-md p-2 text-left text-sm hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                  >
+                    {item.icon && <span className="shrink-0">{item.icon}</span>}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{item.label}</span>
+                      {item.description && (
+                        <span className="block truncate text-xs text-[var(--muted-foreground)]">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
+        <div
+          ref={surfaceRef}
+          className="relative flex-1 touch-none select-none overflow-hidden"
+          style={
+            showGrid
+              ? {
+                  backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                  backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                  backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+                }
+              : undefined
+          }
+          role="group"
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          tabIndex={0}
+          onPointerDown={handleSurfacePointerDown}
+          onPointerMove={handleSurfacePointerMove}
+          onPointerUp={handleSurfacePointerUp}
+          onPointerCancel={handleSurfacePointerUp}
+          onKeyDown={handleSurfaceKeyDown}
+          onDragOver={handleCanvasDragOver}
+          onDrop={handleCanvasDrop}
+        >
+          <div
+            className="absolute left-0 top-0"
+            style={{
+              transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+              transformOrigin: "0 0",
+            }}
+          >
+            <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={1} height={1}>
+              <defs>
+                <marker
+                  id={arrowMarkerId}
+                  viewBox="0 0 10 10"
+                  refX={9}
+                  refY={5}
+                  markerWidth={7}
+                  markerHeight={7}
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border)" />
+                </marker>
+              </defs>
+              {edges.map((edge) => {
+                const sourceNode = nodeById.get(edge.source);
+                const targetNode = nodeById.get(edge.target);
+                if (!sourceNode || !targetNode) return null;
+                const sourcePos = getPortPosition(sourceNode, "output");
+                const targetPos = getPortPosition(targetNode, "input");
+                return (
+                  <g key={edge.id}>
+                    <path
+                      d={buildEdgePath(sourcePos, targetPos)}
+                      stroke="var(--border)"
+                      strokeWidth={2}
+                      fill="none"
+                      markerEnd={`url(#${arrowMarkerId})`}
+                    />
+                    {edge.label && (
+                      <text
+                        x={(sourcePos.x + targetPos.x) / 2}
+                        y={(sourcePos.y + targetPos.y) / 2 - 6}
+                        textAnchor="middle"
+                        fontSize={11}
+                        fill="var(--muted-foreground)"
+                      >
+                        {edge.label}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+              {connecting &&
+                (() => {
+                  const sourceNode = nodeById.get(connecting.sourceId);
+                  if (!sourceNode) return null;
+                  const sourcePos = getPortPosition(sourceNode, "output");
+                  return (
+                    <path
+                      d={buildEdgePath(sourcePos, { x: connecting.x, y: connecting.y })}
+                      stroke="var(--primary)"
+                      strokeWidth={2}
+                      strokeDasharray="4 4"
+                      fill="none"
+                    />
+                  );
+                })()}
+            </svg>
+
+            {nodes.map((node) => {
+              const isSelected = node.id === currentSelectedId;
+              const width = node.width ?? DEFAULT_NODE_WIDTH;
+              return (
+                <div
+                  key={node.id}
+                  role="group"
+                  aria-label={`${node.title} node${node.status ? `, status ${node.status}` : ""}${isSelected ? ", selected" : ""}`}
+                  tabIndex={0}
+                  className={cn(
+                    "absolute rounded-lg border bg-[var(--background)] shadow-sm",
+                    isSelected ? "border-[var(--primary)] ring-2 ring-[var(--primary)]" : "border-[var(--border)]"
+                  )}
+                  style={{ left: node.x, top: node.y, width }}
+                  onKeyDown={(event) => handleNodeKeyDown(event, node)}
+                >
+                  {node.hasInput !== false && (
+                    <div
+                      ref={(el) => {
+                        if (el) inputPortRefs.current.set(node.id, el);
+                        else inputPortRefs.current.delete(node.id);
+                      }}
+                      aria-hidden="true"
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                    />
+                  )}
+
+                  <div
+                    className="flex h-10 cursor-grab items-center gap-2 rounded-t-lg border-b border-[var(--border)] px-3 active:cursor-grabbing"
+                    onPointerDown={(event) => handleNodeHeaderPointerDown(event, node)}
+                    onPointerMove={handleNodeHeaderPointerMove}
+                    onPointerUp={handleNodeHeaderPointerUp}
+                    onPointerCancel={handleNodeHeaderPointerUp}
+                  >
+                    {node.icon && <span className="shrink-0">{node.icon}</span>}
+                    <span className="flex-1 truncate text-sm font-medium">{node.title}</span>
+                    {node.status && (
+                      <span
+                        className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT_CLASSES[node.status])}
+                        aria-hidden="true"
+                      />
+                    )}
+                    {showNodeEditButton && (
+                      <button
+                        type="button"
+                        aria-label={`Edit ${node.title}`}
+                        className="shrink-0 rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          selectNode(node.id);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+
+                  {node.content && <div className="p-3 text-sm text-[var(--muted-foreground)]">{node.content}</div>}
+
+                  {node.hasOutput !== false && (
+                    <div
+                      aria-hidden="true"
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onPointerDown={(event) => handleOutputPointerDown(event, node)}
+                      onPointerMove={handleOutputPointerMove}
+                      onPointerUp={handleOutputPointerUp}
+                      onPointerCancel={() => setConnecting(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {showControls && (
+            <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+              <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+                <Plus className="h-4 w-4" />
+              </Button>
+              <div className="text-center text-xs text-[var(--muted-foreground)]">
+                {Math.round(currentViewport.zoom * 100)}%
+              </div>
+              <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {selectedNode && inspector && (
+          <aside
+            className="w-80 shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4"
+            aria-label={`Inspector for ${selectedNode.title}`}
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="truncate text-sm font-semibold">{selectedNode.title}</h3>
+              <Button variant="ghost" size="icon" aria-label="Close inspector" onClick={() => selectNode(null)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            {inspector}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+};
+
+WorkflowBuilderLayout.displayName = "WorkflowBuilderLayout";
+
+export default WorkflowBuilderLayout;
+  ```
+  </TabItem>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  WorkflowBuilderLayout,
+  type WorkflowNodeData,
+  type WorkflowEdgeData,
+  type WorkflowPaletteItem,
+} from '@ignix-ui/workflow-builder-layout';
+```
+
+### Basic Usage
+
+```tsx
+import { useState } from 'react';
+
+function App() {
+  const [nodes, setNodes] = useState<WorkflowNodeData[]>([
+    { id: 'trigger', x: 0, y: 0, title: 'New Signup' },
+    { id: 'email', x: 300, y: 0, title: 'Send Email' },
+  ]);
+  const [edges, setEdges] = useState<WorkflowEdgeData[]>([
+    { id: 'trigger-email', source: 'trigger', target: 'email' },
+  ]);
+
+  return (
+    <WorkflowBuilderLayout
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={setNodes}
+      onConnect={(edge) => setEdges((prev) => [...prev, { id: `${edge.source}-${edge.target}`, ...edge }])}
+    />
+  );
+}
+```
+
+### With a Palette and Inspector
+
+```tsx
+<WorkflowBuilderLayout
+  nodes={nodes}
+  edges={edges}
+  onNodesChange={setNodes}
+  onConnect={handleConnect}
+  paletteItems={[
+    { type: 'webhook', label: 'Webhook', icon: <Webhook className="h-4 w-4" /> },
+    { type: 'email', label: 'Send Email', icon: <Mail className="h-4 w-4" /> },
+  ]}
+  onPaletteItemDrop={(item, position) =>
+    setNodes((prev) => [...prev, { id: crypto.randomUUID(), x: position.x, y: position.y, title: item.label }])
+  }
+  selectedNodeId={selectedNodeId}
+  onNodeSelect={setSelectedNodeId}
+  inspector={selectedNode && <NodeSettingsForm node={selectedNode} onChange={updateSelectedNode} />}
+/>
+```
+
+### Controlled Viewport
+
+```tsx
+import { useState } from 'react';
+
+function App() {
+  const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 1 });
+
+  return (
+    <WorkflowBuilderLayout
+      nodes={nodes}
+      onNodesChange={setNodes}
+      viewport={viewport}
+      onViewportChange={setViewport}
+    />
+  );
+}
+```
+
+## Interaction Reference
+
+| Input | Action |
+|-------|--------|
+| Drag on empty canvas | Pan the canvas |
+| Drag a node's header | Move that node |
+| Drag from an output port to an input port | Create a connection between the two nodes |
+| Drag a palette item onto the canvas | Drop a new node at that position (requires `onPaletteItemDrop`) |
+| Click a palette item | Select it via `onPaletteItemSelect` (accessible alternative to dragging) |
+| Mouse wheel / trackpad scroll | Pan the canvas |
+| Ctrl/Cmd + wheel | Zoom toward the cursor |
+| Arrow keys (canvas focused) | Pan the canvas |
+| Arrow keys (node focused) | Nudge that node; hold Shift for a larger step |
+| Delete / Backspace (node focused) | Remove that node via `onNodeDelete` |
+| Enter / Space (node focused) | Select the node |
+| Escape | Cancel an in-progress connection drag |
+| `+` / `-` (canvas focused) | Zoom in / out |
+| `0` (canvas focused) | Reset to `defaultViewport` |
+| Zoom control buttons | Zoom in / out / reset |
+
+## Props
+
+### WorkflowBuilderLayout
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `header` | `React.ReactNode` | `undefined` | Custom node rendered at the start of the top toolbar (e.g. a logo/title) |
+| `actions` | `React.ReactNode` | `undefined` | Optional node rendered at the end of the top toolbar |
+| `paletteItems` | `WorkflowPaletteItem[]` | `undefined` | Node types listed in the left sidebar; omit or pass an empty array to hide it |
+| `onPaletteItemSelect` | `(item: WorkflowPaletteItem) => void` | `undefined` | Called when a palette item is clicked |
+| `onPaletteItemDrop` | `(item: WorkflowPaletteItem, position: { x: number; y: number }) => void` | `undefined` | Called with the dropped item and world-space drop position |
+| `showPalette` | `boolean` | `true` | Whether to render the palette sidebar when `paletteItems` is non-empty |
+| `nodes` | `WorkflowNodeData[]` | — | The nodes currently on the canvas (this component is fully controlled) |
+| `edges` | `WorkflowEdgeData[]` | `[]` | Connections between nodes, rendered as curved lines between ports |
+| `onNodesChange` | `(nodes: WorkflowNodeData[]) => void` | `undefined` | Called with the next `nodes` array after a drag or keyboard nudge |
+| `onNodeDelete` | `(id: string) => void` | `undefined` | Called with a node's id when Delete/Backspace is pressed while it's focused |
+| `onConnect` | `(connection: { source: string; target: string }) => void` | `undefined` | Called when a drag from an output port is released over an input port |
+| `selectedNodeId` | `string \| null` | `undefined` | Controlled selected node id; provide alongside `onNodeSelect` to drive selection externally |
+| `onNodeSelect` | `(id: string \| null) => void` | `undefined` | Called whenever the selected node changes, whether controlled or not |
+| `inspector` | `React.ReactNode` | `undefined` | Content rendered in the right panel while a node is selected |
+| `viewport` | `WorkflowViewport` | `undefined` | Controlled pan/zoom state; provide alongside `onViewportChange` to drive the canvas externally |
+| `defaultViewport` | `WorkflowViewport` | `x: 0, y: 0, zoom: 1` | Initial pan/zoom state when uncontrolled, and the state "Reset view" returns to |
+| `onViewportChange` | `(viewport: WorkflowViewport) => void` | `undefined` | Called whenever the viewport changes, whether controlled or not |
+| `minZoom` | `number` | `0.25` | Minimum zoom factor |
+| `maxZoom` | `number` | `2.5` | Maximum zoom factor |
+| `showGrid` | `boolean` | `true` | Whether to render the background dot grid |
+| `gridSize` | `number` | `32` | Spacing between grid dots, in canvas world units |
+| `showControls` | `boolean` | `true` | Whether to render the floating zoom in/out/reset control panel |
+| `className` | `string` | `undefined` | Additional CSS classes applied to the root container |
+
+### WorkflowNodeData
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — | Unique node identifier |
+| `x` | `number` | — | Horizontal position in the canvas's world space |
+| `y` | `number` | — | Vertical position in the canvas's world space |
+| `width` | `number` | `220` | Node width in canvas world units |
+| `title` | `string` | — | Text shown in the node's header |
+| `icon` | `React.ReactNode` | `undefined` | Icon shown before the title |
+| `status` | `"idle" \| "running" \| "success" \| "error"` | `undefined` | Shows a colored status dot in the header when set |
+| `content` | `React.ReactNode` | `undefined` | Optional body content below the header |
+| `hasInput` | `boolean` | `true` | Whether to render an input port on the left edge |
+| `hasOutput` | `boolean` | `true` | Whether to render an output port on the right edge |
+
+### WorkflowEdgeData
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — | Unique edge identifier |
+| `source` | `string` | — | Id of the node the edge starts from (its output port) |
+| `target` | `string` | — | Id of the node the edge ends at (its input port) |
+| `label` | `string` | `undefined` | Optional text drawn at the midpoint of the edge |
+
+### WorkflowPaletteItem
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `string` | — | Identifier used to look up the item on drop |
+| `label` | `string` | — | Text shown in the palette |
+| `icon` | `React.ReactNode` | `undefined` | Icon shown before the label |
+| `description` | `string` | `undefined` | Secondary text shown below the label |
+
+### WorkflowViewport
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `x` | `number` | Horizontal pan offset, in pixels |
+| `y` | `number` | Vertical pan offset, in pixels |
+| `zoom` | `number` | Zoom factor (`1` = 100%) |

--- a/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-1.0.3-sidebars.json
@@ -152,7 +152,8 @@
             "templates/layouts/sidebar-left-layout",
             "templates/layouts/sidebar-right-layout",
             "templates/layouts/single-column-layout",
-            "templates/layouts/three-column-sidebar-layout"
+            "templates/layouts/three-column-sidebar-layout",
+            "templates/layouts/workflow-builder-layout"
           ]
         },
         {

--- a/apps/storybook/src/index.css
+++ b/apps/storybook/src/index.css
@@ -254,3 +254,14 @@
     scrollbar-width: thin;
   }
 }
+
+/* Storybook's iframe document doesn't set an explicit height chain by default, so any story
+   using `h-full` (instead of `h-screen`) to fill its container would collapse to its content's
+   natural height instead of the viewport. */
+@layer base {
+  html,
+  body,
+  #storybook-root {
+    height: 100%;
+  }
+}

--- a/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
@@ -1,0 +1,789 @@
+import * as React from "react";
+import { Button } from "../../../components/button";
+import { Plus, Minus, RotateCcw, X, Pencil } from "lucide-react";
+import { cn } from "../../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the workflow canvas, in the canvas's own (untransformed) coordinate space. */
+export interface WorkflowViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Restricts `value` to the inclusive `[min, max]` range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export type WorkflowNodeStatus = "idle" | "running" | "success" | "error";
+
+/**
+ * A single node placed on the workflow canvas at world coordinates `(x, y)`. Ports render at a
+ * fixed vertical offset from the top edge (matching the header row's height), so edge geometry
+ * never depends on a node's rendered content height.
+ */
+export interface WorkflowNodeData {
+  id: string;
+  x: number;
+  y: number;
+  width?: number;
+  title: string;
+  icon?: React.ReactNode;
+  status?: WorkflowNodeStatus;
+  content?: React.ReactNode;
+  hasInput?: boolean;
+  hasOutput?: boolean;
+}
+
+/** A directed connection between one node's output port and another node's input port. */
+export interface WorkflowEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+/** An entry in the node palette sidebar - a node type consumers can add to the canvas. */
+export interface WorkflowPaletteItem {
+  type: string;
+  label: string;
+  icon?: React.ReactNode;
+  description?: string;
+}
+
+/**
+ * Props for the {@link WorkflowBuilderLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property paletteItems - Node types listed in the left sidebar. Omit (or pass an empty array)
+ * to hide the sidebar entirely.
+ * @property onPaletteItemSelect - Called when a palette item is clicked (accessible alternative
+ * to dragging it onto the canvas).
+ * @property onPaletteItemDrop - Called with the dropped item and the world-space drop position
+ * when a palette item is dragged onto the canvas.
+ * @property showPalette - Whether to render the palette sidebar when `paletteItems` is non-empty.
+ * Default `true`.
+ * @property nodes - The nodes currently on the canvas. This component is fully controlled: wire
+ * `onNodesChange` to persist moves, or nodes won't visually update while dragged.
+ * @property edges - Connections between nodes, rendered as curved lines between ports.
+ * @property onNodesChange - Called with the next `nodes` array after a drag or keyboard nudge.
+ * @property onNodeDelete - Called with a node's id when Delete/Backspace is pressed while it's
+ * focused.
+ * @property onConnect - Called when a drag from one node's output port is released over another
+ * node's input port.
+ * @property selectedNodeId - Controlled selected node id. Provide alongside `onNodeSelect` to
+ * drive selection externally; omit to let the layout manage its own state.
+ * @property onNodeSelect - Called whenever the selected node changes, whether controlled or not.
+ * @property inspector - Content rendered in the right panel while a node is selected (e.g. a
+ * form for editing the selected node).
+ * @property showNodeEditButton - Whether each node renders a pencil icon that selects it (and
+ * thus opens `inspector`) without starting a drag. Default `true`; set to `false` when no
+ * `inspector` is wired up, so nodes don't show an icon that has nothing to open.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to drive
+ * the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface WorkflowBuilderLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  paletteItems?: WorkflowPaletteItem[];
+  onPaletteItemSelect?: (item: WorkflowPaletteItem) => void;
+  onPaletteItemDrop?: (item: WorkflowPaletteItem, position: { x: number; y: number }) => void;
+  showPalette?: boolean;
+  nodes: WorkflowNodeData[];
+  edges?: WorkflowEdgeData[];
+  onNodesChange?: (nodes: WorkflowNodeData[]) => void;
+  onNodeDelete?: (id: string) => void;
+  onConnect?: (connection: { source: string; target: string }) => void;
+  selectedNodeId?: string | null;
+  onNodeSelect?: (id: string | null) => void;
+  inspector?: React.ReactNode;
+  showNodeEditButton?: boolean;
+  viewport?: WorkflowViewport;
+  defaultViewport?: WorkflowViewport;
+  onViewportChange?: (viewport: WorkflowViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: WorkflowViewport = { x: 0, y: 0, zoom: 1 };
+
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
+const MIN_SAFE_ZOOM = 0.01;
+
+const DEFAULT_NODE_WIDTH = 220;
+const NODE_HEADER_HEIGHT = 40;
+const PORT_HIT_RADIUS = 24;
+const NODE_KEYBOARD_STEP = 10;
+const NODE_KEYBOARD_STEP_LARGE = 40;
+const PALETTE_DRAG_MIME = "application/workflow-node-type";
+
+/**
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
+ */
+function normalizeViewport(viewport: WorkflowViewport, minZoom: number, maxZoom: number): WorkflowViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
+const STATUS_DOT_CLASSES: Record<WorkflowNodeStatus, string> = {
+  idle: "bg-[var(--muted-foreground)]",
+  running: "bg-[var(--primary)] animate-pulse",
+  success: "bg-[var(--success)]",
+  error: "bg-[var(--destructive)]",
+};
+
+/** World-space position of a node's input (left edge) or output (right edge) port. */
+function getPortPosition(node: WorkflowNodeData, side: "input" | "output"): { x: number; y: number } {
+  const width = node.width ?? DEFAULT_NODE_WIDTH;
+  return { x: side === "input" ? node.x : node.x + width, y: node.y + NODE_HEADER_HEIGHT / 2 };
+}
+
+/** A horizontal cubic-bezier path between two ports, curved outward proportionally to distance. */
+function buildEdgePath(source: { x: number; y: number }, target: { x: number; y: number }): string {
+  const curvature = Math.max(Math.abs(target.x - source.x) / 2, 40);
+  return `M ${source.x},${source.y} C ${source.x + curvature},${source.y} ${target.x - curvature},${target.y} ${target.x},${target.y}`;
+}
+
+interface DragState {
+  nodeId: string;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+}
+
+interface ConnectingState {
+  sourceId: string;
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * WorkflowBuilderLayout is a node-and-connection workspace shell - the shape behind visual
+ * automation/workflow tools (n8n, Zapier, Node-RED). A node palette sits on the left, an
+ * optional inspector panel on the right, and a pannable/zoomable canvas in between where nodes
+ * are placed, dragged, and wired together by dragging from an output port to an input port.
+ */
+export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
+  header,
+  actions,
+  paletteItems,
+  onPaletteItemSelect,
+  onPaletteItemDrop,
+  showPalette = true,
+  nodes,
+  edges = [],
+  onNodesChange,
+  onNodeDelete,
+  onConnect,
+  selectedNodeId,
+  onNodeSelect,
+  inspector,
+  showNodeEditButton = true,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isViewportControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<WorkflowViewport>(defaultViewport);
+  const rawViewport = isViewportControlled ? viewport : internalViewport;
+
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
+
+  const currentViewport: WorkflowViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
+
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: WorkflowViewport) => WorkflowViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped = normalizeViewport(next, safeMinZoom, safeMaxZoom);
+      if (!isViewportControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isViewportControlled, safeMinZoom, safeMaxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const isSelectionControlled = selectedNodeId !== undefined;
+  const [internalSelectedId, setInternalSelectedId] = React.useState<string | null>(null);
+  const currentSelectedId = isSelectionControlled ? selectedNodeId : internalSelectedId;
+  const selectNode = React.useCallback(
+    (id: string | null) => {
+      if (!isSelectionControlled) setInternalSelectedId(id);
+      onNodeSelect?.(id);
+    },
+    [isSelectionControlled, onNodeSelect]
+  );
+
+  const nodeById = React.useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const selectedNode = currentSelectedId ? (nodeById.get(currentSelectedId) ?? null) : null;
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  const inputPortRefs = React.useRef(new Map<string, HTMLDivElement>());
+  const [connecting, setConnecting] = React.useState<ConnectingState | null>(null);
+
+  // Colons from useId() are stripped since this feeds an SVG url(#id) reference, where they're
+  // unreliable across browsers.
+  const arrowMarkerId = `workflow-arrow-${React.useId().replace(/:/g, "")}`;
+
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handleSurfacePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only pan when the drag starts on empty background, not a node, so nodes stay
+    // independently draggable/connectable.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus, so this restores it for
+    // keyboard pan/zoom.
+    event.currentTarget.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handleSurfacePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handleSurfacePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
+    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
+    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
+    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    if (event.target !== event.currentTarget && event.key !== "Escape") return;
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      case "Escape":
+        if (connecting) {
+          setConnecting(null);
+          event.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
+    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
+    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
+    // or further up to the host app, still works.
+    const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
+    const move = (dx: number, dy: number): void => {
+      onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
+    };
+    switch (event.key) {
+      case "ArrowUp":
+        move(0, -step);
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        move(0, step);
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        move(-step, 0);
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        move(step, 0);
+        event.preventDefault();
+        break;
+      case "Enter":
+      case " ":
+        selectNode(node.id);
+        event.preventDefault();
+        break;
+      case "Delete":
+      case "Backspace":
+        onNodeDelete?.(node.id);
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeHeaderPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus; the header itself isn't
+    // focusable, so this focuses the node (closest ancestor role="group") instead.
+    (event.currentTarget.closest('[role="group"]') as HTMLElement | null)?.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStateRef.current = {
+      nodeId: node.id,
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: node.x,
+      startY: node.y,
+    };
+  };
+
+  const handleNodeHeaderPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const zoom = currentViewport.zoom || 1;
+    const dx = (event.clientX - state.startClientX) / zoom;
+    const dy = (event.clientY - state.startClientY) / zoom;
+    onNodesChange?.(
+      nodes.map((n) => (n.id === state.nodeId ? { ...n, x: state.startX + dx, y: state.startY + dy } : n))
+    );
+  };
+
+  const handleNodeHeaderPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (dragStateRef.current?.pointerId === event.pointerId) {
+      dragStateRef.current = null;
+    }
+  };
+
+  const handleOutputPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const outputPos = getPortPosition(node, "output");
+    setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
+  };
+
+  const handleOutputPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    setConnecting((prev) => (prev && prev.pointerId === event.pointerId ? { ...prev, x: worldX, y: worldY } : prev));
+  };
+
+  const handleOutputPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    // Finds the nearest input port within range via geometry (rect centers) rather than
+    // document.elementFromPoint, since the pointer capture on the output port means the
+    // release target is always the output port itself, never whatever's underneath it.
+    let targetId: string | null = null;
+    let closestDistance = PORT_HIT_RADIUS;
+    inputPortRefs.current.forEach((el, nodeId) => {
+      if (nodeId === connecting.sourceId) return;
+      const rect = el.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (distance <= closestDistance) {
+        closestDistance = distance;
+        targetId = nodeId;
+      }
+    });
+    if (targetId) {
+      onConnect?.({ source: connecting.sourceId, target: targetId });
+    }
+    setConnecting(null);
+  };
+
+  const handleCanvasDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop || !event.dataTransfer.types.includes(PALETTE_DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleCanvasDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop) return;
+    const type = event.dataTransfer.getData(PALETTE_DRAG_MIME);
+    const item = paletteItems?.find((candidate) => candidate.type === type);
+    const surface = surfaceRef.current;
+    if (!type || !item || !surface) return;
+    event.preventDefault();
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    onPaletteItemDrop(item, { x: worldX, y: worldY });
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {showPalette && paletteItems && paletteItems.length > 0 && (
+          <aside
+            className="w-64 shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)] p-2"
+            aria-label="Node palette"
+          >
+            <ul className="flex flex-col gap-1">
+              {paletteItems.map((item) => (
+                <li key={item.type}>
+                  <button
+                    type="button"
+                    draggable={Boolean(onPaletteItemDrop)}
+                    onDragStart={(event) => {
+                      event.dataTransfer.setData(PALETTE_DRAG_MIME, item.type);
+                      event.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onClick={() => onPaletteItemSelect?.(item)}
+                    className="flex w-full items-center gap-2 rounded-md p-2 text-left text-sm hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                  >
+                    {item.icon && <span className="shrink-0">{item.icon}</span>}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{item.label}</span>
+                      {item.description && (
+                        <span className="block truncate text-xs text-[var(--muted-foreground)]">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
+        <div
+          ref={surfaceRef}
+          className="relative flex-1 touch-none select-none overflow-hidden"
+          style={
+            showGrid
+              ? {
+                  backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                  backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                  backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+                }
+              : undefined
+          }
+          role="group"
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          tabIndex={0}
+          onPointerDown={handleSurfacePointerDown}
+          onPointerMove={handleSurfacePointerMove}
+          onPointerUp={handleSurfacePointerUp}
+          onPointerCancel={handleSurfacePointerUp}
+          onKeyDown={handleSurfaceKeyDown}
+          onDragOver={handleCanvasDragOver}
+          onDrop={handleCanvasDrop}
+        >
+          <div
+            className="absolute left-0 top-0"
+            style={{
+              transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+              transformOrigin: "0 0",
+            }}
+          >
+            <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={1} height={1}>
+              <defs>
+                <marker
+                  id={arrowMarkerId}
+                  viewBox="0 0 10 10"
+                  refX={9}
+                  refY={5}
+                  markerWidth={7}
+                  markerHeight={7}
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border)" />
+                </marker>
+              </defs>
+              {edges.map((edge) => {
+                const sourceNode = nodeById.get(edge.source);
+                const targetNode = nodeById.get(edge.target);
+                if (!sourceNode || !targetNode) return null;
+                const sourcePos = getPortPosition(sourceNode, "output");
+                const targetPos = getPortPosition(targetNode, "input");
+                return (
+                  <g key={edge.id}>
+                    <path
+                      d={buildEdgePath(sourcePos, targetPos)}
+                      stroke="var(--border)"
+                      strokeWidth={2}
+                      fill="none"
+                      markerEnd={`url(#${arrowMarkerId})`}
+                    />
+                    {edge.label && (
+                      <text
+                        x={(sourcePos.x + targetPos.x) / 2}
+                        y={(sourcePos.y + targetPos.y) / 2 - 6}
+                        textAnchor="middle"
+                        fontSize={11}
+                        fill="var(--muted-foreground)"
+                      >
+                        {edge.label}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+              {connecting &&
+                (() => {
+                  const sourceNode = nodeById.get(connecting.sourceId);
+                  if (!sourceNode) return null;
+                  const sourcePos = getPortPosition(sourceNode, "output");
+                  return (
+                    <path
+                      d={buildEdgePath(sourcePos, { x: connecting.x, y: connecting.y })}
+                      stroke="var(--primary)"
+                      strokeWidth={2}
+                      strokeDasharray="4 4"
+                      fill="none"
+                    />
+                  );
+                })()}
+            </svg>
+
+            {nodes.map((node) => {
+              const isSelected = node.id === currentSelectedId;
+              const width = node.width ?? DEFAULT_NODE_WIDTH;
+              return (
+                <div
+                  key={node.id}
+                  role="group"
+                  aria-label={`${node.title} node${node.status ? `, status ${node.status}` : ""}${isSelected ? ", selected" : ""}`}
+                  tabIndex={0}
+                  className={cn(
+                    "absolute rounded-lg border bg-[var(--background)] shadow-sm",
+                    isSelected ? "border-[var(--primary)] ring-2 ring-[var(--primary)]" : "border-[var(--border)]"
+                  )}
+                  style={{ left: node.x, top: node.y, width }}
+                  onKeyDown={(event) => handleNodeKeyDown(event, node)}
+                >
+                  {node.hasInput !== false && (
+                    <div
+                      ref={(el) => {
+                        if (el) inputPortRefs.current.set(node.id, el);
+                        else inputPortRefs.current.delete(node.id);
+                      }}
+                      aria-hidden="true"
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                    />
+                  )}
+
+                  <div
+                    className="flex h-10 cursor-grab items-center gap-2 rounded-t-lg border-b border-[var(--border)] px-3 active:cursor-grabbing"
+                    onPointerDown={(event) => handleNodeHeaderPointerDown(event, node)}
+                    onPointerMove={handleNodeHeaderPointerMove}
+                    onPointerUp={handleNodeHeaderPointerUp}
+                    onPointerCancel={handleNodeHeaderPointerUp}
+                  >
+                    {node.icon && <span className="shrink-0">{node.icon}</span>}
+                    <span className="flex-1 truncate text-sm font-medium">{node.title}</span>
+                    {node.status && (
+                      <span
+                        className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT_CLASSES[node.status])}
+                        aria-hidden="true"
+                      />
+                    )}
+                    {showNodeEditButton && (
+                      <button
+                        type="button"
+                        aria-label={`Edit ${node.title}`}
+                        className="shrink-0 rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          selectNode(node.id);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+
+                  {node.content && <div className="p-3 text-sm text-[var(--muted-foreground)]">{node.content}</div>}
+
+                  {node.hasOutput !== false && (
+                    <div
+                      aria-hidden="true"
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onPointerDown={(event) => handleOutputPointerDown(event, node)}
+                      onPointerMove={handleOutputPointerMove}
+                      onPointerUp={handleOutputPointerUp}
+                      onPointerCancel={() => setConnecting(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {showControls && (
+            <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+              <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+                <Plus className="h-4 w-4" />
+              </Button>
+              <div className="text-center text-xs text-[var(--muted-foreground)]">
+                {Math.round(currentViewport.zoom * 100)}%
+              </div>
+              <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {selectedNode && inspector && (
+          <aside
+            className="w-80 shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4"
+            aria-label={`Inspector for ${selectedNode.title}`}
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="truncate text-sm font-semibold">{selectedNode.title}</h3>
+              <Button variant="ghost" size="icon" aria-label="Close inspector" onClick={() => selectNode(null)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            {inspector}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+};
+
+WorkflowBuilderLayout.displayName = "WorkflowBuilderLayout";
+
+export default WorkflowBuilderLayout;

--- a/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
@@ -95,7 +95,9 @@ export interface WorkflowPaletteItem {
  * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
  * @property showControls - Whether to render the floating zoom in/out/reset control panel.
  * Default `true`.
- * @property className - Class name for the root container.
+ * @property className - Class name for the root container. The root fills its parent's height
+ * (`h-full`), not the viewport - give it a sized ancestor, or pass a height utility here (e.g.
+ * `h-screen`) to make it fill the viewport directly.
  */
 export interface WorkflowBuilderLayoutProps {
   header?: React.ReactNode;
@@ -179,9 +181,8 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
-  // handlers compare against a real pointerId, so they naturally no-op against this instead of
-  // needing a separate keyboard-vs-pointer branch.
+  // `null` marks a keyboard-initiated connection - pointer move/up handlers compare against a
+  // real pointerId, so they naturally no-op against this without a separate branch.
   pointerId: number | null;
   x: number;
   y: number;
@@ -541,7 +542,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   return (
-    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+    <div className={cn("flex h-full min-h-0 w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
       {(header || actions) && (
         <header
           className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"

--- a/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
+++ b/apps/storybook/src/templates/layouts/workflow-builder-layout/index.tsx
@@ -179,7 +179,10 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  pointerId: number;
+  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
+  // handlers compare against a real pointerId, so they naturally no-op against this instead of
+  // needing a separate keyboard-vs-pointer branch.
+  pointerId: number | null;
   x: number;
   y: number;
 }
@@ -347,10 +350,9 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
-    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
-    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
-    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    // Ignores bubbled key events from a focused node (handled separately), except Escape -
+    // cancelling a connection (started by a pointer drag, which never moves focus) shouldn't
+    // depend on what currently has focus.
     if (event.target !== event.currentTarget && event.key !== "Escape") return;
     const step = 40;
     switch (event.key) {
@@ -396,10 +398,8 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
-    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
-    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
-    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
-    // or further up to the host app, still works.
+    // Does not stopPropagation - handleSurfaceKeyDown's own target check already prevents
+    // double-handling arrow keys, and letting other keys (e.g. Escape) bubble up still works.
     const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
     const move = (dx: number, dy: number): void => {
       onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
@@ -475,6 +475,10 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     if (event.button !== 0) return;
     event.stopPropagation();
     event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus. A port itself isn't focusable,
+    // and a connection isn't owned by either node, so this focuses the canvas - otherwise
+    // whatever had focus before (or nothing) would stay focused through and after the drag.
+    surfaceRef.current?.focus();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     const outputPos = getPortPosition(node, "output");
     setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
@@ -496,14 +500,17 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     // document.elementFromPoint, since the pointer capture on the output port means the
     // release target is always the output port itself, never whatever's underneath it.
     let targetId: string | null = null;
-    let closestDistance = PORT_HIT_RADIUS;
+    // Strict `<` against the running minimum (not the fixed radius) so the first port
+    // encountered wins an exact tie, while a port sitting exactly at PORT_HIT_RADIUS is still
+    // selectable as the sole candidate.
+    let closestDistance = Infinity;
     inputPortRefs.current.forEach((el, nodeId) => {
       if (nodeId === connecting.sourceId) return;
       const rect = el.getBoundingClientRect();
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-      if (distance <= closestDistance) {
+      if (distance <= PORT_HIT_RADIUS && distance < closestDistance) {
         closestDistance = distance;
         targetId = nodeId;
       }
@@ -593,7 +600,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
               : undefined
           }
           role="group"
-          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes, or press Enter on an output port then Enter on an input port. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
           tabIndex={0}
           onPointerDown={handleSurfacePointerDown}
           onPointerMove={handleSurfacePointerMove}
@@ -692,9 +699,18 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
                         if (el) inputPortRefs.current.set(node.id, el);
                         else inputPortRefs.current.delete(node.id);
                       }}
-                      aria-hidden="true"
-                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect to ${node.title} input`}
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        if (!connecting || connecting.sourceId === node.id) return;
+                        event.preventDefault();
+                        onConnect?.({ source: connecting.sourceId, target: node.id });
+                        setConnecting(null);
+                      }}
                     />
                   )}
 
@@ -733,13 +749,21 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
 
                   {node.hasOutput !== false && (
                     <div
-                      aria-hidden="true"
-                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect ${node.title} to another node`}
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
                       onPointerDown={(event) => handleOutputPointerDown(event, node)}
                       onPointerMove={handleOutputPointerMove}
                       onPointerUp={handleOutputPointerUp}
                       onPointerCancel={() => setConnecting(null)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
+                        const outputPos = getPortPosition(node, "output");
+                        setConnecting({ sourceId: node.id, pointerId: null, x: outputPos.x, y: outputPos.y });
+                      }}
                     />
                   )}
                 </div>

--- a/apps/storybook/src/templates/layouts/workflow-builder-layout/workflow-builder-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/workflow-builder-layout/workflow-builder-layout.stories.tsx
@@ -1,0 +1,246 @@
+/**
+ * @file workflow-builder-layout.stories.tsx
+ * @description Storybook stories for the WorkflowBuilderLayout template. Covers the node
+ * palette, the pannable/zoomable canvas where nodes are placed and wired together, the
+ * inspector panel, and dragging a palette item onto the canvas to create a new node.
+ */
+
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  WorkflowBuilderLayout,
+  type WorkflowNodeData,
+  type WorkflowEdgeData,
+  type WorkflowPaletteItem,
+} from ".";
+import { Sparkles, Github, Webhook, Mail, Filter, Clock, Play } from "lucide-react";
+
+const meta: Meta<typeof WorkflowBuilderLayout> = {
+  title: "Templates/Layouts/WorkflowBuilderLayout",
+  component: WorkflowBuilderLayout,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A node-and-connection workspace shell - the shape behind visual automation/workflow tools. A node palette sits on the left, an optional inspector panel on the right, and a pannable/zoomable canvas in between where nodes are placed, dragged, and wired together by dragging from an output port to an input port.",
+      },
+    },
+  },
+  argTypes: {
+    minZoom: { control: { type: "number", min: 0.1, max: 1, step: 0.05 } },
+    maxZoom: { control: { type: "number", min: 1, max: 4, step: 0.25 } },
+    gridSize: { control: { type: "number", min: 8, max: 128, step: 8 } },
+    showGrid: { control: "boolean" },
+    showControls: { control: "boolean" },
+    showPalette: { control: "boolean" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkflowBuilderLayout>;
+
+const PALETTE_ITEMS: WorkflowPaletteItem[] = [
+  { type: "webhook", label: "Webhook", icon: <Webhook className="h-4 w-4" />, description: "Start on an HTTP call" },
+  { type: "filter", label: "Filter", icon: <Filter className="h-4 w-4" />, description: "Keep matching items only" },
+  { type: "delay", label: "Delay", icon: <Clock className="h-4 w-4" />, description: "Wait before continuing" },
+  { type: "email", label: "Send Email", icon: <Mail className="h-4 w-4" />, description: "Send a templated email" },
+];
+
+const PIPELINE_NODES: WorkflowNodeData[] = [
+  { id: "trigger", x: 40, y: 120, title: "New Signup", icon: <Play className="h-4 w-4" />, status: "success" },
+  { id: "filter", x: 320, y: 40, title: "Filter: Verified", icon: <Filter className="h-4 w-4" />, status: "idle" },
+  { id: "delay", x: 320, y: 220, title: "Wait 1 Day", icon: <Clock className="h-4 w-4" />, status: "idle" },
+  { id: "email", x: 600, y: 120, title: "Send Welcome Email", icon: <Mail className="h-4 w-4" />, status: "running" },
+];
+
+const PIPELINE_EDGES: WorkflowEdgeData[] = [
+  { id: "trigger-filter", source: "trigger", target: "filter" },
+  { id: "trigger-delay", source: "trigger", target: "delay" },
+  { id: "filter-email", source: "filter", target: "email", label: "verified" },
+  { id: "delay-email", source: "delay", target: "email" },
+];
+
+/** Wires up the controlled nodes/edges/selection state a story needs to be interactive. */
+function useWorkflowState(initialNodes: WorkflowNodeData[], initialEdges: WorkflowEdgeData[] = []) {
+  const [nodes, setNodes] = React.useState<WorkflowNodeData[]>(initialNodes);
+  const [edges, setEdges] = React.useState<WorkflowEdgeData[]>(initialEdges);
+  const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(null);
+
+  const onConnect = React.useCallback((connection: { source: string; target: string }) => {
+    setEdges((prev) => [...prev, { id: `${connection.source}->${connection.target}-${prev.length}`, ...connection }]);
+  }, []);
+
+  const onNodeDelete = React.useCallback((id: string) => {
+    setNodes((prev) => prev.filter((node) => node.id !== id));
+    setEdges((prev) => prev.filter((edge) => edge.source !== id && edge.target !== id));
+    setSelectedNodeId((prev) => (prev === id ? null : prev));
+  }, []);
+
+  return { nodes, setNodes, edges, setEdges, selectedNodeId, setSelectedNodeId, onConnect, onNodeDelete };
+}
+
+export const Default: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES, PIPELINE_EDGES);
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        onNodeDelete={state.onNodeDelete}
+        selectedNodeId={state.selectedNodeId}
+        onNodeSelect={state.setSelectedNodeId}
+        paletteItems={PALETTE_ITEMS}
+        showNodeEditButton={false}
+      />
+    );
+  },
+};
+
+export const WithHeaderAndActions: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES, PIPELINE_EDGES);
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        selectedNodeId={state.selectedNodeId}
+        onNodeSelect={state.setSelectedNodeId}
+        paletteItems={PALETTE_ITEMS}
+        header={
+          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <Sparkles className="h-4 w-4" />
+            Onboarding Flow
+          </div>
+        }
+        actions={
+          <a href="#" aria-label="GitHub" className="rounded-md p-2 hover:bg-[var(--accent)]">
+            <Github className="h-4 w-4" />
+          </a>
+        }
+        showNodeEditButton={false}
+      />
+    );
+  },
+};
+
+export const WithInspector: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES, PIPELINE_EDGES);
+    const selectedNode = state.nodes.find((node) => node.id === state.selectedNodeId) ?? null;
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        onNodeDelete={state.onNodeDelete}
+        selectedNodeId={state.selectedNodeId}
+        onNodeSelect={state.setSelectedNodeId}
+        paletteItems={PALETTE_ITEMS}
+        inspector={
+          selectedNode && (
+            <div className="flex flex-col gap-3">
+              <label className="flex flex-col gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+                Node title
+                <input
+                  className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+                  value={selectedNode.title}
+                  onChange={(event) =>
+                    state.setNodes((prev) =>
+                      prev.map((node) => (node.id === selectedNode.id ? { ...node, title: event.target.value } : node))
+                    )
+                  }
+                />
+              </label>
+              <p className="text-xs text-[var(--muted-foreground)]">Node id: {selectedNode.id}</p>
+            </div>
+          )
+        }
+      />
+    );
+  },
+};
+
+export const WithoutGrid: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES, PIPELINE_EDGES);
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        showGrid={false}
+        showNodeEditButton={false}
+      />
+    );
+  },
+};
+
+export const WithoutControls: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES, PIPELINE_EDGES);
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        showControls={false}
+        showNodeEditButton={false}
+      />
+    );
+  },
+};
+
+export const DragFromPalette: Story = {
+  render: (args) => {
+    const state = useWorkflowState(PIPELINE_NODES.slice(0, 1));
+    let nextId = 1;
+    return (
+      <WorkflowBuilderLayout
+        {...args}
+        nodes={state.nodes}
+        edges={state.edges}
+        onNodesChange={state.setNodes}
+        onConnect={state.onConnect}
+        onNodeDelete={state.onNodeDelete}
+        selectedNodeId={state.selectedNodeId}
+        onNodeSelect={state.setSelectedNodeId}
+        paletteItems={PALETTE_ITEMS}
+        onPaletteItemDrop={(item, position) => {
+          const id = `${item.type}-${nextId++}`;
+          state.setNodes((prev) => [
+            ...prev,
+            { id, x: position.x, y: position.y, title: item.label, icon: item.icon, status: "idle" },
+          ]);
+        }}
+        showNodeEditButton={false}
+      />
+    );
+  },
+};
+
+export const NodeStatuses: Story = {
+  args: {
+    showNodeEditButton: false,
+    nodes: [
+      { id: "idle", x: 40, y: 40, title: "Idle", status: "idle" },
+      { id: "running", x: 320, y: 40, title: "Running", status: "running" },
+      { id: "success", x: 40, y: 220, title: "Success", status: "success" },
+      { id: "error", x: 320, y: 220, title: "Error", status: "error" },
+    ],
+  },
+};

--- a/apps/storybook/src/templates/layouts/workflow-builder-layout/workflow-builder-layout.stories.tsx
+++ b/apps/storybook/src/templates/layouts/workflow-builder-layout/workflow-builder-layout.stories.tsx
@@ -208,7 +208,10 @@ export const WithoutControls: Story = {
 export const DragFromPalette: Story = {
   render: (args) => {
     const state = useWorkflowState(PIPELINE_NODES.slice(0, 1));
-    let nextId = 1;
+    // A render-local `let` resets every re-render (e.g. the one triggered by the drop's own
+    // setNodes call), so consecutive drops would collide on the same id - a ref persists across
+    // re-renders instead.
+    const nextIdRef = React.useRef(1);
     return (
       <WorkflowBuilderLayout
         {...args}
@@ -221,7 +224,7 @@ export const DragFromPalette: Story = {
         onNodeSelect={state.setSelectedNodeId}
         paletteItems={PALETTE_ITEMS}
         onPaletteItemDrop={(item, position) => {
-          const id = `${item.type}-${nextId++}`;
+          const id = `${item.type}-${nextIdRef.current++}`;
           state.setNodes((prev) => [
             ...prev,
             { id, x: position.x, y: position.y, title: item.label, icon: item.icon, status: "idle" },

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -1137,6 +1137,10 @@
       "files": {
         "main": {
           "path": "templates/layouts/workflow-builder-layout/index.tsx",
+          "type": "template"
+        }
+      }
+    },
     "documentationlayout": {
       "name": "DocumentationLayout",
       "description": "A full-page documentation/reference site shell: sticky header, a collapsible-tree left navigation sidebar (a drawer on mobile), page content with breadcrumbs and prev/next links, and a scroll-spy 'On this page' panel.",

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -1109,6 +1109,22 @@
         }
       }
     },
+    "workflowbuilderlayout": {
+      "name": "WorkflowBuilderLayout",
+      "description": "A node-and-connection workspace shell - a node palette, a pannable/zoomable canvas for placing and wiring draggable nodes, and an optional inspector panel, with drag/wheel/keyboard pan-zoom and floating zoom controls.",
+      "dependencies": [
+        "lucide-react"
+      ],
+      "componentDependencies": [
+        "button"
+      ],
+      "files": {
+        "main": {
+          "path": "templates/layouts/workflow-builder-layout/index.tsx",
+          "type": "template"
+        }
+      }
+    },
     "forgot-password": {
       "name": "forgotPassword",
       "description": "A fully responsive and customizable Forgot Password component with an input field and submit button, built to support secure in-app password reset processes.",

--- a/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
+++ b/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
@@ -1,0 +1,789 @@
+import * as React from "react";
+import { Button } from "@ignix-ui/button";
+import { Plus, Minus, RotateCcw, X, Pencil } from "lucide-react";
+import { cn } from "../../../utils/cn";
+
+/* -------------------------------------------------------------------------- */
+/*                              TYPES & INTERFACES                            */
+/* -------------------------------------------------------------------------- */
+
+/** Pan/zoom state of the workflow canvas, in the canvas's own (untransformed) coordinate space. */
+export interface WorkflowViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Restricts `value` to the inclusive `[min, max]` range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export type WorkflowNodeStatus = "idle" | "running" | "success" | "error";
+
+/**
+ * A single node placed on the workflow canvas at world coordinates `(x, y)`. Ports render at a
+ * fixed vertical offset from the top edge (matching the header row's height), so edge geometry
+ * never depends on a node's rendered content height.
+ */
+export interface WorkflowNodeData {
+  id: string;
+  x: number;
+  y: number;
+  width?: number;
+  title: string;
+  icon?: React.ReactNode;
+  status?: WorkflowNodeStatus;
+  content?: React.ReactNode;
+  hasInput?: boolean;
+  hasOutput?: boolean;
+}
+
+/** A directed connection between one node's output port and another node's input port. */
+export interface WorkflowEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+/** An entry in the node palette sidebar - a node type consumers can add to the canvas. */
+export interface WorkflowPaletteItem {
+  type: string;
+  label: string;
+  icon?: React.ReactNode;
+  description?: string;
+}
+
+/**
+ * Props for the {@link WorkflowBuilderLayout} template.
+ *
+ * @property header - Custom node rendered at the start of the top toolbar (e.g. a logo/title).
+ * @property actions - Optional node rendered at the end of the top toolbar.
+ * @property paletteItems - Node types listed in the left sidebar. Omit (or pass an empty array)
+ * to hide the sidebar entirely.
+ * @property onPaletteItemSelect - Called when a palette item is clicked (accessible alternative
+ * to dragging it onto the canvas).
+ * @property onPaletteItemDrop - Called with the dropped item and the world-space drop position
+ * when a palette item is dragged onto the canvas.
+ * @property showPalette - Whether to render the palette sidebar when `paletteItems` is non-empty.
+ * Default `true`.
+ * @property nodes - The nodes currently on the canvas. This component is fully controlled: wire
+ * `onNodesChange` to persist moves, or nodes won't visually update while dragged.
+ * @property edges - Connections between nodes, rendered as curved lines between ports.
+ * @property onNodesChange - Called with the next `nodes` array after a drag or keyboard nudge.
+ * @property onNodeDelete - Called with a node's id when Delete/Backspace is pressed while it's
+ * focused.
+ * @property onConnect - Called when a drag from one node's output port is released over another
+ * node's input port.
+ * @property selectedNodeId - Controlled selected node id. Provide alongside `onNodeSelect` to
+ * drive selection externally; omit to let the layout manage its own state.
+ * @property onNodeSelect - Called whenever the selected node changes, whether controlled or not.
+ * @property inspector - Content rendered in the right panel while a node is selected (e.g. a
+ * form for editing the selected node).
+ * @property showNodeEditButton - Whether each node renders a pencil icon that selects it (and
+ * thus opens `inspector`) without starting a drag. Default `true`; set to `false` when no
+ * `inspector` is wired up, so nodes don't show an icon that has nothing to open.
+ * @property viewport - Controlled pan/zoom state. Provide alongside `onViewportChange` to drive
+ * the canvas externally; omit to let the layout manage its own state.
+ * @property defaultViewport - Initial pan/zoom state when uncontrolled, and the state the
+ * "Reset view" control returns to. Defaults to `{ x: 0, y: 0, zoom: 1 }`.
+ * @property onViewportChange - Called whenever the viewport changes, whether controlled or not.
+ * @property minZoom - Minimum zoom factor. Default `0.25`.
+ * @property maxZoom - Maximum zoom factor. Default `2.5`.
+ * @property showGrid - Whether to render the background dot grid. Default `true`.
+ * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
+ * @property showControls - Whether to render the floating zoom in/out/reset control panel.
+ * Default `true`.
+ * @property className - Class name for the root container.
+ */
+export interface WorkflowBuilderLayoutProps {
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  paletteItems?: WorkflowPaletteItem[];
+  onPaletteItemSelect?: (item: WorkflowPaletteItem) => void;
+  onPaletteItemDrop?: (item: WorkflowPaletteItem, position: { x: number; y: number }) => void;
+  showPalette?: boolean;
+  nodes: WorkflowNodeData[];
+  edges?: WorkflowEdgeData[];
+  onNodesChange?: (nodes: WorkflowNodeData[]) => void;
+  onNodeDelete?: (id: string) => void;
+  onConnect?: (connection: { source: string; target: string }) => void;
+  selectedNodeId?: string | null;
+  onNodeSelect?: (id: string | null) => void;
+  inspector?: React.ReactNode;
+  showNodeEditButton?: boolean;
+  viewport?: WorkflowViewport;
+  defaultViewport?: WorkflowViewport;
+  onViewportChange?: (viewport: WorkflowViewport) => void;
+  minZoom?: number;
+  maxZoom?: number;
+  showGrid?: boolean;
+  gridSize?: number;
+  showControls?: boolean;
+  className?: string;
+}
+
+const DEFAULT_VIEWPORT: WorkflowViewport = { x: 0, y: 0, zoom: 1 };
+
+// Floors zoom regardless of consumer-configured minZoom - the wheel handler's zoom-to-cursor
+// math divides by zoom, so 0 (or less) would produce Infinity/NaN and corrupt the viewport.
+const MIN_SAFE_ZOOM = 0.01;
+
+const DEFAULT_NODE_WIDTH = 220;
+const NODE_HEADER_HEIGHT = 40;
+const PORT_HIT_RADIUS = 24;
+const NODE_KEYBOARD_STEP = 10;
+const NODE_KEYBOARD_STEP_LARGE = 40;
+const PALETTE_DRAG_MIME = "application/workflow-node-type";
+
+/**
+ * Replaces non-finite x/y/zoom with safe fallbacks, then clamps zoom to `[minZoom, maxZoom]`.
+ * NaN otherwise propagates into everything derived from the viewport (CSS transform, refs,
+ * `onViewportChange`), since NaN pollutes every calculation that touches it.
+ */
+function normalizeViewport(viewport: WorkflowViewport, minZoom: number, maxZoom: number): WorkflowViewport {
+  const x = Number.isFinite(viewport.x) ? viewport.x : DEFAULT_VIEWPORT.x;
+  const y = Number.isFinite(viewport.y) ? viewport.y : DEFAULT_VIEWPORT.y;
+  const zoom = Number.isFinite(viewport.zoom) ? viewport.zoom : DEFAULT_VIEWPORT.zoom;
+  return { x, y, zoom: clamp(zoom, minZoom, maxZoom) };
+}
+
+const STATUS_DOT_CLASSES: Record<WorkflowNodeStatus, string> = {
+  idle: "bg-[var(--muted-foreground)]",
+  running: "bg-[var(--primary)] animate-pulse",
+  success: "bg-[var(--success)]",
+  error: "bg-[var(--destructive)]",
+};
+
+/** World-space position of a node's input (left edge) or output (right edge) port. */
+function getPortPosition(node: WorkflowNodeData, side: "input" | "output"): { x: number; y: number } {
+  const width = node.width ?? DEFAULT_NODE_WIDTH;
+  return { x: side === "input" ? node.x : node.x + width, y: node.y + NODE_HEADER_HEIGHT / 2 };
+}
+
+/** A horizontal cubic-bezier path between two ports, curved outward proportionally to distance. */
+function buildEdgePath(source: { x: number; y: number }, target: { x: number; y: number }): string {
+  const curvature = Math.max(Math.abs(target.x - source.x) / 2, 40);
+  return `M ${source.x},${source.y} C ${source.x + curvature},${source.y} ${target.x - curvature},${target.y} ${target.x},${target.y}`;
+}
+
+interface DragState {
+  nodeId: string;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+}
+
+interface ConnectingState {
+  sourceId: string;
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              MAIN COMPONENT                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * WorkflowBuilderLayout is a node-and-connection workspace shell - the shape behind visual
+ * automation/workflow tools (n8n, Zapier, Node-RED). A node palette sits on the left, an
+ * optional inspector panel on the right, and a pannable/zoomable canvas in between where nodes
+ * are placed, dragged, and wired together by dragging from an output port to an input port.
+ */
+export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
+  header,
+  actions,
+  paletteItems,
+  onPaletteItemSelect,
+  onPaletteItemDrop,
+  showPalette = true,
+  nodes,
+  edges = [],
+  onNodesChange,
+  onNodeDelete,
+  onConnect,
+  selectedNodeId,
+  onNodeSelect,
+  inspector,
+  showNodeEditButton = true,
+  viewport,
+  defaultViewport = DEFAULT_VIEWPORT,
+  onViewportChange,
+  minZoom = 0.25,
+  maxZoom = 2.5,
+  showGrid = true,
+  gridSize = 32,
+  showControls = true,
+  className,
+}) => {
+  const isViewportControlled = viewport !== undefined;
+  const [internalViewport, setInternalViewport] = React.useState<WorkflowViewport>(defaultViewport);
+  const rawViewport = isViewportControlled ? viewport : internalViewport;
+
+  // Guards against non-finite bounds (propagate NaN through clamp) and an inverted range
+  // (maxZoom < minZoom would freeze zoom at a fixed value).
+  const safeMinZoom = Number.isFinite(minZoom) ? Math.max(minZoom, MIN_SAFE_ZOOM) : MIN_SAFE_ZOOM;
+  const safeMaxZoom = Number.isFinite(maxZoom)
+    ? Math.max(maxZoom, safeMinZoom)
+    : Math.max(safeMinZoom, DEFAULT_VIEWPORT.zoom);
+
+  const currentViewport: WorkflowViewport = normalizeViewport(rawViewport, safeMinZoom, safeMaxZoom);
+
+  // Lets event handlers read the latest viewport/callback without depending on them, so an
+  // inline onViewportChange doesn't tear down and reattach the wheel listener every render.
+  const viewportRef = React.useRef(currentViewport);
+  viewportRef.current = currentViewport;
+  const onViewportChangeRef = React.useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const updateViewport = React.useCallback(
+    (updater: (prev: WorkflowViewport) => WorkflowViewport) => {
+      const next = updater(viewportRef.current);
+      const clamped = normalizeViewport(next, safeMinZoom, safeMaxZoom);
+      if (!isViewportControlled) {
+        setInternalViewport(clamped);
+      }
+      onViewportChangeRef.current?.(clamped);
+    },
+    [isViewportControlled, safeMinZoom, safeMaxZoom]
+  );
+
+  const zoomIn = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom * 1.2 })),
+    [updateViewport]
+  );
+  const zoomOut = React.useCallback(
+    () => updateViewport((prev) => ({ ...prev, zoom: prev.zoom / 1.2 })),
+    [updateViewport]
+  );
+  const resetView = React.useCallback(
+    () => updateViewport(() => defaultViewport),
+    [updateViewport, defaultViewport]
+  );
+
+  const isSelectionControlled = selectedNodeId !== undefined;
+  const [internalSelectedId, setInternalSelectedId] = React.useState<string | null>(null);
+  const currentSelectedId = isSelectionControlled ? selectedNodeId : internalSelectedId;
+  const selectNode = React.useCallback(
+    (id: string | null) => {
+      if (!isSelectionControlled) setInternalSelectedId(id);
+      onNodeSelect?.(id);
+    },
+    [isSelectionControlled, onNodeSelect]
+  );
+
+  const nodeById = React.useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const selectedNode = currentSelectedId ? (nodeById.get(currentSelectedId) ?? null) : null;
+
+  const surfaceRef = React.useRef<HTMLDivElement>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  const inputPortRefs = React.useRef(new Map<string, HTMLDivElement>());
+  const [connecting, setConnecting] = React.useState<ConnectingState | null>(null);
+
+  // Colons from useId() are stripped since this feeds an SVG url(#id) reference, where they're
+  // unreliable across browsers.
+  const arrowMarkerId = `workflow-arrow-${React.useId().replace(/:/g, "")}`;
+
+  // React's JSX onWheel is passive by default (can't preventDefault), so a native listener
+  // with { passive: false } is used instead to stop page scroll/zoom.
+  React.useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = surface.getBoundingClientRect();
+      const pointerX = event.clientX - rect.left;
+      const pointerY = event.clientY - rect.top;
+
+      if (event.ctrlKey || event.metaKey) {
+        updateViewport((prev) => {
+          const nextZoom = clamp(prev.zoom * (1 - event.deltaY * 0.01), safeMinZoom, safeMaxZoom);
+          const worldX = (pointerX - prev.x) / prev.zoom;
+          const worldY = (pointerY - prev.y) / prev.zoom;
+          return { x: pointerX - worldX * nextZoom, y: pointerY - worldY * nextZoom, zoom: nextZoom };
+        });
+      } else {
+        updateViewport((prev) => ({ ...prev, x: prev.x - event.deltaX, y: prev.y - event.deltaY }));
+      }
+    };
+
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => surface.removeEventListener("wheel", handleWheel);
+  }, [updateViewport, safeMinZoom, safeMaxZoom]);
+
+  const panStateRef = React.useRef<{ pointerId: number; lastX: number; lastY: number } | null>(null);
+
+  const handleSurfacePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    // Only pan when the drag starts on empty background, not a node, so nodes stay
+    // independently draggable/connectable.
+    if (event.target !== event.currentTarget || event.button !== 0) return;
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus, so this restores it for
+    // keyboard pan/zoom.
+    event.currentTarget.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    panStateRef.current = { pointerId: event.pointerId, lastX: event.clientX, lastY: event.clientY };
+  };
+
+  const handleSurfacePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    updateViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handleSurfacePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+    }
+  };
+
+  const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
+    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
+    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
+    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    if (event.target !== event.currentTarget && event.key !== "Escape") return;
+    const step = 40;
+    switch (event.key) {
+      case "ArrowUp":
+        updateViewport((prev) => ({ ...prev, y: prev.y + step }));
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        updateViewport((prev) => ({ ...prev, y: prev.y - step }));
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        updateViewport((prev) => ({ ...prev, x: prev.x + step }));
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        updateViewport((prev) => ({ ...prev, x: prev.x - step }));
+        event.preventDefault();
+        break;
+      case "+":
+      case "=":
+        zoomIn();
+        event.preventDefault();
+        break;
+      case "-":
+      case "_":
+        zoomOut();
+        event.preventDefault();
+        break;
+      case "0":
+        resetView();
+        event.preventDefault();
+        break;
+      case "Escape":
+        if (connecting) {
+          setConnecting(null);
+          event.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
+    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
+    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
+    // or further up to the host app, still works.
+    const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
+    const move = (dx: number, dy: number): void => {
+      onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
+    };
+    switch (event.key) {
+      case "ArrowUp":
+        move(0, -step);
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        move(0, step);
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        move(-step, 0);
+        event.preventDefault();
+        break;
+      case "ArrowRight":
+        move(step, 0);
+        event.preventDefault();
+        break;
+      case "Enter":
+      case " ":
+        selectNode(node.id);
+        event.preventDefault();
+        break;
+      case "Delete":
+      case "Backspace":
+        onNodeDelete?.(node.id);
+        event.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleNodeHeaderPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus; the header itself isn't
+    // focusable, so this focuses the node (closest ancestor role="group") instead.
+    (event.currentTarget.closest('[role="group"]') as HTMLElement | null)?.focus();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStateRef.current = {
+      nodeId: node.id,
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: node.x,
+      startY: node.y,
+    };
+  };
+
+  const handleNodeHeaderPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const zoom = currentViewport.zoom || 1;
+    const dx = (event.clientX - state.startClientX) / zoom;
+    const dy = (event.clientY - state.startClientY) / zoom;
+    onNodesChange?.(
+      nodes.map((n) => (n.id === state.nodeId ? { ...n, x: state.startX + dx, y: state.startY + dy } : n))
+    );
+  };
+
+  const handleNodeHeaderPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (dragStateRef.current?.pointerId === event.pointerId) {
+      dragStateRef.current = null;
+    }
+  };
+
+  const handleOutputPointerDown = (event: React.PointerEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
+    if (event.button !== 0) return;
+    event.stopPropagation();
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const outputPos = getPortPosition(node, "output");
+    setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
+  };
+
+  const handleOutputPointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    setConnecting((prev) => (prev && prev.pointerId === event.pointerId ? { ...prev, x: worldX, y: worldY } : prev));
+  };
+
+  const handleOutputPointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!connecting || connecting.pointerId !== event.pointerId) return;
+    // Finds the nearest input port within range via geometry (rect centers) rather than
+    // document.elementFromPoint, since the pointer capture on the output port means the
+    // release target is always the output port itself, never whatever's underneath it.
+    let targetId: string | null = null;
+    let closestDistance = PORT_HIT_RADIUS;
+    inputPortRefs.current.forEach((el, nodeId) => {
+      if (nodeId === connecting.sourceId) return;
+      const rect = el.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (distance <= closestDistance) {
+        closestDistance = distance;
+        targetId = nodeId;
+      }
+    });
+    if (targetId) {
+      onConnect?.({ source: connecting.sourceId, target: targetId });
+    }
+    setConnecting(null);
+  };
+
+  const handleCanvasDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop || !event.dataTransfer.types.includes(PALETTE_DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleCanvasDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+    if (!onPaletteItemDrop) return;
+    const type = event.dataTransfer.getData(PALETTE_DRAG_MIME);
+    const item = paletteItems?.find((candidate) => candidate.type === type);
+    const surface = surfaceRef.current;
+    if (!type || !item || !surface) return;
+    event.preventDefault();
+    const rect = surface.getBoundingClientRect();
+    const worldX = (event.clientX - rect.left - currentViewport.x) / currentViewport.zoom;
+    const worldY = (event.clientY - rect.top - currentViewport.y) / currentViewport.zoom;
+    onPaletteItemDrop(item, { x: worldX, y: worldY });
+  };
+
+  return (
+    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+      {(header || actions) && (
+        <header
+          className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"
+          role="banner"
+        >
+          {header && <div className="flex shrink-0 items-center">{header}</div>}
+          {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {showPalette && paletteItems && paletteItems.length > 0 && (
+          <aside
+            className="w-64 shrink-0 overflow-y-auto border-r border-[var(--border)] bg-[var(--background)] p-2"
+            aria-label="Node palette"
+          >
+            <ul className="flex flex-col gap-1">
+              {paletteItems.map((item) => (
+                <li key={item.type}>
+                  <button
+                    type="button"
+                    draggable={Boolean(onPaletteItemDrop)}
+                    onDragStart={(event) => {
+                      event.dataTransfer.setData(PALETTE_DRAG_MIME, item.type);
+                      event.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onClick={() => onPaletteItemSelect?.(item)}
+                    className="flex w-full items-center gap-2 rounded-md p-2 text-left text-sm hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                  >
+                    {item.icon && <span className="shrink-0">{item.icon}</span>}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{item.label}</span>
+                      {item.description && (
+                        <span className="block truncate text-xs text-[var(--muted-foreground)]">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
+        <div
+          ref={surfaceRef}
+          className="relative flex-1 touch-none select-none overflow-hidden"
+          style={
+            showGrid
+              ? {
+                  backgroundImage: "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+                  backgroundSize: `${gridSize * currentViewport.zoom}px ${gridSize * currentViewport.zoom}px`,
+                  backgroundPosition: `${currentViewport.x}px ${currentViewport.y}px`,
+                }
+              : undefined
+          }
+          role="group"
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          tabIndex={0}
+          onPointerDown={handleSurfacePointerDown}
+          onPointerMove={handleSurfacePointerMove}
+          onPointerUp={handleSurfacePointerUp}
+          onPointerCancel={handleSurfacePointerUp}
+          onKeyDown={handleSurfaceKeyDown}
+          onDragOver={handleCanvasDragOver}
+          onDrop={handleCanvasDrop}
+        >
+          <div
+            className="absolute left-0 top-0"
+            style={{
+              transform: `translate(${currentViewport.x}px, ${currentViewport.y}px) scale(${currentViewport.zoom})`,
+              transformOrigin: "0 0",
+            }}
+          >
+            <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={1} height={1}>
+              <defs>
+                <marker
+                  id={arrowMarkerId}
+                  viewBox="0 0 10 10"
+                  refX={9}
+                  refY={5}
+                  markerWidth={7}
+                  markerHeight={7}
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border)" />
+                </marker>
+              </defs>
+              {edges.map((edge) => {
+                const sourceNode = nodeById.get(edge.source);
+                const targetNode = nodeById.get(edge.target);
+                if (!sourceNode || !targetNode) return null;
+                const sourcePos = getPortPosition(sourceNode, "output");
+                const targetPos = getPortPosition(targetNode, "input");
+                return (
+                  <g key={edge.id}>
+                    <path
+                      d={buildEdgePath(sourcePos, targetPos)}
+                      stroke="var(--border)"
+                      strokeWidth={2}
+                      fill="none"
+                      markerEnd={`url(#${arrowMarkerId})`}
+                    />
+                    {edge.label && (
+                      <text
+                        x={(sourcePos.x + targetPos.x) / 2}
+                        y={(sourcePos.y + targetPos.y) / 2 - 6}
+                        textAnchor="middle"
+                        fontSize={11}
+                        fill="var(--muted-foreground)"
+                      >
+                        {edge.label}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+              {connecting &&
+                (() => {
+                  const sourceNode = nodeById.get(connecting.sourceId);
+                  if (!sourceNode) return null;
+                  const sourcePos = getPortPosition(sourceNode, "output");
+                  return (
+                    <path
+                      d={buildEdgePath(sourcePos, { x: connecting.x, y: connecting.y })}
+                      stroke="var(--primary)"
+                      strokeWidth={2}
+                      strokeDasharray="4 4"
+                      fill="none"
+                    />
+                  );
+                })()}
+            </svg>
+
+            {nodes.map((node) => {
+              const isSelected = node.id === currentSelectedId;
+              const width = node.width ?? DEFAULT_NODE_WIDTH;
+              return (
+                <div
+                  key={node.id}
+                  role="group"
+                  aria-label={`${node.title} node${node.status ? `, status ${node.status}` : ""}${isSelected ? ", selected" : ""}`}
+                  tabIndex={0}
+                  className={cn(
+                    "absolute rounded-lg border bg-[var(--background)] shadow-sm",
+                    isSelected ? "border-[var(--primary)] ring-2 ring-[var(--primary)]" : "border-[var(--border)]"
+                  )}
+                  style={{ left: node.x, top: node.y, width }}
+                  onKeyDown={(event) => handleNodeKeyDown(event, node)}
+                >
+                  {node.hasInput !== false && (
+                    <div
+                      ref={(el) => {
+                        if (el) inputPortRefs.current.set(node.id, el);
+                        else inputPortRefs.current.delete(node.id);
+                      }}
+                      aria-hidden="true"
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                    />
+                  )}
+
+                  <div
+                    className="flex h-10 cursor-grab items-center gap-2 rounded-t-lg border-b border-[var(--border)] px-3 active:cursor-grabbing"
+                    onPointerDown={(event) => handleNodeHeaderPointerDown(event, node)}
+                    onPointerMove={handleNodeHeaderPointerMove}
+                    onPointerUp={handleNodeHeaderPointerUp}
+                    onPointerCancel={handleNodeHeaderPointerUp}
+                  >
+                    {node.icon && <span className="shrink-0">{node.icon}</span>}
+                    <span className="flex-1 truncate text-sm font-medium">{node.title}</span>
+                    {node.status && (
+                      <span
+                        className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT_CLASSES[node.status])}
+                        aria-hidden="true"
+                      />
+                    )}
+                    {showNodeEditButton && (
+                      <button
+                        type="button"
+                        aria-label={`Edit ${node.title}`}
+                        className="shrink-0 rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          selectNode(node.id);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+
+                  {node.content && <div className="p-3 text-sm text-[var(--muted-foreground)]">{node.content}</div>}
+
+                  {node.hasOutput !== false && (
+                    <div
+                      aria-hidden="true"
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onPointerDown={(event) => handleOutputPointerDown(event, node)}
+                      onPointerMove={handleOutputPointerMove}
+                      onPointerUp={handleOutputPointerUp}
+                      onPointerCancel={() => setConnecting(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {showControls && (
+            <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1 shadow-lg">
+              <Button variant="outline" size="icon" aria-label="Zoom in" onClick={zoomIn}>
+                <Plus className="h-4 w-4" />
+              </Button>
+              <div className="text-center text-xs text-[var(--muted-foreground)]">
+                {Math.round(currentViewport.zoom * 100)}%
+              </div>
+              <Button variant="outline" size="icon" aria-label="Zoom out" onClick={zoomOut}>
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" aria-label="Reset view" onClick={resetView}>
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {selectedNode && inspector && (
+          <aside
+            className="w-80 shrink-0 overflow-y-auto border-l border-[var(--border)] bg-[var(--background)] p-4"
+            aria-label={`Inspector for ${selectedNode.title}`}
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="truncate text-sm font-semibold">{selectedNode.title}</h3>
+              <Button variant="ghost" size="icon" aria-label="Close inspector" onClick={() => selectNode(null)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            {inspector}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+};
+
+WorkflowBuilderLayout.displayName = "WorkflowBuilderLayout";
+
+export default WorkflowBuilderLayout;

--- a/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
+++ b/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
@@ -95,7 +95,9 @@ export interface WorkflowPaletteItem {
  * @property gridSize - Spacing between grid dots, in canvas world units. Default `32`.
  * @property showControls - Whether to render the floating zoom in/out/reset control panel.
  * Default `true`.
- * @property className - Class name for the root container.
+ * @property className - Class name for the root container. The root fills its parent's height
+ * (`h-full`), not the viewport - give it a sized ancestor, or pass a height utility here (e.g.
+ * `h-screen`) to make it fill the viewport directly.
  */
 export interface WorkflowBuilderLayoutProps {
   header?: React.ReactNode;
@@ -179,9 +181,8 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
-  // handlers compare against a real pointerId, so they naturally no-op against this instead of
-  // needing a separate keyboard-vs-pointer branch.
+  // `null` marks a keyboard-initiated connection - pointer move/up handlers compare against a
+  // real pointerId, so they naturally no-op against this without a separate branch.
   pointerId: number | null;
   x: number;
   y: number;
@@ -541,7 +542,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   return (
-    <div className={cn("flex h-screen w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
+    <div className={cn("flex h-full min-h-0 w-full flex-col bg-[var(--background)] text-[var(--foreground)]", className)}>
       {(header || actions) && (
         <header
           className="z-10 flex h-14 w-full shrink-0 items-center gap-3 border-b border-[var(--border)] bg-[var(--background)] px-4"

--- a/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
+++ b/packages/registry/templates/layouts/workflow-builder-layout/index.tsx
@@ -179,7 +179,10 @@ interface DragState {
 
 interface ConnectingState {
   sourceId: string;
-  pointerId: number;
+  // `null` for a keyboard-initiated connection (Enter on an output port) - pointer move/up
+  // handlers compare against a real pointerId, so they naturally no-op against this instead of
+  // needing a separate keyboard-vs-pointer branch.
+  pointerId: number | null;
   x: number;
   y: number;
 }
@@ -347,10 +350,9 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleSurfaceKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    // Ignores key events bubbled from a focused node (handled separately) - otherwise arrow
-    // keys would both nudge the node and pan the canvas. Escape is let through regardless of
-    // where it bubbled from, since cancelling an in-progress connection (started by a pointer
-    // drag, which never moves focus) shouldn't depend on which element currently has focus.
+    // Ignores bubbled key events from a focused node (handled separately), except Escape -
+    // cancelling a connection (started by a pointer drag, which never moves focus) shouldn't
+    // depend on what currently has focus.
     if (event.target !== event.currentTarget && event.key !== "Escape") return;
     const step = 40;
     switch (event.key) {
@@ -396,10 +398,8 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
   };
 
   const handleNodeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, node: WorkflowNodeData): void => {
-    // Does not stopPropagation: handleSurfaceKeyDown already ignores bubbled events via its own
-    // `event.target !== event.currentTarget` check, so this can't double-handle arrow keys - and
-    // letting unhandled keys (e.g. Escape, to cancel an in-progress connection) bubble up to it,
-    // or further up to the host app, still works.
+    // Does not stopPropagation - handleSurfaceKeyDown's own target check already prevents
+    // double-handling arrow keys, and letting other keys (e.g. Escape) bubble up still works.
     const step = event.shiftKey ? NODE_KEYBOARD_STEP_LARGE : NODE_KEYBOARD_STEP;
     const move = (dx: number, dy: number): void => {
       onNodesChange?.(nodes.map((n) => (n.id === node.id ? { ...n, x: n.x + dx, y: n.y + dy } : n)));
@@ -475,6 +475,10 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     if (event.button !== 0) return;
     event.stopPropagation();
     event.preventDefault();
+    // preventDefault() also suppresses default click-to-focus. A port itself isn't focusable,
+    // and a connection isn't owned by either node, so this focuses the canvas - otherwise
+    // whatever had focus before (or nothing) would stay focused through and after the drag.
+    surfaceRef.current?.focus();
     event.currentTarget.setPointerCapture?.(event.pointerId);
     const outputPos = getPortPosition(node, "output");
     setConnecting({ sourceId: node.id, pointerId: event.pointerId, x: outputPos.x, y: outputPos.y });
@@ -496,14 +500,17 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
     // document.elementFromPoint, since the pointer capture on the output port means the
     // release target is always the output port itself, never whatever's underneath it.
     let targetId: string | null = null;
-    let closestDistance = PORT_HIT_RADIUS;
+    // Strict `<` against the running minimum (not the fixed radius) so the first port
+    // encountered wins an exact tie, while a port sitting exactly at PORT_HIT_RADIUS is still
+    // selectable as the sole candidate.
+    let closestDistance = Infinity;
     inputPortRefs.current.forEach((el, nodeId) => {
       if (nodeId === connecting.sourceId) return;
       const rect = el.getBoundingClientRect();
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-      if (distance <= closestDistance) {
+      if (distance <= PORT_HIT_RADIUS && distance < closestDistance) {
         closestDistance = distance;
         targetId = nodeId;
       }
@@ -593,7 +600,7 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
               : undefined
           }
           role="group"
-          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
+          aria-label="Workflow canvas. Drag to pan, scroll to pan, ctrl or cmd plus scroll to zoom. Drag a node's header to move it, click its edit icon to select it, and drag from an output port to an input port to connect two nodes, or press Enter on an output port then Enter on an input port. Focus and use arrow keys to pan, plus and minus to zoom, zero to reset the view."
           tabIndex={0}
           onPointerDown={handleSurfacePointerDown}
           onPointerMove={handleSurfacePointerMove}
@@ -692,9 +699,18 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
                         if (el) inputPortRefs.current.set(node.id, el);
                         else inputPortRefs.current.delete(node.id);
                       }}
-                      aria-hidden="true"
-                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect to ${node.title} input`}
+                      className="absolute -left-1.5 h-3 w-3 rounded-full border-2 border-[var(--background)] bg-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        if (!connecting || connecting.sourceId === node.id) return;
+                        event.preventDefault();
+                        onConnect?.({ source: connecting.sourceId, target: node.id });
+                        setConnecting(null);
+                      }}
                     />
                   )}
 
@@ -733,13 +749,21 @@ export const WorkflowBuilderLayout: React.FC<WorkflowBuilderLayoutProps> = ({
 
                   {node.hasOutput !== false && (
                     <div
-                      aria-hidden="true"
-                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)]"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Connect ${node.title} to another node`}
+                      className="absolute -right-1.5 h-3 w-3 cursor-crosshair rounded-full border-2 border-[var(--background)] bg-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       style={{ top: NODE_HEADER_HEIGHT / 2 - 6 }}
                       onPointerDown={(event) => handleOutputPointerDown(event, node)}
                       onPointerMove={handleOutputPointerMove}
                       onPointerUp={handleOutputPointerUp}
                       onPointerCancel={() => setConnecting(null)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
+                        const outputPos = getPortPosition(node, "output");
+                        setConnecting({ sourceId: node.id, pointerId: null, x: outputPos.x, y: outputPos.y });
+                      }}
                     />
                   )}
                 </div>

--- a/packages/registry/templates/layouts/workflow-builder-layout/workflow-builder-layout.test.tsx
+++ b/packages/registry/templates/layouts/workflow-builder-layout/workflow-builder-layout.test.tsx
@@ -1,0 +1,426 @@
+// workflow-builder-layout.test.tsx
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("lucide-react", () => ({
+  Plus: () => <div data-testid="plus-icon" />,
+  Minus: () => <div data-testid="minus-icon" />,
+  RotateCcw: () => <div data-testid="reset-icon" />,
+  X: () => <div data-testid="close-icon" />,
+  Pencil: () => <div data-testid="edit-icon" />,
+}));
+
+import { WorkflowBuilderLayout, type WorkflowNodeData, type WorkflowEdgeData } from ".";
+
+function getSurface(container: HTMLElement): HTMLElement {
+  return container.querySelector('[aria-label^="Workflow canvas"]') as HTMLElement;
+}
+
+function getNode(container: HTMLElement, title: string): HTMLElement {
+  return Array.from(container.querySelectorAll('[role="group"]')).find((el) =>
+    (el.getAttribute("aria-label") ?? "").startsWith(title)
+  ) as HTMLElement;
+}
+
+// jsdom doesn't implement the PointerEvent constructor, so @testing-library's fireEvent.pointerX
+// helpers silently fall back to a bare `Event` that drops clientX/clientY/pointerId entirely.
+// Dispatching a MouseEvent (which jsdom does support, and which carries the same fields React's
+// synthetic pointer events read) under the same "pointerdown"/"pointermove"/"pointerup" type
+// names reaches the same onPointer* handlers with the properties intact.
+function firePointer(
+  el: Element,
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  init: { pointerId: number; clientX?: number; clientY?: number; button?: number }
+): void {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    button: init.button ?? 0,
+  });
+  Object.defineProperty(event, "pointerId", { value: init.pointerId, configurable: true });
+  act(() => {
+    el.dispatchEvent(event);
+  });
+}
+
+const NODES: WorkflowNodeData[] = [
+  { id: "a", x: 0, y: 0, title: "Trigger" },
+  { id: "b", x: 300, y: 0, title: "Action" },
+];
+
+const EDGES: WorkflowEdgeData[] = [{ id: "e1", source: "a", target: "b" }];
+
+describe("WorkflowBuilderLayout", () => {
+  describe("rendering", () => {
+    it("renders nodes from the nodes prop", () => {
+      render(<WorkflowBuilderLayout nodes={NODES} />);
+      expect(screen.getByText("Trigger")).toBeInTheDocument();
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+
+    it("renders header and actions when provided", () => {
+      render(
+        <WorkflowBuilderLayout nodes={NODES} header={<span>Logo</span>} actions={<button>Publish</button>} />
+      );
+      expect(screen.getByRole("banner")).toBeInTheDocument();
+      expect(screen.getByText("Logo")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Publish" })).toBeInTheDocument();
+    });
+
+    it("omits the header entirely when neither header nor actions are provided", () => {
+      render(<WorkflowBuilderLayout nodes={NODES} />);
+      expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+    });
+
+    it("renders an edge between two existing nodes", () => {
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} edges={EDGES} />);
+      expect(container.querySelector("svg path")).toBeInTheDocument();
+    });
+
+    it("skips an edge that references a non-existent node instead of crashing", () => {
+      const badEdges: WorkflowEdgeData[] = [{ id: "e1", source: "a", target: "missing" }];
+      expect(() => render(<WorkflowBuilderLayout nodes={NODES} edges={badEdges} />)).not.toThrow();
+    });
+
+    it("renders the node status dot when a status is provided", () => {
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={[{ id: "a", x: 0, y: 0, title: "Trigger", status: "success" }]} />
+      );
+      const dot = container.querySelector('[aria-hidden="true"].rounded-full.h-2') as HTMLElement | null;
+      expect(dot?.classList.contains("bg-[var(--success)]")).toBe(true);
+    });
+  });
+
+  describe("palette", () => {
+    it("renders palette items and fires onPaletteItemSelect on click", () => {
+      const onSelect = vi.fn();
+      render(
+        <WorkflowBuilderLayout
+          nodes={NODES}
+          paletteItems={[{ type: "http", label: "HTTP Request" }]}
+          onPaletteItemSelect={onSelect}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "HTTP Request" }));
+      expect(onSelect).toHaveBeenCalledWith({ type: "http", label: "HTTP Request" });
+    });
+
+    it("hides the palette when showPalette is false", () => {
+      render(
+        <WorkflowBuilderLayout nodes={NODES} paletteItems={[{ type: "http", label: "HTTP Request" }]} showPalette={false} />
+      );
+      expect(screen.queryByLabelText("Node palette")).not.toBeInTheDocument();
+    });
+
+    it("omits the palette when no items are provided", () => {
+      render(<WorkflowBuilderLayout nodes={NODES} />);
+      expect(screen.queryByLabelText("Node palette")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("selection", () => {
+    it("does not select a node merely from pressing its header (that only starts a drag)", () => {
+      const onSelect = vi.fn();
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={NODES} onNodeSelect={onSelect} inspector={<p>Node settings</p>} />
+      );
+      const node = getNode(container, "Trigger");
+      firePointer(node.querySelector(".cursor-grab") as HTMLElement, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("selects a node when its edit icon is clicked, without starting a drag", () => {
+      const onSelect = vi.fn();
+      const onNodesChange = vi.fn();
+      const { container } = render(
+        <WorkflowBuilderLayout
+          nodes={NODES}
+          onNodeSelect={onSelect}
+          onNodesChange={onNodesChange}
+          inspector={<p>Node settings</p>}
+        />
+      );
+      const node = getNode(container, "Trigger");
+      fireEvent.click(node.querySelector('[aria-label="Edit Trigger"]') as HTMLElement);
+      expect(onSelect).toHaveBeenCalledWith("a");
+      expect(onNodesChange).not.toHaveBeenCalled();
+    });
+
+    it("renders the edit icon even without inspector content, so onNodeSelect still fires", () => {
+      // `inspector` is commonly computed from the *currently selected* node (e.g.
+      // `selectedNode && <Panel />`), so it's falsy before anything is selected - gating the
+      // edit icon on it would make the very first selection impossible.
+      const onSelect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodeSelect={onSelect} />);
+      const node = getNode(container, "Trigger");
+      const editButton = node.querySelector('[aria-label="Edit Trigger"]') as HTMLElement;
+      expect(editButton).toBeInTheDocument();
+      fireEvent.click(editButton);
+      expect(onSelect).toHaveBeenCalledWith("a");
+    });
+
+    it("omits the edit icon when showNodeEditButton is false", () => {
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} showNodeEditButton={false} />);
+      const node = getNode(container, "Trigger");
+      expect(node.querySelector('[aria-label="Edit Trigger"]')).not.toBeInTheDocument();
+    });
+
+    it("shows the inspector for the selected node when inspector content is provided", () => {
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={NODES} selectedNodeId="a" inspector={<p>Node settings</p>} />
+      );
+      expect(screen.getByText("Node settings")).toBeInTheDocument();
+      expect(screen.getByLabelText("Inspector for Trigger")).toBeInTheDocument();
+      void container;
+    });
+
+    it("does not show the inspector when no node is selected", () => {
+      render(<WorkflowBuilderLayout nodes={NODES} selectedNodeId={null} inspector={<p>Node settings</p>} />);
+      expect(screen.queryByText("Node settings")).not.toBeInTheDocument();
+    });
+
+    it("closes the inspector via the close button, notifying a controlled consumer", () => {
+      const onSelect = vi.fn();
+      render(
+        <WorkflowBuilderLayout nodes={NODES} selectedNodeId="a" onNodeSelect={onSelect} inspector={<p>Node settings</p>} />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Close inspector" }));
+      expect(onSelect).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("focus on click", () => {
+    // preventDefault() (needed to stop native drag-to-select-text while panning/dragging) also
+    // suppresses the browser's default click-to-focus behavior, so clicking wouldn't actually
+    // move keyboard focus without an explicit .focus() call in these handlers.
+    it("focuses the canvas surface when empty background is pressed, enabling keyboard pan", () => {
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} />);
+      const surface = getSurface(container);
+      firePointer(surface, "pointerdown", { pointerId: 1, clientX: 500, clientY: 500 });
+      expect(document.activeElement).toBe(surface);
+    });
+
+    it("focuses the node when its header is pressed, enabling keyboard nudge/delete", () => {
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} />);
+      const node = getNode(container, "Trigger");
+      firePointer(node.querySelector(".cursor-grab") as HTMLElement, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+      expect(document.activeElement).toBe(node);
+    });
+  });
+
+  describe("dragging nodes", () => {
+    it("reports a moved node's new position via onNodesChange", () => {
+      const onNodesChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodesChange={onNodesChange} />);
+      const handle = getNode(container, "Trigger").querySelector(".cursor-grab") as HTMLElement;
+      firePointer(handle, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });
+      firePointer(handle, "pointermove", { pointerId: 1, clientX: 150, clientY: 130 });
+      expect(onNodesChange).toHaveBeenLastCalledWith([
+        { id: "a", x: 50, y: 30, title: "Trigger" },
+        NODES[1],
+      ]);
+    });
+
+    it("divides the drag delta by the current zoom so dragging tracks the pointer at any zoom level", () => {
+      const onNodesChange = vi.fn();
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={NODES} onNodesChange={onNodesChange} viewport={{ x: 0, y: 0, zoom: 2 }} />
+      );
+      const handle = getNode(container, "Trigger").querySelector(".cursor-grab") as HTMLElement;
+      firePointer(handle, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+      firePointer(handle, "pointermove", { pointerId: 1, clientX: 100, clientY: 0 });
+      expect(onNodesChange).toHaveBeenLastCalledWith([
+        { id: "a", x: 50, y: 0, title: "Trigger" },
+        NODES[1],
+      ]);
+    });
+
+    it("ignores a move event from a different, unrelated pointer id", () => {
+      const onNodesChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodesChange={onNodesChange} />);
+      const handle = getNode(container, "Trigger").querySelector(".cursor-grab") as HTMLElement;
+      firePointer(handle, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+      firePointer(handle, "pointermove", { pointerId: 2, clientX: 999, clientY: 999 });
+      expect(onNodesChange).not.toHaveBeenCalled();
+    });
+
+    it("does not start a canvas pan when the drag begins on a node", () => {
+      const onViewportChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onViewportChange={onViewportChange} />);
+      const handle = getNode(container, "Trigger").querySelector(".cursor-grab") as HTMLElement;
+      firePointer(handle, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+      firePointer(handle, "pointermove", { pointerId: 1, clientX: 50, clientY: 50 });
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("keyboard interaction on a node", () => {
+    it("nudges the focused node's position with arrow keys", () => {
+      const onNodesChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodesChange={onNodesChange} />);
+      const node = getNode(container, "Trigger");
+      fireEvent.keyDown(node, { key: "ArrowRight" });
+      expect(onNodesChange).toHaveBeenLastCalledWith([{ ...NODES[0], x: 10 }, NODES[1]]);
+    });
+
+    it("uses a larger step when Shift is held", () => {
+      const onNodesChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodesChange={onNodesChange} />);
+      const node = getNode(container, "Trigger");
+      fireEvent.keyDown(node, { key: "ArrowRight", shiftKey: true });
+      expect(onNodesChange).toHaveBeenLastCalledWith([{ ...NODES[0], x: 40 }, NODES[1]]);
+    });
+
+    it("calls onNodeDelete on Delete", () => {
+      const onNodeDelete = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onNodeDelete={onNodeDelete} />);
+      const node = getNode(container, "Trigger");
+      fireEvent.keyDown(node, { key: "Delete" });
+      expect(onNodeDelete).toHaveBeenCalledWith("a");
+    });
+
+    it("does not also pan the canvas when an arrow key is pressed on a focused node", () => {
+      const onViewportChange = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onViewportChange={onViewportChange} />);
+      const node = getNode(container, "Trigger");
+      fireEvent.keyDown(node, { key: "ArrowRight" });
+      expect(onViewportChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("connecting nodes", () => {
+    it("calls onConnect when a drag from an output port is released over another node's input port", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      inputPort.getBoundingClientRect = () =>
+        ({ left: 300, top: 20, right: 306, bottom: 26, width: 6, height: 6 }) as DOMRect;
+
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      firePointer(outputPort, "pointermove", { pointerId: 5, clientX: 302, clientY: 22 });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 302, clientY: 22 });
+
+      expect(onConnect).toHaveBeenCalledWith({ source: "a", target: "b" });
+    });
+
+    it("does not connect when released far from any input port", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      inputPort.getBoundingClientRect = () =>
+        ({ left: 300, top: 20, right: 306, bottom: 26, width: 6, height: 6 }) as DOMRect;
+
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 900, clientY: 900 });
+
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("cancels an in-progress connection when Escape is pressed", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      fireEvent.keyDown(getSurface(container), { key: "Escape" });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 300, clientY: 20 });
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("still cancels via Escape when keyboard focus is on a node (not the canvas) during the drag", () => {
+      // Starting a connection (pointerdown on an output port) never moves focus, so whatever had
+      // focus before - e.g. a node, after clicking its edit icon - stays focused. Escape bubbles
+      // from there through the node's own keydown handler up to the canvas; the node handler must
+      // not swallow it.
+      const onConnect = vi.fn();
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} showNodeEditButton />
+      );
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const editButton = sourceNode.querySelector('[aria-label="Edit Trigger"]') as HTMLElement;
+      editButton.focus();
+      expect(document.activeElement).toBe(editButton);
+
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+      inputPort.getBoundingClientRect = () =>
+        ({ left: 300, top: 20, right: 306, bottom: 26, width: 6, height: 6 }) as DOMRect;
+
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      fireEvent.keyDown(editButton, { key: "Escape" });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 302, clientY: 22 });
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("controlled vs uncontrolled viewport", () => {
+    it("clamps zoom to the configured minZoom/maxZoom", () => {
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} minZoom={0.5} maxZoom={1} />);
+      const surface = getSurface(container);
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      void surface;
+    });
+
+    it("recovers to a finite zoom when maxZoom is less than minZoom", () => {
+      render(<WorkflowBuilderLayout nodes={NODES} minZoom={2} maxZoom={0.5} />);
+      expect(screen.getByText("200%")).toBeInTheDocument();
+    });
+
+    it("replaces non-finite x/y with coordinate defaults instead of producing an invalid transform", () => {
+      const { container } = render(
+        <WorkflowBuilderLayout nodes={NODES} viewport={{ x: NaN, y: 0, zoom: 1 }} onViewportChange={() => undefined} />
+      );
+      const layer = container.querySelector('[aria-label^="Workflow canvas"] > div') as HTMLElement;
+      expect(layer.style.transform).not.toContain("NaN");
+      expect(layer.style.transform).toContain("translate(0px");
+    });
+
+    it("replaces a non-finite controlled zoom value with a finite fallback", () => {
+      render(
+        <WorkflowBuilderLayout nodes={NODES} viewport={{ x: 0, y: 0, zoom: NaN }} onViewportChange={() => undefined} />
+      );
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.queryByText("NaN%")).not.toBeInTheDocument();
+    });
+
+    it("does not tear down and reattach the wheel listener when onViewportChange is a fresh inline function every render", () => {
+      const addEventListenerSpy = vi.spyOn(HTMLElement.prototype, "addEventListener");
+      const removeEventListenerSpy = vi.spyOn(HTMLElement.prototype, "removeEventListener");
+      function Wrapper() {
+        const [, setTick] = React.useState(0);
+        return (
+          <>
+            <WorkflowBuilderLayout nodes={NODES} onViewportChange={() => undefined} />
+            <button onClick={() => setTick((t) => t + 1)}>rerender</button>
+          </>
+        );
+      }
+      render(<Wrapper />);
+      addEventListenerSpy.mockClear();
+      removeEventListenerSpy.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: "rerender" }));
+      fireEvent.click(screen.getByRole("button", { name: "rerender" }));
+      const wheelAttaches = addEventListenerSpy.mock.calls.filter((call) => call[0] === "wheel").length;
+      const wheelDetaches = removeEventListenerSpy.mock.calls.filter((call) => call[0] === "wheel").length;
+      expect(wheelAttaches).toBe(0);
+      expect(wheelDetaches).toBe(0);
+      addEventListenerSpy.mockRestore();
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/packages/registry/templates/layouts/workflow-builder-layout/workflow-builder-layout.test.tsx
+++ b/packages/registry/templates/layouts/workflow-builder-layout/workflow-builder-layout.test.tsx
@@ -46,6 +46,22 @@ function firePointer(
   });
 }
 
+// jsdom has no DragEvent constructor at all, so @testing-library's fireEvent.dragOver/drop fall
+// back to a bare Event that carries neither clientX/clientY nor dataTransfer. Dispatching a
+// MouseEvent (for the coordinates) with dataTransfer attached separately, under the real
+// "dragover"/"drop" type names, reaches the same onDragOver/onDrop handlers intact.
+function fireDrag(
+  el: Element,
+  type: "dragover" | "drop",
+  init: { clientX: number; clientY: number; dataTransfer: unknown }
+): void {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: init.clientX, clientY: init.clientY });
+  Object.defineProperty(event, "dataTransfer", { value: init.dataTransfer, configurable: true });
+  act(() => {
+    el.dispatchEvent(event);
+  });
+}
+
 const NODES: WorkflowNodeData[] = [
   { id: "a", x: 0, y: 0, title: "Trigger" },
   { id: "b", x: 300, y: 0, title: "Action" },
@@ -118,6 +134,35 @@ describe("WorkflowBuilderLayout", () => {
     it("omits the palette when no items are provided", () => {
       render(<WorkflowBuilderLayout nodes={NODES} />);
       expect(screen.queryByLabelText("Node palette")).not.toBeInTheDocument();
+    });
+
+    it("calls onPaletteItemDrop with world coordinates derived from the canvas bounds and viewport", () => {
+      const onPaletteItemDrop = vi.fn();
+      const { container } = render(
+        <WorkflowBuilderLayout
+          nodes={NODES}
+          paletteItems={[{ type: "http", label: "HTTP Request" }]}
+          onPaletteItemDrop={onPaletteItemDrop}
+          viewport={{ x: 10, y: 20, zoom: 2 }}
+        />
+      );
+      const surface = getSurface(container);
+      surface.getBoundingClientRect = () =>
+        ({ left: 100, top: 50, right: 900, bottom: 650, width: 800, height: 600 }) as DOMRect;
+
+      const dataTransfer = {
+        types: ["application/workflow-node-type"],
+        dropEffect: "",
+        getData: (type: string) => (type === "application/workflow-node-type" ? "http" : ""),
+      };
+
+      fireDrag(surface, "dragover", { dataTransfer, clientX: 300, clientY: 250 });
+      expect(dataTransfer.dropEffect).toBe("copy");
+
+      fireDrag(surface, "drop", { dataTransfer, clientX: 300, clientY: 250 });
+
+      // worldX = (300 - 100 - 10) / 2 = 95; worldY = (250 - 50 - 20) / 2 = 90
+      expect(onPaletteItemDrop).toHaveBeenCalledWith({ type: "http", label: "HTTP Request" }, { x: 95, y: 90 });
     });
   });
 
@@ -208,6 +253,16 @@ describe("WorkflowBuilderLayout", () => {
       const node = getNode(container, "Trigger");
       firePointer(node.querySelector(".cursor-grab") as HTMLElement, "pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
       expect(document.activeElement).toBe(node);
+    });
+
+    it("focuses the canvas surface when starting a connection from an output port", () => {
+      // A port isn't focusable and a connection isn't owned by either node, so this should claim
+      // focus for the canvas rather than leaving it on whatever (or nothing) had it before.
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={vi.fn()} />);
+      const surface = getSurface(container);
+      const outputPort = getNode(container, "Trigger").querySelector(".cursor-crosshair") as HTMLElement;
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      expect(document.activeElement).toBe(surface);
     });
   });
 
@@ -327,6 +382,51 @@ describe("WorkflowBuilderLayout", () => {
       expect(onConnect).not.toHaveBeenCalled();
     });
 
+    it("connects to a port sitting exactly at the hit-radius boundary", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      // Port center at (224, 20); release at (200, 20) - exactly 24px away (PORT_HIT_RADIUS).
+      inputPort.getBoundingClientRect = () =>
+        ({ left: 221, top: 17, right: 227, bottom: 23, width: 6, height: 6 }) as DOMRect;
+
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 200, clientY: 20 });
+
+      expect(onConnect).toHaveBeenCalledWith({ source: "a", target: "b" });
+    });
+
+    it("picks the first-encountered port when two input ports are exactly equidistant", () => {
+      const onConnect = vi.fn();
+      const threeNodes: WorkflowNodeData[] = [
+        { id: "a", x: 0, y: 0, title: "Source" },
+        { id: "b", x: 300, y: 0, title: "First" },
+        { id: "c", x: 300, y: 40, title: "Second" },
+      ];
+      const { container } = render(<WorkflowBuilderLayout nodes={threeNodes} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Source");
+      const firstNode = getNode(container, "First");
+      const secondNode = getNode(container, "Second");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const firstInputPort = firstNode.firstElementChild as HTMLElement;
+      const secondInputPort = secondNode.firstElementChild as HTMLElement;
+
+      // Both ports report identical bounding rects, so they're exactly equidistant from any
+      // release point - the tie must resolve to whichever was encountered first (node "b").
+      const tiedRect = () => ({ left: 300, top: 20, right: 306, bottom: 26, width: 6, height: 6 }) as DOMRect;
+      firstInputPort.getBoundingClientRect = tiedRect;
+      secondInputPort.getBoundingClientRect = tiedRect;
+
+      firePointer(outputPort, "pointerdown", { pointerId: 5, clientX: 220, clientY: 20 });
+      firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 303, clientY: 23 });
+
+      expect(onConnect).toHaveBeenCalledWith({ source: "a", target: "b" });
+    });
+
     it("cancels an in-progress connection when Escape is pressed", () => {
       const onConnect = vi.fn();
       const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
@@ -363,17 +463,76 @@ describe("WorkflowBuilderLayout", () => {
       firePointer(outputPort, "pointerup", { pointerId: 5, clientX: 302, clientY: 22 });
       expect(onConnect).not.toHaveBeenCalled();
     });
+
+    it("connects two nodes via keyboard: Enter on an output port, then Enter on an input port", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      fireEvent.keyDown(outputPort, { key: "Enter" });
+      fireEvent.keyDown(inputPort, { key: "Enter" });
+
+      expect(onConnect).toHaveBeenCalledWith({ source: "a", target: "b" });
+    });
+
+    it("does nothing when Enter is pressed on an input port with no connection in progress", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const targetNode = getNode(container, "Action");
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      fireEvent.keyDown(inputPort, { key: "Enter" });
+
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("does not connect a node's output to its own input via keyboard", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const ownInputPort = sourceNode.firstElementChild as HTMLElement;
+
+      fireEvent.keyDown(outputPort, { key: "Enter" });
+      fireEvent.keyDown(ownInputPort, { key: "Enter" });
+
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("cancels a keyboard-initiated connection when Escape is pressed", () => {
+      const onConnect = vi.fn();
+      const { container } = render(<WorkflowBuilderLayout nodes={NODES} onConnect={onConnect} />);
+      const sourceNode = getNode(container, "Trigger");
+      const targetNode = getNode(container, "Action");
+      const outputPort = sourceNode.querySelector(".cursor-crosshair") as HTMLElement;
+      const inputPort = targetNode.firstElementChild as HTMLElement;
+
+      fireEvent.keyDown(outputPort, { key: "Enter" });
+      fireEvent.keyDown(outputPort, { key: "Escape" });
+      fireEvent.keyDown(inputPort, { key: "Enter" });
+
+      expect(onConnect).not.toHaveBeenCalled();
+    });
   });
 
   describe("controlled vs uncontrolled viewport", () => {
     it("clamps zoom to the configured minZoom/maxZoom", () => {
-      const { container } = render(<WorkflowBuilderLayout nodes={NODES} minZoom={0.5} maxZoom={1} />);
-      const surface = getSurface(container);
+      render(<WorkflowBuilderLayout nodes={NODES} minZoom={0.5} maxZoom={1} />);
       fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
       fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
       fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
       expect(screen.getByText("100%")).toBeInTheDocument();
-      void surface;
+
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+      expect(screen.getByText("50%")).toBeInTheDocument();
     });
 
     it("recovers to a finite zoom when maxZoom is less than minZoom", () => {


### PR DESCRIPTION

## Description

### What does this PR do?

Adds `WorkflowBuilderLayout` — a new production-ready layout template: a node-and-connection workspace shell for visual automation/workflow tools.It provides a node palette sidebar, a pannable/zoomable canvas where nodes are placed and wired together by dragging from an output port to an input port, and an optional inspector panel for editing the selected node.

### Related Issues

- Implements one item from the #876 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [x] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.
- [x] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

### Docs 
<img width="1615" height="1019" alt="image" src="https://github.com/user-attachments/assets/af003661-d1b0-4db0-9f1f-c38e93a204e3" />

### StoryBook
<img width="1899" height="826" alt="image" src="https://github.com/user-attachments/assets/630ee039-5e55-467c-9530-269787a913c1" />

### Local 
<img width="1475" height="634" alt="image" src="https://github.com/user-attachments/assets/ebd2007f-75a1-437e-a169-60b453450f6c" />


## Additional Context

 **Key capabilities:**

- Controlled `nodes` / `edges` data model, with drag-to-reposition nodes, drag-to-connect ports (curved SVG edges with arrowheads), and drag-from-palette-to-canvas node creation.
- Pan/zoom canvas (drag, wheel/trackpad, ctrl/cmd + scroll to zoom, keyboard arrow/+/-/0 shortcuts), reusing the NaN-safe, inverted-range-safe viewport-clamping approach already established in `InfiniteCanvasLayout`.
- Node selection via a dedicated edit icon (`showNodeEditButton` prop), so dragging a node never accidentally opens its inspector.
- Full keyboard support: arrow-key pan/nudge, Enter/Space to select, Delete/Backspace to remove a node, Escape to cancel an in-progress connection.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Added `WorkflowBuilderLayout` with typed node, edge, palette, viewport, and props APIs.
  - Added pan and zoom, node dragging, port connections, curved SVG edges, selection, deletion, keyboard controls, and palette drag-and-drop.
  - Added optional palette, inspector, header, actions, grid, controls, node edit button, and node status support.
  - Added controlled and uncontrolled state support with safe viewport and zoom normalization.

- **Bug fixes**
  - Replaced viewport-bound `h-screen` sizing with container-aware `h-full` handling.
  - Added safeguards for non-finite viewport values and invalid zoom ranges.
  - Fixed the missing `useState` import in the demo code snippet.

- **Tooling / config changes**
  - Registered `WorkflowBuilderLayout` with `lucide-react` and `button` dependencies.
  - Added tests for rendering, interactions, connections, keyboard controls, drag behavior, and viewport handling.
  - Added full-height styles for `html`, `body`, and `#storybook-root` in Storybook.

- **Docs / Storybook updates**
  - Added `WorkflowBuilderLayoutDemo` with preview and code tabs.
  - Added versioned documentation, examples, interaction guidance, and API reference.
  - Added the layout to the documentation index and sidebar.
  - Added seven Storybook stories for layout variants and workflow interactions.

### Breaking changes

None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->