### PR TITLE
fix(component): persist tab selection in tabs component

### DIFF
--- a/apps/docs/src/components/Demo/TabDemo.tsx
+++ b/apps/docs/src/components/Demo/TabDemo.tsx
@@ -50,6 +50,7 @@ const TabDemo = () => {
               <TabsComponent
                 options={["Home", "Profile", "Settings", "About"]}
                 selected={0}
+                storageKey="tab-demo"
                 variant={variant as any}
                 theme={theme as any}
               />

--- a/apps/docs/src/components/UI/tab/index.tsx
+++ b/apps/docs/src/components/UI/tab/index.tsx
@@ -11,7 +11,15 @@ export interface TabsProps
   options: string[];
   selected?: number;
   value?: (index: any) => void;
+  /**
+   * The selected tab is always persisted to localStorage and restored on mount, surviving a
+   * page refresh. Defaults to a key derived from `options` - override it when multiple `Tabs`
+   * instances share the same options but must remember their selection independently.
+   */
+  storageKey?: string;
 }
+
+const STORAGE_PREFIX = "ignix-tabs:";
 
 const tabsVariants = cva("relative flex items-center", {
   variants: {
@@ -60,9 +68,35 @@ export const Tabs: React.FC<TabsProps> = ({
   size = "md",
   className,
   theme,
+  storageKey,
   ...props
 }) => {
-  const [activeIndex, setActiveIndex] = useState(selected);
+  const resolvedStorageKey = `${STORAGE_PREFIX}${storageKey ?? options.join("|")}`;
+
+  const [activeIndex, setActiveIndex] = useState(() => {
+    try {
+      const saved = localStorage.getItem(resolvedStorageKey);
+      if (saved !== null) {
+        const parsed = Number(saved);
+        if (Number.isInteger(parsed) && parsed >= 0 && parsed < options.length) {
+          return parsed;
+        }
+      }
+    } catch {
+      console.warn("Could not load tab selection from storage");
+    }
+    return selected;
+  });
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index);
+    try {
+      localStorage.setItem(resolvedStorageKey, String(index));
+    } catch {
+      console.warn("Could not save tab selection to storage");
+    }
+    value && value(index);
+  };
 
   return (
     <div
@@ -81,10 +115,7 @@ export const Tabs: React.FC<TabsProps> = ({
             key={option}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              setActiveIndex(index);
-              value && value(index);
-            }}
+            onClick={() => handleSelect(index)}
             className={cn(
               "relative px-4 py-2 transition-all",
               isActive

--- a/apps/docs/versioned_docs/version-1.0.3/components/tab.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/tab.mdx
@@ -18,7 +18,7 @@ The Tabs component is a versatile navigation interface that allows users to swit
 <Tabs>
   <TabItem value="cli" label="CLI" default>
     ```bash
-    ignix add component tab
+    ignix add component tabs
     ```
   </TabItem>
       <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
@@ -37,7 +37,15 @@ export interface TabsProps
   options: string[];
   selected?: number;
   value?: (index: number) => void;
+  /**
+   * The selected tab is always persisted to localStorage and restored on mount, surviving a
+   * page refresh. Defaults to a key derived from `options` - override it when multiple `Tabs`
+   * instances share the same options but must remember their selection independently.
+   */
+  storageKey?: string;
 }
+
+const STORAGE_PREFIX = "ignix-tabs:";
 
 const tabsVariants = cva("relative flex items-center", {
   variants: {
@@ -86,9 +94,35 @@ export const Tabs: React.FC<TabsProps> = ({
   size = "md",
   className,
   theme,
+  storageKey,
   ...props
 }) => {
-  const [activeIndex, setActiveIndex] = useState(selected);
+  const resolvedStorageKey = `${STORAGE_PREFIX}${storageKey ?? options.join("|")}`;
+
+  const [activeIndex, setActiveIndex] = useState(() => {
+    try {
+      const saved = localStorage.getItem(resolvedStorageKey);
+      if (saved !== null) {
+        const parsed = Number(saved);
+        if (Number.isInteger(parsed) && parsed >= 0 && parsed < options.length) {
+          return parsed;
+        }
+      }
+    } catch {
+      console.warn("Could not load tab selection from storage");
+    }
+    return selected;
+  });
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index);
+    try {
+      localStorage.setItem(resolvedStorageKey, String(index));
+    } catch {
+      console.warn("Could not save tab selection to storage");
+    }
+    value && value(index);
+  };
 
   return (
     <div
@@ -107,10 +141,7 @@ export const Tabs: React.FC<TabsProps> = ({
             key={option}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              setActiveIndex(index);
-              value && value(index);
-            }}
+            onClick={() => handleSelect(index)}
             className={cn(
               "relative px-4 py-2 transition-all",
               isActive
@@ -169,6 +200,23 @@ function BasicTabs() {
 }
 ```
 
+### Persisting the Selected Tab
+
+The selected tab is always remembered across a page refresh - no extra prop needed. The selection is saved to `localStorage` under a key derived from `options`, and restored on mount (falling back to `selected` when nothing is stored yet).
+
+```tsx
+function PersistentTabs() {
+  return <Tabs options={["Tab 1", "Tab 2", "Tab 3"]} selected={0} />;
+}
+```
+
+If two `Tabs` instances share the same `options` but need to remember their selection independently, give each one an explicit `storageKey`:
+
+```tsx
+<Tabs options={["Tab 1", "Tab 2", "Tab 3"]} storageKey="sidebar-tabs" />
+<Tabs options={["Tab 1", "Tab 2", "Tab 3"]} storageKey="main-content-tabs" />
+```
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -176,6 +224,7 @@ function BasicTabs() {
 | `options` | `string[]` | **required** | Array of tab labels to render |
 | `selected` | `number` | `0` | Index of the initially selected tab |
 | `value` | `(index: number) => void` | `undefined` | Callback fired with the index of the newly selected tab |
+| `storageKey` | `string` | derived from `options` | Overrides the localStorage key used to persist the selected tab (always on, surviving a page refresh); set this when multiple `Tabs` instances share identical `options` but must remember their selection independently |
 | `variant` | `'underline' \| 'filled' \| 'pill' \| 'outline' \| 'ghost' \| 'shadow' \| 'gradient' \| 'glow' \| 'block'` | `'underline'` | Visual style of the tab strip |
 | `theme` | `'light' \| 'dark' \| 'glass' \| 'glassDark' \| 'glassLight' \| 'glassGradient' \| 'glassGradientDark'` | `undefined` | Color theme applied to the tab container |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Font size of the tab labels |

--- a/apps/storybook/src/components/tab/index.tsx
+++ b/apps/storybook/src/components/tab/index.tsx
@@ -11,7 +11,15 @@ export interface TabsProps
   options: string[];
   selected?: number;
   value?: (index: number) => void;
+  /**
+   * The selected tab is always persisted to localStorage and restored on mount, surviving a
+   * page refresh. Defaults to a key derived from `options` - override it when multiple `Tabs`
+   * instances share the same options but must remember their selection independently.
+   */
+  storageKey?: string;
 }
+
+const STORAGE_PREFIX = "ignix-tabs:";
 
 const tabsVariants = cva("relative flex items-center", {
   variants: {
@@ -60,9 +68,35 @@ export const Tabs: React.FC<TabsProps> = ({
   size = "md",
   className,
   theme,
+  storageKey,
   ...props
 }) => {
-  const [activeIndex, setActiveIndex] = useState(selected);
+  const resolvedStorageKey = `${STORAGE_PREFIX}${storageKey ?? options.join("|")}`;
+
+  const [activeIndex, setActiveIndex] = useState(() => {
+    try {
+      const saved = localStorage.getItem(resolvedStorageKey);
+      if (saved !== null) {
+        const parsed = Number(saved);
+        if (Number.isInteger(parsed) && parsed >= 0 && parsed < options.length) {
+          return parsed;
+        }
+      }
+    } catch {
+      console.warn("Could not load tab selection from storage");
+    }
+    return selected;
+  });
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index);
+    try {
+      localStorage.setItem(resolvedStorageKey, String(index));
+    } catch {
+      console.warn("Could not save tab selection to storage");
+    }
+    value && value(index);
+  };
 
   return (
     <div
@@ -81,10 +115,7 @@ export const Tabs: React.FC<TabsProps> = ({
             key={option}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              setActiveIndex(index);
-              value && value(index);
-            }}
+            onClick={() => handleSelect(index)}
             className={cn(
               "relative px-4 py-2 transition-all",
               isActive

--- a/apps/storybook/src/components/tab/tab.stories.tsx
+++ b/apps/storybook/src/components/tab/tab.stories.tsx
@@ -95,3 +95,34 @@ export const Controlled: Story = {
     );
   },
 };
+
+export const Persistent: Story = {
+  name: "Persistent (survives refresh)",
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Tabs options={options} variant="underline" />
+      <p className="text-sm text-muted-foreground">
+        The selected tab is always saved to localStorage under a key derived from <code>options</code> - reload this story and it stays selected. No prop needed.
+      </p>
+    </div>
+  ),
+};
+
+export const IndependentInstances: Story = {
+  name: "Independent instances (custom storageKey)",
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="text-xs text-muted-foreground mb-2">storageKey=&quot;left-tabs&quot;</p>
+        <Tabs options={options} variant="underline" storageKey="left-tabs" />
+      </div>
+      <div>
+        <p className="text-xs text-muted-foreground mb-2">storageKey=&quot;right-tabs&quot;</p>
+        <Tabs options={options} variant="underline" storageKey="right-tabs" />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Both share the same <code>options</code>, so without a <code>storageKey</code> they'd persist to the same default key and stay in sync. Giving each an explicit <code>storageKey</code> keeps their remembered selection independent.
+      </p>
+    </div>
+  ),
+};

--- a/packages/registry/components/tab/index.tsx
+++ b/packages/registry/components/tab/index.tsx
@@ -11,7 +11,15 @@ export interface TabsProps
   options: string[];
   selected?: number;
   value?: (index: number) => void;
+  /**
+   * The selected tab is always persisted to localStorage and restored on mount, surviving a
+   * page refresh. Defaults to a key derived from `options` - override it when multiple `Tabs`
+   * instances share the same options but must remember their selection independently.
+   */
+  storageKey?: string;
 }
+
+const STORAGE_PREFIX = "ignix-tabs:";
 
 const tabsVariants = cva("relative flex items-center", {
   variants: {
@@ -60,9 +68,35 @@ export const Tabs: React.FC<TabsProps> = ({
   size = "md",
   className,
   theme,
+  storageKey,
   ...props
 }) => {
-  const [activeIndex, setActiveIndex] = useState(selected);
+  const resolvedStorageKey = `${STORAGE_PREFIX}${storageKey ?? options.join("|")}`;
+
+  const [activeIndex, setActiveIndex] = useState(() => {
+    try {
+      const saved = localStorage.getItem(resolvedStorageKey);
+      if (saved !== null) {
+        const parsed = Number(saved);
+        if (Number.isInteger(parsed) && parsed >= 0 && parsed < options.length) {
+          return parsed;
+        }
+      }
+    } catch {
+      console.warn("Could not load tab selection from storage");
+    }
+    return selected;
+  });
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index);
+    try {
+      localStorage.setItem(resolvedStorageKey, String(index));
+    } catch {
+      console.warn("Could not save tab selection to storage");
+    }
+    value && value(index);
+  };
 
   return (
     <div
@@ -81,10 +115,7 @@ export const Tabs: React.FC<TabsProps> = ({
             key={option}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              setActiveIndex(index);
-              value && value(index);
-            }}
+            onClick={() => handleSelect(index)}
             className={cn(
               "relative px-4 py-2 transition-all",
               isActive

--- a/packages/registry/components/tab/tab.test.tsx
+++ b/packages/registry/components/tab/tab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 
 vi.mock("framer-motion", () => ({
@@ -23,6 +23,10 @@ import { Tabs } from ".";
 const options = ["Overview", "Analytics", "Reports", "Settings"];
 
 describe("Tabs", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   describe("rendering", () => {
     it("renders all tab options as buttons", () => {
       render(<Tabs options={options} />);
@@ -168,6 +172,60 @@ describe("Tabs", () => {
       const { container } = render(<Tabs options={[]} />);
       expect(container.firstChild).toBeInTheDocument();
       expect(screen.queryAllByRole("button")).toHaveLength(0);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists automatically without a storageKey, using a default key derived from options", async () => {
+      const user = userEvent.setup();
+      const { unmount } = render(<Tabs options={options} />);
+      await user.click(screen.getByRole("button", { name: "Reports" }));
+      unmount();
+
+      render(<Tabs options={options} />);
+      expect(screen.getByRole("button", { name: "Reports" }).className).not.toContain("text-gray-500");
+      expect(screen.getByRole("button", { name: "Overview" }).className).toContain("text-gray-500");
+    });
+
+    it("falls back to the selected prop when nothing is stored", () => {
+      render(<Tabs options={options} selected={1} storageKey="demo-tabs" />);
+      expect(screen.getByRole("button", { name: "Analytics" }).className).not.toContain("text-gray-500");
+    });
+
+    it("restores a previously saved tab index on mount", () => {
+      localStorage.setItem("ignix-tabs:demo-tabs", "2");
+      render(<Tabs options={options} storageKey="demo-tabs" />);
+      expect(screen.getByRole("button", { name: "Reports" }).className).not.toContain("text-gray-500");
+      expect(screen.getByRole("button", { name: "Overview" }).className).toContain("text-gray-500");
+    });
+
+    it("saves the clicked tab index to storage", async () => {
+      const user = userEvent.setup();
+      render(<Tabs options={options} storageKey="demo-tabs" />);
+      await user.click(screen.getByRole("button", { name: "Settings" }));
+      expect(localStorage.getItem("ignix-tabs:demo-tabs")).toBe("3");
+    });
+
+    it("ignores an out-of-range stored index", () => {
+      localStorage.setItem("ignix-tabs:demo-tabs", "99");
+      render(<Tabs options={options} storageKey="demo-tabs" />);
+      expect(screen.getByRole("button", { name: "Overview" }).className).not.toContain("text-gray-500");
+    });
+
+    it("keeps independent state for two instances that share options but have different storageKeys", async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Tabs options={options} storageKey="left" />
+          <Tabs options={options} storageKey="right" />
+        </>
+      );
+      const leftButtons = screen.getAllByRole("button", { name: "Reports" });
+      await user.click(leftButtons[0]);
+
+      const overviews = screen.getAllByRole("button", { name: "Overview" });
+      expect(overviews[0].className).toContain("text-gray-500");
+      expect(overviews[1].className).not.toContain("text-gray-500");
     });
   });
 


### PR DESCRIPTION

## Description

### What does this PR do?
Fixes the `Tabs` component so the selected tab no longer resets after a page refresh. 

Also fixed the `Tab` component's install command in the docs (`ignix add component tab` → `ignix add component tabs`, matching the actual registry key).

### Related Issues

- Closes #966 

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screen recording

[Entire Screen - Screencastify - September 2, 2026 6_00 PM.webm](https://github.com/user-attachments/assets/7decacd1-f0fc-4417-a902-845ef42370e1)

## Additional Context

- The selected tab is now automatically persisted to `localStorage` and restored on mount. 
---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New components or component API changes**
  - Added the optional `storageKey` prop to `Tabs`.
  - Added validated `localStorage` persistence with automatic keys derived from `options`.
  - Added support for independent tab instances with custom storage keys.

- **Bug fixes**
  - Restores the selected tab after page refresh.
  - Persists the selected index after user selection.
  - Falls back to `selected` when stored data is missing or invalid.
  - Clears storage before each persistence test.

- **Tooling / config changes**
  - None.

- **Docs / Storybook updates**
  - Added `Persistent` and `IndependentInstances` Storybook stories.
  - Added persistence examples and `storageKey` documentation.
  - Corrected the install command to `ignix add component tabs`.
  - Enabled persistence in the tab documentation demo.

### Breaking changes
None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->