### PR TITLE
feat(component): add versatile theme-aware Badge component with variants

### DIFF
--- a/apps/docs/src/components/Demo/BadgeDemo.tsx
+++ b/apps/docs/src/components/Demo/BadgeDemo.tsx
@@ -4,62 +4,91 @@ import VariantSelector from './VariantSelector';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { Mail } from 'lucide-react';
+import { Mail, Star } from 'lucide-react';
 
-const badgeVariants = ['pulse', 'bounce', 'tinypop'];
-const badgeTypes = ['primary', 'secondary', 'success', 'warning', 'error'];
+const badgeVariants = [
+  'default',
+  'secondary',
+  'success',
+  'warning',
+  'destructive',
+  'info',
+  'purple',
+  'outline',
+  'notification',
+];
+const badgeSizes = ['sm', 'md', 'lg'];
 
 const BadgeDemo = () => {
-  const [variant, setVariant] = useState('pulse');
-  const [type, setType] = useState('primary');
+  const [variant, setVariant] = useState('default');
+  const [size, setSize] = useState('md');
+  const [removed, setRemoved] = useState(false);
 
   const codeString = `
 import { Badge } from '@ignix-ui/badge';
 
-<div className="flex items-center gap-8 border rounded-lg p-4 mt-4">
-  <div className="relative inline-flex items-center">
-      <Badge mode="attached" text="3" type="${type}" variant="${variant}">
-      <Mail className="h-11 w-11" />
-    </Badge>
-  </div>
-  <div className="flex items-center gap-1">
-    <span className="text-lg font-medium">Notifications</span>
-    <Badge text="99+" type="${type}" variant="${variant}" />
-  </div>
+<div className="flex flex-wrap items-center gap-4">
+  <Badge variant="${variant}" size="${size}">
+    Status
+  </Badge>
+
+  <Badge variant="${variant}" size="${size}" icon={<Star className="h-3 w-3" />}>
+    Featured
+  </Badge>
+
+  <Badge variant="${variant}" size="${size}" onRemove={() => setRemoved(true)}>
+    Dismissible
+  </Badge>
+
+  <Badge variant="notification" anchor={<Mail className="h-8 w-8" />}>
+    3
+  </Badge>
 </div>
 `;
 
   return (
     <div className="flex flex-col space-y-4 mb-8">
       <div className="flex flex-wrap gap-4 justify-start md:justify-end">
-        <VariantSelector
-          variants={badgeVariants}
-          selectedVariant={variant}
-          onSelectVariant={setVariant}
-        />
-        <VariantSelector
-          variants={badgeTypes}
-          selectedVariant={type}
-          onSelectVariant={setType}
-          type='Type'
-        />
+        <VariantSelector variants={badgeVariants} selectedVariant={variant} onSelectVariant={setVariant} type="Variant" />
+        <VariantSelector variants={badgeSizes} selectedVariant={size} onSelectVariant={setSize} type="Size" />
       </div>
       <Tabs>
-        <TabItem value="preview" label="Preview">
-          <div className="flex items-center gap-8 border rounded-lg p-4 mt-4">
-            <div className="relative inline-flex items-center">
-               <Badge mode="attached" text="3" type={type as any} variant={variant as any}>
-                <Mail className="h-11 w-11" />
+        <TabItem value="preview" label="Preview" default>
+          <div className="flex flex-wrap items-center gap-6 border rounded-lg p-4 mt-4">
+            <Badge variant={variant as any} size={size as any}>
+              Status
+            </Badge>
+
+            <Badge variant={variant as any} size={size as any} icon={<Star className="h-3 w-3" />}>
+              Featured
+            </Badge>
+
+            {!removed ? (
+              <Badge variant={variant as any} size={size as any} onRemove={() => setRemoved(true)}>
+                Dismissible
               </Badge>
-            </div>
+            ) : (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground underline"
+                onClick={() => setRemoved(false)}
+              >
+                Reset dismissed badge
+              </button>
+            )}
+
             <div className="flex items-center gap-1">
-              <span className="text-lg font-medium">Notifications</span>
-              <Badge text="99+" type={type as any} variant={variant as any}/>
+              <span className="text-sm font-medium">Notifications</span>
+              <Badge variant="notification" anchor={<Mail className="h-8 w-8" />}>
+                3
+              </Badge>
             </div>
           </div>
         </TabItem>
         <TabItem value="code" label="Code">
-          <CodeBlock language="tsx" className='whitespace-pre-wrap max-h-[500px] overflow-y-scroll'>{codeString}</CodeBlock>
+          <CodeBlock language="tsx" className="whitespace-pre-wrap max-h-[500px] overflow-y-scroll">
+            {codeString}
+          </CodeBlock>
         </TabItem>
       </Tabs>
     </div>

--- a/apps/docs/src/components/Demo/BadgeDemo.tsx
+++ b/apps/docs/src/components/Demo/BadgeDemo.tsx
@@ -25,25 +25,35 @@ const BadgeDemo = () => {
   const [removed, setRemoved] = useState(false);
 
   const codeString = `
+import { useState } from 'react';
 import { Badge } from '@ignix-ui/badge';
+import { Mail, Star } from 'lucide-react';
 
-<div className="flex flex-wrap items-center gap-4">
-  <Badge variant="${variant}" size="${size}">
-    Status
-  </Badge>
+function BadgeExample() {
+  const [removed, setRemoved] = useState(false);
 
-  <Badge variant="${variant}" size="${size}" icon={<Star className="h-3 w-3" />}>
-    Featured
-  </Badge>
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <Badge variant="${variant}" size="${size}">
+        Status
+      </Badge>
 
-  <Badge variant="${variant}" size="${size}" onRemove={() => setRemoved(true)}>
-    Dismissible
-  </Badge>
+      <Badge variant="${variant}" size="${size}" icon={<Star className="h-3 w-3" />}>
+        Featured
+      </Badge>
 
-  <Badge variant="notification" anchor={<Mail className="h-8 w-8" />}>
-    3
-  </Badge>
-</div>
+      {!removed && (
+        <Badge variant="${variant}" size="${size}" onRemove={() => setRemoved(true)}>
+          Dismissible
+        </Badge>
+      )}
+
+      <Badge variant="notification" anchor={<Mail className="h-8 w-8" />}>
+        3
+      </Badge>
+    </div>
+  );
+}
 `;
 
   return (

--- a/apps/docs/src/components/UI/badge/index.tsx
+++ b/apps/docs/src/components/UI/badge/index.tsx
@@ -1,148 +1,164 @@
 import React from "react";
 import { motion, type Variants } from "framer-motion";
+import { X } from "lucide-react";
 import { cn } from "../../../utils/cn";
 
-type BadgeBaseProps = {
-    text?: string;
-    type?: "primary" | "secondary" | "success" | "warning" | "error";
-    variant?: "pulse" | "bounce" | "tinypop" | "none";
-    className?: string;
+export type BadgeVariant =
+  | "default"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "destructive"
+  | "info"
+  | "purple"
+  | "outline"
+  | "notification";
+
+export type BadgeSize = "sm" | "md" | "lg";
+
+export type BadgeAnimation = "none" | "pulse" | "bounce" | "tinypop";
+
+export interface BadgeProps
+  extends Omit<
+    React.HTMLAttributes<HTMLSpanElement>,
+    "children" | "color" | "onAnimationStart" | "onAnimationEnd" | "onDrag" | "onDragStart" | "onDragEnd"
+  > {
+  children?: React.ReactNode;
+  /** Color/style of the badge. `"notification"` reproduces the original circular counter look. */
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  /** Leading icon, rendered before the content. */
+  icon?: React.ReactNode;
+  /** Renders a dismiss button after the content; called when it's clicked. */
+  onRemove?: () => void;
+  /** Accessible label for the dismiss button. Default `"Remove"`. */
+  removeLabel?: string;
+  /**
+   * Anchors the badge to the top-right corner of this element instead of rendering inline -
+   * reproduces the original `mode="attached"` notification-badge positioning.
+   */
+  anchor?: React.ReactNode;
+  /** Motion applied to the badge. Defaults to `"tinypop"` for `variant="notification"`, `"none"` otherwise. */
+  animate?: BadgeAnimation;
+  className?: string;
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  default: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+  success: "bg-success text-success-foreground",
+  warning: "bg-warning text-warning-foreground",
+  destructive: "bg-destructive text-destructive-foreground",
+  info: "bg-info text-info-foreground",
+  purple: "bg-purple text-purple-foreground",
+  outline: "bg-transparent text-foreground border border-border",
+  notification: "bg-primary text-primary-foreground shadow-lg shadow-primary/25 ring-2 ring-primary/20",
 };
 
-type InlineBadgeProps = BadgeBaseProps & {
-    mode?: "inline";
-    children?: never;
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "text-[11px] px-2 py-0.5 gap-1",
+  md: "text-xs px-2.5 py-0.5 gap-1.5",
+  lg: "text-sm px-3 py-1 gap-1.5",
 };
 
-type AttachedBadgeProps = BadgeBaseProps & {
-    mode: "attached";
-    children: React.ReactNode;
+// The notification variant is a circular counter, not a text pill, so it gets its own
+// size scale (fixed height/min-width) instead of SIZE_CLASSES' padding-based one.
+const NOTIFICATION_SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "h-4 min-w-[16px] px-1 text-[10px]",
+  md: "h-5 min-w-[20px] px-1.5 text-xs",
+  lg: "h-6 min-w-[24px] px-2 text-sm",
 };
 
-type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
+  pulse: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.1, 1], transition: { duration: 2, repeat: Infinity, ease: "easeOut" } },
+  },
+  bounce: {
+    initial: { y: 0, scale: 1 },
+    animate: {
+      y: [0, -6, 0],
+      scale: [1, 1.15, 1],
+      transition: { duration: 0.8, repeat: Infinity, ease: "easeOut" },
+    },
+  },
+  tinypop: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.25, 1], transition: { duration: 1.5, repeat: Infinity, ease: "easeInOut" } },
+  },
+};
 
-const Badge: React.FC<BadgeProps> = ({
-    text,
-    type = "primary",
-    variant = "tinypop",
-    mode = "inline",
-    className,
-    children,
+const NONE_VARIANT: Variants = { initial: {}, animate: {} };
+
+export const Badge: React.FC<BadgeProps> = ({
+  children,
+  variant = "default",
+  size = "md",
+  icon,
+  onRemove,
+  removeLabel = "Remove",
+  anchor,
+  animate,
+  className,
+  ...props
 }) => {
-    const types = {
-        primary: cn(
-            "bg-primary text-primary-foreground",
-            "shadow-lg shadow-primary/25",
-            "ring-2 ring-primary/20"
-        ),
-        secondary: cn(
-            "bg-secondary text-secondary-foreground",
-            "shadow-lg shadow-secondary/25",
-            "ring-2 ring-secondary/20"
-        ),
-        success: cn(
-            "bg-success text-success-foreground",
-            "shadow-lg shadow-success/25",
-            "ring-2 ring-success/20"
-        ),
-        warning: cn(
-            "bg-warning text-warning-foreground",
-            "shadow-lg shadow-warning/25",
-            "ring-2 ring-warning/30"
-        ),
-        error: cn(
-            "bg-destructive text-destructive-foreground",
-            "shadow-lg shadow-destructive/25",
-            "ring-2 ring-destructive/20"
-        ),
-    };
+  const isNotification = variant === "notification";
+  const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
+  const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
-    const animationVariants: Record<string, Variants> = {
-        none: {
-            initial: {},
-            animate: {},
-        },
-        pulse: {
-            initial: { scale: 1 },
-            animate: {
-                scale: [1, 1.1, 1],
-                transition: {
-                    duration: 2,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                },
-            },
-        },
-        bounce: {
-            initial: { y: 0, scale: 1 },
-            animate: {
-                y: [0, -6, 0],
-                scale: [1, 1.15, 1],
-                transition: {
-                    duration: 0.8,
-                    repeat: Infinity,
-                    ease: "easeOut",
-                },
-            },
-        },
-        tinypop: {
-            initial: { scale: 1 },
-            animate: {
-                scale: [1, 1.25, 1],
-                transition: {
-                    duration: 1.5,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                },
-            },
-        },
-    };
-
-    const isAttached = mode === "attached";
-
-    // Base styles
-    const baseStyles = cn(
-        "flex items-center justify-center",
-        "rounded-full font-bold tracking-tight",
-        "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
-
-        types[type],
+  const content = (
+    <motion.span
+      variants={motionVariants}
+      initial="initial"
+      animate="animate"
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-full font-medium leading-none whitespace-nowrap",
+        VARIANT_CLASSES[variant],
+        isNotification ? NOTIFICATION_SIZE_CLASSES[size] : SIZE_CLASSES[size],
+        anchor && "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
         className
-    );
-
-    const positionStyles = isAttached
-        ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
-        : "relative -top-2 sm:-top-2";
-
-    const badgeContent = (
-        <motion.div
-            variants={animationVariants[variant]}
-            initial="initial"
-            animate="animate"
-            className={cn(baseStyles, positionStyles)}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
+      )}
+      {...props}
+    >
+      {icon && (
+        <span className="shrink-0" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {children}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
         >
-            <span className="leading-none">{text}</span>
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {isNotification && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10"
+          aria-hidden="true"
+        />
+      )}
+    </motion.span>
+  );
 
-            <div
-                className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
-                aria-hidden="true"
-            />
-        </motion.div>
+  if (anchor) {
+    return (
+      <span className="relative inline-flex items-center">
+        {anchor}
+        {content}
+      </span>
     );
+  }
 
-    if (isAttached) {
-        return (
-            <div className="relative inline-flex items-center">
-                {children}
-                {badgeContent}
-            </div>
-        );
-    }
-
-    return badgeContent;
+  return content;
 };
 
 Badge.displayName = "Badge";
-export { Badge };
+
+export default Badge;

--- a/apps/docs/src/components/UI/badge/index.tsx
+++ b/apps/docs/src/components/UI/badge/index.tsx
@@ -90,7 +90,11 @@ const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
 
 const NONE_VARIANT: Variants = { initial: {}, animate: {} };
 
-export const Badge: React.FC<BadgeProps> = ({
+/**
+ * Badge is a versatile, theme-aware status indicator - color pill, outline tag, or (via
+ * `variant="notification"`) a floating counter attached to an icon or button.
+ */
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(({
   children,
   variant = "default",
   size = "md",
@@ -101,13 +105,14 @@ export const Badge: React.FC<BadgeProps> = ({
   animate,
   className,
   ...props
-}) => {
+}, ref) => {
   const isNotification = variant === "notification";
   const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
   const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
   const content = (
     <motion.span
+      ref={ref}
       variants={motionVariants}
       initial="initial"
       animate="animate"
@@ -131,7 +136,10 @@ export const Badge: React.FC<BadgeProps> = ({
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
           aria-label={removeLabel}
           className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
         >
@@ -157,7 +165,7 @@ export const Badge: React.FC<BadgeProps> = ({
   }
 
   return content;
-};
+});
 
 Badge.displayName = "Badge";
 

--- a/apps/docs/src/components/UI/list-view-page/index.tsx
+++ b/apps/docs/src/components/UI/list-view-page/index.tsx
@@ -793,10 +793,12 @@ function Toolbar({
                                     Filters
                                     {activeFilterCount > 0 && (
                                         <Badge
-                                            text={String(activeFilterCount)}
-                                            variant="pulse"
+                                            variant="notification"
+                                            animate="pulse"
                                             className="h-5 min-w-5 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground"
-                                        />
+                                        >
+                                            {activeFilterCount}
+                                        </Badge>
                                     )}
                                 </Button>
                             )}
@@ -1237,15 +1239,13 @@ function StatusBadge({
 }) {
     const s = styles?.[status] ?? DEFAULT_STATUS_STYLE;
     return (
-        <span
-            className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                s.className
-            )}
+        <Badge
+            variant="outline"
+            icon={<span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />}
+            className={cn("gap-1.5 px-2 py-0.5 text-[11px] font-medium", s.className)}
         >
-            <span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />
             {status}
-        </span>
+        </Badge>
     );
 }
 
@@ -1452,12 +1452,14 @@ function ViewDialog({
                         </div>
                         {item.status && statusStyles?.[item.status] && (
                             <Badge
+                                variant="outline"
                                 className={cn(
                                     "shrink-0 gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium whitespace-nowrap",
                                     statusStyles[item.status].className
                                 )}
-                                text={item.status}
-                            />
+                            >
+                                {item.status}
+                            </Badge>
                         )}
                     </div>
 

--- a/apps/docs/src/components/UI/list-view-page/index.tsx
+++ b/apps/docs/src/components/UI/list-view-page/index.tsx
@@ -1230,6 +1230,7 @@ function SkeletonRow() {
 /*                                BADGES                                      */
 /* -------------------------------------------------------------------------- */
 
+/** Renders an item's status as a labeled Badge with a colored dot, using a per-status style map. */
 function StatusBadge({
     status,
     styles,

--- a/apps/docs/src/components/UI/timeline-view-page/index.tsx
+++ b/apps/docs/src/components/UI/timeline-view-page/index.tsx
@@ -36,19 +36,16 @@ export function StatusBadge({
     status: TimelineStatus;
     className?: string;
 }) {
-    const typeMap = {
+    const variantMap = {
         completed: "success",
         in_progress: "warning",
         pending: "secondary",
     } as const;
 
     return (
-        <Badge
-            text={STATUS_LABELS[status]}
-            type={typeMap[status]}
-            variant="none"
-            className={className}
-        />
+        <Badge variant={variantMap[status]} className={className}>
+            {STATUS_LABELS[status]}
+        </Badge>
     );
 }
 

--- a/apps/docs/src/components/UI/timeline-view-page/index.tsx
+++ b/apps/docs/src/components/UI/timeline-view-page/index.tsx
@@ -29,6 +29,7 @@ export const STATUS_LABELS: Record<TimelineStatus, string> = {
 
 // Constants
 
+/** Renders a timeline item's status as a labeled Badge, colored by {@link TimelineStatus}. */
 export function StatusBadge({
     status,
     className,

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -77,6 +77,10 @@
   --info-light: #22d3ee;
   --info-dark: #0e7490;
   --info-foreground: #ffffff;
+  --purple: #a855f7;
+  --purple-light: #c084fc;
+  --purple-dark: #7e22ce;
+  --purple-foreground: #ffffff;
   --red-primary: hsl(var(--primary));
 
   --ifm-paragraph-margin-bottom: 0rem;
@@ -198,6 +202,10 @@
   --info-light: #22d3ee;
   --info-dark: #0e7490;
   --info-foreground: #ffffff;
+  --purple: #a855f7;
+  --purple-light: #c084fc;
+  --purple-dark: #7e22ce;
+  --purple-foreground: #ffffff;
 
   /* Floating Dock */
   --dock-solid: #1e293b;
@@ -295,6 +303,10 @@
   --color-info-light: var(--info-light);
   --color-info-dark: var(--info-dark);
   --color-info-foreground: var(--info-foreground);
+  --color-purple: var(--purple);
+  --color-purple-light: var(--purple-light);
+  --color-purple-dark: var(--purple-dark);
+  --color-purple-foreground: var(--purple-foreground);
 
   --animate-shine: shine var(--duration) infinite linear;
 

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -77,7 +77,7 @@
   --info-light: #22d3ee;
   --info-dark: #0e7490;
   --info-foreground: #ffffff;
-  --purple: #a855f7;
+  --purple: #7e22ce;
   --purple-light: #c084fc;
   --purple-dark: #7e22ce;
   --purple-foreground: #ffffff;
@@ -202,7 +202,7 @@
   --info-light: #22d3ee;
   --info-dark: #0e7490;
   --info-foreground: #ffffff;
-  --purple: #a855f7;
+  --purple: #7e22ce;
   --purple-light: #c084fc;
   --purple-dark: #7e22ce;
   --purple-foreground: #ffffff;

--- a/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
@@ -1,16 +1,16 @@
 ---
 sidebar_position: 3
 title: Badge
-description: A small status descriptor for UI elements that can display numbers, text, or a small dot.
+description: A versatile, theme-aware badge for status indicators, colored action pills, and notification counters.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Badge } from '@site/src/components/UI/badge';
-import { Mail } from 'lucide-react';
+import { Mail, Star } from 'lucide-react';
 import BadgeDemo from '@site/src/components/Demo/BadgeDemo';
 
-Badges are small status descriptors that can be used to highlight specific information, such as notification counts, status indicators, or labels. They can include text, numbers, or just a dot indicator.
+Badges are small, theme-aware status descriptors for dashboards, CMS-style tools, and any UI that needs to label state (Draft/Published, CREATE/UPDATE/DELETE, Active/Disabled, role tags, severity labels) alongside a dedicated notification-counter variant for floating counts on icons and buttons.
 
 <BadgeDemo />
 
@@ -24,153 +24,170 @@ Badges are small status descriptors that can be used to highlight specific infor
   </TabItem>
     <TabItem value="manual" label="Manual" className="max-h-[500px] overflow-y-auto">
     ```tsx
-  import React from "react";
-import { motion, Variants } from "framer-motion";
-import { cn } from "../../../utils/cn";
+import React from "react";
+import { motion, type Variants } from "framer-motion";
+import { X } from "lucide-react";
+import { cn } from "../../utils/cn";
 
-type BadgeBaseProps = {
-  text?: string;
-  type?: "primary" | "secondary" | "success" | "warning" | "error";
-  variant?: "pulse" | "bounce" | "tinypop" | "none";
+export type BadgeVariant =
+  | "default"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "destructive"
+  | "info"
+  | "purple"
+  | "outline"
+  | "notification";
+
+export type BadgeSize = "sm" | "md" | "lg";
+
+export type BadgeAnimation = "none" | "pulse" | "bounce" | "tinypop";
+
+export interface BadgeProps
+  extends Omit<
+    React.HTMLAttributes<HTMLSpanElement>,
+    "children" | "color" | "onAnimationStart" | "onAnimationEnd" | "onDrag" | "onDragStart" | "onDragEnd"
+  > {
+  children?: React.ReactNode;
+  /** Color/style of the badge. `"notification"` reproduces the original circular counter look. */
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  /** Leading icon, rendered before the content. */
+  icon?: React.ReactNode;
+  /** Renders a dismiss button after the content; called when it's clicked. */
+  onRemove?: () => void;
+  /** Accessible label for the dismiss button. Default `"Remove"`. */
+  removeLabel?: string;
+  /**
+   * Anchors the badge to the top-right corner of this element instead of rendering inline -
+   * reproduces the original `mode="attached"` notification-badge positioning.
+   */
+  anchor?: React.ReactNode;
+  /** Motion applied to the badge. Defaults to `"tinypop"` for `variant="notification"`, `"none"` otherwise. */
+  animate?: BadgeAnimation;
   className?: string;
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  default: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+  success: "bg-success text-success-foreground",
+  warning: "bg-warning text-warning-foreground",
+  destructive: "bg-destructive text-destructive-foreground",
+  info: "bg-info text-info-foreground",
+  purple: "bg-purple text-purple-foreground",
+  outline: "bg-transparent text-foreground border border-border",
+  notification: "bg-primary text-primary-foreground shadow-lg shadow-primary/25 ring-2 ring-primary/20",
 };
 
-type InlineBadgeProps = BadgeBaseProps & {
-  mode?: "inline";
-  children?: never;
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "text-[11px] px-2 py-0.5 gap-1",
+  md: "text-xs px-2.5 py-0.5 gap-1.5",
+  lg: "text-sm px-3 py-1 gap-1.5",
 };
 
-type AttachedBadgeProps = BadgeBaseProps & {
-  mode: "attached";
-  children: React.ReactNode;
+// The notification variant is a circular counter, not a text pill, so it gets its own
+// size scale (fixed height/min-width) instead of SIZE_CLASSES' padding-based one.
+const NOTIFICATION_SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "h-4 min-w-[16px] px-1 text-[10px]",
+  md: "h-5 min-w-[20px] px-1.5 text-xs",
+  lg: "h-6 min-w-[24px] px-2 text-sm",
 };
 
-type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
+  pulse: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.1, 1], transition: { duration: 2, repeat: Infinity, ease: "easeOut" } },
+  },
+  bounce: {
+    initial: { y: 0, scale: 1 },
+    animate: {
+      y: [0, -6, 0],
+      scale: [1, 1.15, 1],
+      transition: { duration: 0.8, repeat: Infinity, ease: "easeOut" },
+    },
+  },
+  tinypop: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.25, 1], transition: { duration: 1.5, repeat: Infinity, ease: "easeInOut" } },
+  },
+};
 
-const Badge: React.FC<BadgeProps> = ({
-  text,
-  type = "primary",
-  variant = "tinypop",
-  mode = "inline",
-  className,
+const NONE_VARIANT: Variants = { initial: {}, animate: {} };
+
+export const Badge: React.FC<BadgeProps> = ({
   children,
+  variant = "default",
+  size = "md",
+  icon,
+  onRemove,
+  removeLabel = "Remove",
+  anchor,
+  animate,
+  className,
+  ...props
 }) => {
-  const types = {
-    primary: cn(
-      "bg-primary text-primary-foreground",
-      "ring-2 ring-primary/20"
-    ),
-    secondary: cn(
-      "bg-secondary text-secondary-foreground",
-      "shadow-lg shadow-secondary/25",
-      "ring-2 ring-secondary/20"
-    ),
-    success: cn(
-      "bg-success text-success-foreground",
-      "shadow-lg shadow-success/25",
-      "ring-2 ring-success/20"
-    ),
-    warning: cn(
-      "bg-warning text-warning-foreground",
-      "shadow-lg shadow-warning/25",
-      "ring-2 ring-warning/30"
-    ),
-    error: cn(
-      "bg-destructive text-destructive-foreground",
-      "shadow-lg shadow-destructive/25",
-      "ring-2 ring-destructive/20"
-    ),
-  };
+  const isNotification = variant === "notification";
+  const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
+  const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
-  const animationVariants: Record<string, Variants> = {
-    none: {
-      initial: {},
-      animate: {},
-    },
-    pulse: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.1, 1],
-        transition: {
-          duration: 2,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    bounce: {
-      initial: { y: 0, scale: 1 },
-      animate: {
-        y: [0, -6, 0],
-        scale: [1, 1.15, 1],
-        transition: {
-          duration: 0.8,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    tinypop: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.25, 1],
-        transition: {
-          duration: 1.5,
-          repeat: Infinity,
-          ease: "easeInOut",
-        },
-      },
-    },
-  };
-
-  const isAttached = mode === "attached";
-
-  // Base styles
-  const baseStyles = cn(
-    "flex items-center justify-center",
-    "rounded-full font-bold tracking-tight",
-    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
-
-    types[type],
-    className
-  );
-
-  const positionStyles = isAttached
-    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
-    : "relative -top-2 sm:-top-2";
-
-  const badgeContent = (
-    <motion.div
-      variants={animationVariants[variant]}
+  const content = (
+    <motion.span
+      variants={motionVariants}
       initial="initial"
       animate="animate"
-      className={cn(baseStyles, positionStyles)}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-full font-medium leading-none whitespace-nowrap",
+        VARIANT_CLASSES[variant],
+        isNotification ? NOTIFICATION_SIZE_CLASSES[size] : SIZE_CLASSES[size],
+        anchor && "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
+        className
+      )}
+      {...props}
     >
-    <span className="leading-none">{text}</span>
-
-    <div
-        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
-        aria-hidden="true"
-    />
-    </motion.div>
+      {icon && (
+        <span className="shrink-0" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {children}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {isNotification && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10"
+          aria-hidden="true"
+        />
+      )}
+    </motion.span>
   );
 
-  if (isAttached) {
+  if (anchor) {
     return (
-      <div className="relative inline-flex items-center">
-        {children}
-        {badgeContent}
-      </div>
+      <span className="relative inline-flex items-center">
+        {anchor}
+        {content}
+      </span>
     );
   }
 
-  return badgeContent;
+  return content;
 };
 
 Badge.displayName = "Badge";
-export { Badge };
+
+export default Badge;
     ```
   </TabItem>
 </Tabs>
@@ -183,27 +200,57 @@ Import the component:
 import { Badge } from '@ignix-ui/badge';
 ```
 
-### Basic Usage
+### Status Pill
 
 ```tsx
-function BasicBadge() {
+<Badge variant="success">Published</Badge>
+<Badge variant="secondary">Draft</Badge>
+<Badge variant="destructive">Archived</Badge>
+```
+
+### With an Icon
+
+```tsx
+<Badge variant="info" icon={<Star className="h-3 w-3" />}>
+  Featured
+</Badge>
+```
+
+### Dismissible
+
+```tsx
+import { useState } from 'react';
+
+function DismissibleTag() {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+
   return (
-    <div className="relative inline-flex items-center">
-      <Badge mode="attached" text="3" type="primary" variant="pulse">
-        <Mail className="h-11 w-11" />
-      </Badge>
-    </div>
+    <Badge variant="secondary" onRemove={() => setVisible(false)}>
+      React
+    </Badge>
   );
 }
+```
+
+### Notification Counter (Attached)
+
+```tsx
+<Badge variant="notification" anchor={<Mail className="h-10 w-10" />}>
+  3
+</Badge>
 ```
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `text` | `string` | - | Text to display inside the badge |
-| `mode` | `"inline" \| "attached"` | `"inline"` | Inline badge or attached badge mode |
-| `type` | `"primary" \| "secondary" \| "success" \| "warning" \| "error"` | `"primary"` | Visual style variant of the badge |
-| `variant` | `"pulse" \| "bounce" \| "tinypop"` | `"tinypop"` | Animation variant applied to the badge |
-| `className` | `string` | - | Additional CSS classes for the badge |
-| `children` | `React.ReactNode` | - | Component the badge will be attached to |
+| `children` | `React.ReactNode` | `undefined` | Content displayed inside the badge |
+| `variant` | `"default" \| "secondary" \| "success" \| "warning" \| "destructive" \| "info" \| "purple" \| "outline" \| "notification"` | `"default"` | Color/style of the badge; `"notification"` reproduces the original circular counter look |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Size of the badge |
+| `icon` | `React.ReactNode` | `undefined` | Leading icon, rendered before the content |
+| `onRemove` | `() => void` | `undefined` | Renders a dismiss button after the content; called when it's clicked |
+| `removeLabel` | `string` | `"Remove"` | Accessible label for the dismiss button |
+| `anchor` | `React.ReactNode` | `undefined` | Anchors the badge to the top-right corner of this element instead of rendering inline |
+| `animate` | `"none" \| "pulse" \| "bounce" \| "tinypop"` | `"tinypop"` for `notification`, `"none"` otherwise | Motion applied to the badge |
+| `className` | `string` | `undefined` | Additional CSS classes for the badge |

--- a/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
+++ b/apps/docs/versioned_docs/version-1.0.3/components/badge.mdx
@@ -27,7 +27,7 @@ Badges are small, theme-aware status descriptors for dashboards, CMS-style tools
 import React from "react";
 import { motion, type Variants } from "framer-motion";
 import { X } from "lucide-react";
-import { cn } from "../../utils/cn";
+import { cn } from "../../../utils/cn";
 
 export type BadgeVariant =
   | "default"
@@ -116,7 +116,11 @@ const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
 
 const NONE_VARIANT: Variants = { initial: {}, animate: {} };
 
-export const Badge: React.FC<BadgeProps> = ({
+/**
+ * Badge is a versatile, theme-aware status indicator - color pill, outline tag, or (via
+ * `variant="notification"`) a floating counter attached to an icon or button.
+ */
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(({
   children,
   variant = "default",
   size = "md",
@@ -127,13 +131,14 @@ export const Badge: React.FC<BadgeProps> = ({
   animate,
   className,
   ...props
-}) => {
+}, ref) => {
   const isNotification = variant === "notification";
   const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
   const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
   const content = (
     <motion.span
+      ref={ref}
       variants={motionVariants}
       initial="initial"
       animate="animate"
@@ -157,7 +162,10 @@ export const Badge: React.FC<BadgeProps> = ({
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
           aria-label={removeLabel}
           className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
         >
@@ -183,7 +191,7 @@ export const Badge: React.FC<BadgeProps> = ({
   }
 
   return content;
-};
+});
 
 Badge.displayName = "Badge";
 

--- a/apps/storybook/src/components/badge/badge.stories.tsx
+++ b/apps/storybook/src/components/badge/badge.stories.tsx
@@ -1,6 +1,19 @@
+import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Badge, type AttachedBadgeProps } from "./index";
-import { Mail } from "lucide-react";
+import { Badge, type BadgeVariant } from "./index";
+import { Mail, Star } from "lucide-react";
+
+const VARIANTS: BadgeVariant[] = [
+  "default",
+  "secondary",
+  "success",
+  "warning",
+  "destructive",
+  "info",
+  "purple",
+  "outline",
+  "notification",
+];
 
 const meta: Meta<typeof Badge> = {
   title: "Components/Badge",
@@ -10,44 +23,37 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component: `
-The **Badge** component is a small status indicator used for notifications, counts, and labels.
+A versatile, theme-aware badge for status indicators, colored action pills, and notification counters.
 
 ### Features
-- Inline and attached modes
-- Multiple color types (primary, success, warning, error)
-- Built-in animation variants (pulse, bounce, tinypop)
-- Works with text, icons, buttons, and avatars
+- Color variants: default, secondary, success, warning, destructive, info, purple, outline, notification
+- Size variants: sm, md, lg
+- Optional leading icon and dismiss (\`onRemove\`) button
+- \`anchor\` prop reproduces the classic floating notification-counter positioning
+- Built-in animation variants (pulse, bounce, tinypop) via \`animate\`
         `,
       },
     },
   },
   argTypes: {
-    text: {
-      control: "text",
-      description: "Content displayed inside the badge",
-      defaultValue: "5",
-    },
-    type: {
-      control: "select",
-      options: ["primary", "secondary", "success", "warning", "error"],
-      description: "Color style of the badge",
-    },
     variant: {
       control: "select",
-      options: ["pulse", "bounce", "tinypop"],
-      description: "Animation style",
+      options: VARIANTS,
+      description: "Color/style of the badge",
     },
-    mode: {
+    size: {
       control: "select",
-      options: ["inline", "attached"],
-      description: "Layout behavior of the badge",
+      options: ["sm", "md", "lg"],
+      description: "Size of the badge",
     },
-    className: {
-      control: "text",
-      description: "Custom styles",
+    animate: {
+      control: "select",
+      options: ["none", "pulse", "bounce", "tinypop"],
+      description: "Motion applied to the badge",
     },
     children: {
-      table: { disable: true },
+      control: "text",
+      description: "Content displayed inside the badge",
     },
   },
 };
@@ -55,78 +61,124 @@ The **Badge** component is a small status indicator used for notifications, coun
 export default meta;
 type Story = StoryObj<typeof Badge>;
 
-
-// Inline Badge (default usage)
-export const Inline: Story = {
+export const Default: Story = {
   args: {
-    text: "99+",
-    type: "error",
-    mode: "inline",
+    children: "Badge",
+    variant: "default",
+    size: "md",
   },
-  render: (args) => (
-    <div className="flex items-center gap-2">
-      <span className="text-lg font-medium">Notifications</span>
-      <Badge {...args} />
+};
+
+export const AllVariants: Story = {
+  name: "All variants",
+  render: () => (
+    <div className="flex flex-wrap gap-3 items-center">
+      {VARIANTS.map((variant) => (
+        <Badge key={variant} variant={variant}>
+          {variant}
+        </Badge>
+      ))}
     </div>
   ),
 };
 
-
-// Attached to Icon
-export const AttachedIcon: Story = {
-  args: {
-    text: "3",
-    type: "primary",
-    variant: "pulse",
-    mode: "attached",
-  },
-  render: (args) => (
-    <Badge {...args as AttachedBadgeProps}>
-      <Mail className="h-10 w-10" />
-    </Badge>
-  ),
-};
-
-
-// Attached to Button
-export const AttachedButton: Story = {
-  args: {
-    text: "New",
-    type: "error",
-    variant: "tinypop",
-    mode: "attached",
-  },
-  render: (args) => (
-    <Badge {...args as AttachedBadgeProps}>
-      <button className="px-4 py-2 bg-muted rounded-lg shadow">
-        Components
-      </button>
-    </Badge>
-  ),
-};
-
-
-// Variants Showcase
-export const Variants: Story = {
+export const AllSizes: Story = {
+  name: "All sizes",
   render: () => (
-    <div className="flex gap-4 items-center">
-      <Badge text="5" variant="pulse" type="primary" />
-      <Badge text="5" variant="bounce" type="success" />
-      <Badge text="5" variant="tinypop" type="warning" />
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+      <Badge size="lg">Large</Badge>
     </div>
   ),
 };
 
+export const StatusPills: Story = {
+  args: {
+    children: "dxxx"
+  },
 
-// Types Showcase
-export const Types: Story = {
+  name: "Status pills (real-world use)",
+
+  render: () => (
+    <div className="flex flex-wrap gap-3 items-center">
+      <Badge variant="success">Published</Badge>
+      <Badge variant="secondary">Draft</Badge>
+      <Badge variant="destructive">Archived</Badge>
+      <Badge variant="info">CREATE</Badge>
+      <Badge variant="warning">UPDATE</Badge>
+      <Badge variant="destructive">DELETE</Badge>
+      <Badge variant="purple">Admin</Badge>
+      <Badge variant="outline">Disabled</Badge>
+    </div>
+  )
+};
+
+export const WithIcon: Story = {
+  name: "With icon",
+  render: () => (
+    <div className="flex flex-wrap gap-3 items-center">
+      <Badge variant="success" icon={<Star className="h-3 w-3" />}>
+        Featured
+      </Badge>
+      <Badge variant="info" icon={<Mail className="h-3 w-3" />}>
+        3 new messages
+      </Badge>
+    </div>
+  ),
+};
+
+export const Dismissible: Story = {
+  name: "Dismissible (onRemove)",
+  render: () => {
+    const [tags, setTags] = useState(["React", "TypeScript", "Tailwind"]);
+    return (
+      <div className="flex flex-wrap gap-2 items-center">
+        {tags.length === 0 && <span className="text-sm text-muted-foreground">All tags removed</span>}
+        {tags.map((tag) => (
+          <Badge key={tag} variant="secondary" onRemove={() => setTags((prev) => prev.filter((t) => t !== tag))}>
+            {tag}
+          </Badge>
+        ))}
+      </div>
+    );
+  },
+};
+
+export const NotificationCounter: Story = {
+  name: "Notification counter (attached)",
+  render: () => (
+    <div className="flex items-center gap-8">
+      <Badge variant="notification" anchor={<Mail className="h-10 w-10" />}>
+        3
+      </Badge>
+      <Badge variant="notification" animate="bounce" anchor={<button className="rounded-lg bg-muted px-4 py-2 shadow">Inbox</button>}>
+        New
+      </Badge>
+      <div className="flex items-center gap-1">
+        <span className="text-lg font-medium">Alerts</span>
+        <Badge variant="notification">99+</Badge>
+      </div>
+    </div>
+  ),
+};
+
+export const AnimationVariants: Story = {
+  name: "Animation variants",
   render: () => (
     <div className="flex gap-4 items-center">
-      <Badge text="1" type="primary" />
-      <Badge text="2" type="secondary" />
-      <Badge text="3" type="success" />
-      <Badge text="4" type="warning" />
-      <Badge text="5" type="error" />
+      <Badge variant="notification" animate="pulse">
+        5
+      </Badge>
+      <Badge variant="notification" animate="bounce">
+        5
+      </Badge>
+      <Badge variant="notification" animate="tinypop">
+        5
+      </Badge>
+      <Badge variant="notification" animate="none">
+        5
+      </Badge>
     </div>
   ),
 };

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -1,148 +1,164 @@
 import React from "react";
 import { motion, type Variants } from "framer-motion";
+import { X } from "lucide-react";
 import { cn } from "../../../utils/cn";
 
-type BadgeBaseProps = {
-  text?: string;
-  type?: "primary" | "secondary" | "success" | "warning" | "error";
-  variant?: "pulse" | "bounce" | "tinypop" | "none";
+export type BadgeVariant =
+  | "default"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "destructive"
+  | "info"
+  | "purple"
+  | "outline"
+  | "notification";
+
+export type BadgeSize = "sm" | "md" | "lg";
+
+export type BadgeAnimation = "none" | "pulse" | "bounce" | "tinypop";
+
+export interface BadgeProps
+  extends Omit<
+    React.HTMLAttributes<HTMLSpanElement>,
+    "children" | "color" | "onAnimationStart" | "onAnimationEnd" | "onDrag" | "onDragStart" | "onDragEnd"
+  > {
+  children?: React.ReactNode;
+  /** Color/style of the badge. `"notification"` reproduces the original circular counter look. */
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  /** Leading icon, rendered before the content. */
+  icon?: React.ReactNode;
+  /** Renders a dismiss button after the content; called when it's clicked. */
+  onRemove?: () => void;
+  /** Accessible label for the dismiss button. Default `"Remove"`. */
+  removeLabel?: string;
+  /**
+   * Anchors the badge to the top-right corner of this element instead of rendering inline -
+   * reproduces the original `mode="attached"` notification-badge positioning.
+   */
+  anchor?: React.ReactNode;
+  /** Motion applied to the badge. Defaults to `"tinypop"` for `variant="notification"`, `"none"` otherwise. */
+  animate?: BadgeAnimation;
   className?: string;
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  default: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+  success: "bg-success text-success-foreground",
+  warning: "bg-warning text-warning-foreground",
+  destructive: "bg-destructive text-destructive-foreground",
+  info: "bg-info text-info-foreground",
+  purple: "bg-purple text-purple-foreground",
+  outline: "bg-transparent text-foreground border border-border",
+  notification: "bg-primary text-primary-foreground shadow-lg shadow-primary/25 ring-2 ring-primary/20",
 };
 
-export type InlineBadgeProps = BadgeBaseProps & {
-  mode?: "inline";
-  children?: never;
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "text-[11px] px-2 py-0.5 gap-1",
+  md: "text-xs px-2.5 py-0.5 gap-1.5",
+  lg: "text-sm px-3 py-1 gap-1.5",
 };
 
-export type AttachedBadgeProps = BadgeBaseProps & {
-  mode: "attached";
-  children: React.ReactNode;
+// The notification variant is a circular counter, not a text pill, so it gets its own
+// size scale (fixed height/min-width) instead of SIZE_CLASSES' padding-based one.
+const NOTIFICATION_SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "h-4 min-w-[16px] px-1 text-[10px]",
+  md: "h-5 min-w-[20px] px-1.5 text-xs",
+  lg: "h-6 min-w-[24px] px-2 text-sm",
 };
 
-export type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
+  pulse: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.1, 1], transition: { duration: 2, repeat: Infinity, ease: "easeOut" } },
+  },
+  bounce: {
+    initial: { y: 0, scale: 1 },
+    animate: {
+      y: [0, -6, 0],
+      scale: [1, 1.15, 1],
+      transition: { duration: 0.8, repeat: Infinity, ease: "easeOut" },
+    },
+  },
+  tinypop: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.25, 1], transition: { duration: 1.5, repeat: Infinity, ease: "easeInOut" } },
+  },
+};
 
-const Badge: React.FC<BadgeProps> = ({
-  text,
-  type = "primary",
-  variant = "tinypop",
-  mode = "inline",
-  className,
+const NONE_VARIANT: Variants = { initial: {}, animate: {} };
+
+export const Badge: React.FC<BadgeProps> = ({
   children,
+  variant = "default",
+  size = "md",
+  icon,
+  onRemove,
+  removeLabel = "Remove",
+  anchor,
+  animate,
+  className,
+  ...props
 }) => {
-  const types = {
-    primary: cn(
-      "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
-      "ring-2 ring-primary/20"
-    ),
-    secondary: cn(
-      "bg-secondary text-secondary-foreground",
-      "shadow-lg shadow-secondary/25",
-      "ring-2 ring-secondary/20"
-    ),
-    success: cn(
-      "bg-success text-success-foreground",
-      "shadow-lg shadow-success/25",
-      "ring-2 ring-success/20"
-    ),
-    warning: cn(
-      "bg-warning text-warning-foreground",
-      "shadow-lg shadow-warning/25",
-      "ring-2 ring-warning/30"
-    ),
-    error: cn(
-      "bg-destructive text-destructive-foreground",
-      "shadow-lg shadow-destructive/25",
-      "ring-2 ring-destructive/20"
-    ),
-  };
+  const isNotification = variant === "notification";
+  const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
+  const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
-  const animationVariants: Record<string, Variants> = {
-    none: {
-      initial: {},
-      animate: {},
-    },
-    pulse: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.1, 1],
-        transition: {
-          duration: 2,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    bounce: {
-      initial: { y: 0, scale: 1 },
-      animate: {
-        y: [0, -6, 0],
-        scale: [1, 1.15, 1],
-        transition: {
-          duration: 0.8,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    tinypop: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.25, 1],
-        transition: {
-          duration: 1.5,
-          repeat: Infinity,
-          ease: "easeInOut",
-        },
-      },
-    },
-  };
-
-  const isAttached = mode === "attached";
-
-  // Base styles
-  const baseStyles = cn(
-    "flex items-center justify-center",
-    "rounded-full font-bold tracking-tight",
-    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
-
-    types[type],
-    className
-  );
-
-  const positionStyles = isAttached
-    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
-    : "relative -top-2 sm:-top-2";
-
-  const badgeContent = (
-    <motion.div
-      variants={animationVariants[variant]}
+  const content = (
+    <motion.span
+      variants={motionVariants}
       initial="initial"
       animate="animate"
-      className={cn(baseStyles, positionStyles)}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-full font-medium leading-none whitespace-nowrap",
+        VARIANT_CLASSES[variant],
+        isNotification ? NOTIFICATION_SIZE_CLASSES[size] : SIZE_CLASSES[size],
+        anchor && "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
+        className
+      )}
+      {...props}
     >
-      <span className="leading-none">{text}</span>
-
-      <div
-        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
-        aria-hidden="true"
-      />
-    </motion.div>
+      {icon && (
+        <span className="shrink-0" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {children}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {isNotification && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10"
+          aria-hidden="true"
+        />
+      )}
+    </motion.span>
   );
 
-  if (isAttached) {
+  if (anchor) {
     return (
-      <div className="relative inline-flex items-center">
-        {children}
-        {badgeContent}
-      </div>
+      <span className="relative inline-flex items-center">
+        {anchor}
+        {content}
+      </span>
     );
   }
 
-  return badgeContent;
+  return content;
 };
 
 Badge.displayName = "Badge";
-export { Badge };
+
+export default Badge;

--- a/apps/storybook/src/components/badge/index.tsx
+++ b/apps/storybook/src/components/badge/index.tsx
@@ -90,7 +90,11 @@ const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
 
 const NONE_VARIANT: Variants = { initial: {}, animate: {} };
 
-export const Badge: React.FC<BadgeProps> = ({
+/**
+ * Badge is a versatile, theme-aware status indicator - color pill, outline tag, or (via
+ * `variant="notification"`) a floating counter attached to an icon or button.
+ */
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(({
   children,
   variant = "default",
   size = "md",
@@ -101,13 +105,14 @@ export const Badge: React.FC<BadgeProps> = ({
   animate,
   className,
   ...props
-}) => {
+}, ref) => {
   const isNotification = variant === "notification";
   const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
   const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
   const content = (
     <motion.span
+      ref={ref}
       variants={motionVariants}
       initial="initial"
       animate="animate"
@@ -131,7 +136,10 @@ export const Badge: React.FC<BadgeProps> = ({
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
           aria-label={removeLabel}
           className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
         >
@@ -157,7 +165,7 @@ export const Badge: React.FC<BadgeProps> = ({
   }
 
   return content;
-};
+});
 
 Badge.displayName = "Badge";
 

--- a/apps/storybook/src/index.css
+++ b/apps/storybook/src/index.css
@@ -53,6 +53,13 @@
     --info-dark: #0e7490;
     /* cyan-600 */
     --info-foreground: #ffffff;
+    --purple: #a855f7;
+    /* purple-500 */
+    --purple-light: #c084fc;
+    /* purple-400 */
+    --purple-dark: #7e22ce;
+    /* purple-600 */
+    --purple-foreground: #ffffff;
 
     /* Floating Dock */
     --dock-solid: #1e293b;
@@ -134,6 +141,13 @@
     --info-dark: #0e7490;
     /* cyan-600 */
     --info-foreground: #ffffff;
+    --purple: #a855f7;
+    /* purple-500 */
+    --purple-light: #c084fc;
+    /* purple-400 */
+    --purple-dark: #7e22ce;
+    /* purple-600 */
+    --purple-foreground: #ffffff;
 
     /* Floating Dock */
     --dock-solid: #1e293b;
@@ -191,6 +205,10 @@
   --color-info-light: var(--info-light);
   --color-info-dark: var(--info-dark);
   --color-info-foreground: var(--info-foreground);
+  --color-purple: var(--purple);
+  --color-purple-light: var(--purple-light);
+  --color-purple-dark: var(--purple-dark);
+  --color-purple-foreground: var(--purple-foreground);
 
   /* Floating Dock */
   --color-dock-solid: var(--dock-solid);

--- a/apps/storybook/src/index.css
+++ b/apps/storybook/src/index.css
@@ -53,12 +53,12 @@
     --info-dark: #0e7490;
     /* cyan-600 */
     --info-foreground: #ffffff;
-    --purple: #a855f7;
-    /* purple-500 */
+    --purple: #7e22ce;
+    /* purple-700 */
     --purple-light: #c084fc;
     /* purple-400 */
     --purple-dark: #7e22ce;
-    /* purple-600 */
+    /* purple-700 */
     --purple-foreground: #ffffff;
 
     /* Floating Dock */
@@ -141,12 +141,12 @@
     --info-dark: #0e7490;
     /* cyan-600 */
     --info-foreground: #ffffff;
-    --purple: #a855f7;
-    /* purple-500 */
+    --purple: #7e22ce;
+    /* purple-700 */
     --purple-light: #c084fc;
     /* purple-400 */
     --purple-dark: #7e22ce;
-    /* purple-600 */
+    /* purple-700 */
     --purple-foreground: #ffffff;
 
     /* Floating Dock */

--- a/apps/storybook/src/templates/pages/data-management/list-view-page/index.tsx
+++ b/apps/storybook/src/templates/pages/data-management/list-view-page/index.tsx
@@ -793,10 +793,12 @@ function Toolbar({
                                     Filters
                                     {activeFilterCount > 0 && (
                                         <Badge
-                                            text={String(activeFilterCount)}
-                                            variant="pulse"
+                                            variant="notification"
+                                            animate="pulse"
                                             className="h-5 min-w-5 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground"
-                                        />
+                                        >
+                                            {activeFilterCount}
+                                        </Badge>
                                     )}
                                 </Button>
                             )}
@@ -1237,15 +1239,13 @@ function StatusBadge({
 }) {
     const s = styles?.[status] ?? DEFAULT_STATUS_STYLE;
     return (
-        <span
-            className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                s.className
-            )}
+        <Badge
+            variant="outline"
+            icon={<span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />}
+            className={cn("gap-1.5 px-2 py-0.5 text-[11px] font-medium", s.className)}
         >
-            <span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />
             {status}
-        </span>
+        </Badge>
     );
 }
 
@@ -1452,12 +1452,14 @@ function ViewDialog({
                         </div>
                         {item.status && statusStyles?.[item.status] && (
                             <Badge
+                                variant="outline"
                                 className={cn(
                                     "shrink-0 gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium whitespace-nowrap",
                                     statusStyles[item.status].className
                                 )}
-                                text={item.status}
-                            />
+                            >
+                                {item.status}
+                            </Badge>
                         )}
                     </div>
 

--- a/apps/storybook/src/templates/pages/data-management/list-view-page/index.tsx
+++ b/apps/storybook/src/templates/pages/data-management/list-view-page/index.tsx
@@ -1230,6 +1230,7 @@ function SkeletonRow() {
 /*                                BADGES                                      */
 /* -------------------------------------------------------------------------- */
 
+/** Renders an item's status as a labeled Badge with a colored dot, using a per-status style map. */
 function StatusBadge({
     status,
     styles,

--- a/apps/storybook/src/templates/pages/data-management/timeline-view-page/index.tsx
+++ b/apps/storybook/src/templates/pages/data-management/timeline-view-page/index.tsx
@@ -36,19 +36,16 @@ export function StatusBadge({
     status: TimelineStatus;
     className?: string;
 }) {
-    const typeMap = {
+    const variantMap = {
         completed: "success",
         in_progress: "warning",
         pending: "secondary",
     } as const;
 
     return (
-        <Badge
-            text={STATUS_LABELS[status]}
-            type={typeMap[status]}
-            variant="none"
-            className={className}
-        />
+        <Badge variant={variantMap[status]} className={className}>
+            {STATUS_LABELS[status]}
+        </Badge>
     );
 }
 

--- a/apps/storybook/src/templates/pages/data-management/timeline-view-page/index.tsx
+++ b/apps/storybook/src/templates/pages/data-management/timeline-view-page/index.tsx
@@ -29,6 +29,7 @@ export const STATUS_LABELS: Record<TimelineStatus, string> = {
 
 // Constants
 
+/** Renders a timeline item's status as a labeled Badge, colored by {@link TimelineStatus}. */
 export function StatusBadge({
     status,
     className,

--- a/packages/registry/components/badge/badge.test.tsx
+++ b/packages/registry/components/badge/badge.test.tsx
@@ -1,155 +1,208 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
-import { Badge } from "./index";
 import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Badge, type BadgeVariant, type BadgeSize } from "./index";
 
 vi.mock("framer-motion", () => {
   const motion = new Proxy(
     {},
     {
       get: (_target, tag: string) =>
-        React.forwardRef(({ children, ...rest }: any, ref) =>
-          React.createElement(tag, { ...rest, ref }, children)
-        ),
+        React.forwardRef(({ children, ...rest }: any, ref) => React.createElement(tag, { ...rest, ref }, children)),
     }
   );
 
   return {
     motion,
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => (
-      <>{children}</>
-    ),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
 
-const renderBadge = (props: Partial<React.ComponentProps<typeof Badge>> = {}) =>
-  render(<Badge text="Badge Text" {...props} />);
-
 describe("Badge rendering", () => {
   it("renders without crashing", () => {
-    renderBadge();
-    expect(screen.getByText("Badge Text")).toBeInTheDocument();
+    render(<Badge>Draft</Badge>);
+    expect(screen.getByText("Draft")).toBeInTheDocument();
   });
 
-  it("displays the text prop", () => {
-    renderBadge({ text: "42" });
+  it("renders children as provided (text, number, node)", () => {
+    render(<Badge>{42}</Badge>);
     expect(screen.getByText("42")).toBeInTheDocument();
   });
 
-  it("renders the badge text inside a <span>", () => {
-    renderBadge({ text: "Hello" });
-    expect(screen.getByText("Hello").tagName).toBe("SPAN");
-  });
-
-  it("renders overlay only in attached mode", () => {
-    const { container } = render(
-      <Badge mode="attached" text="1">
-        <div>child</div>
-      </Badge>
-    );
-
-    const overlay = container.querySelector("div[aria-hidden='true']");
-    expect(overlay).toBeInTheDocument();
-  });
-});
-
-describe("Badge children", () => {
-  it("renders children only in attached mode", () => {
-    render(
-      <Badge mode="attached" text="3">
-        <button>Bell</button>
-      </Badge>
-    );
-
-    expect(screen.getByRole("button", { name: "Bell" })).toBeInTheDocument();
-  });
-
-  it("does NOT render children in inline mode", () => {
-    render(
-      <Badge text="3">
-        <button>Bell</button>
-      </Badge>
-    );
-
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
-  });
-});
-
-describe("Badge type prop", () => {
-  const typeCases: Array<[React.ComponentProps<typeof Badge>["type"], string]> = [
-    ["primary", "bg-primary"],
-    ["secondary", "bg-secondary"],
-    ["success", "bg-success"],
-    ["warning", "bg-warning"],
-    ["error", "bg-destructive"],
-  ];
-
-  it.each(typeCases)('type="%s" applies class "%s"', (type, expectedClass) => {
-    render(<Badge text="X" type={type} />);
-    const badge = screen.getByText("X").parentElement;
-    expect(badge?.className).toContain(expectedClass);
-  });
-
-  it("defaults to primary type", () => {
-    render(<Badge text="X" />);
-    const badge = screen.getByText("X").parentElement;
-    expect(badge?.className).toContain("bg-primary");
+  it("has correct displayName", () => {
+    expect(Badge.displayName).toBe("Badge");
   });
 });
 
 describe("Badge variant prop", () => {
-  it.each(["pulse", "bounce", "tinypop"] as const)(
-    'variant="%s" renders',
-    (variant) => {
-      renderBadge({ variant });
-      expect(screen.getByText("Badge Text")).toBeInTheDocument();
-    }
-  );
+  const variantCases: Array<[BadgeVariant, string]> = [
+    ["default", "bg-primary"],
+    ["secondary", "bg-secondary"],
+    ["success", "bg-success"],
+    ["warning", "bg-warning"],
+    ["destructive", "bg-destructive"],
+    ["info", "bg-info"],
+    ["purple", "bg-purple"],
+    ["outline", "border-border"],
+    ["notification", "ring-2"],
+  ];
+
+  it.each(variantCases)('variant="%s" applies class "%s"', (variant, expectedClass) => {
+    render(<Badge variant={variant}>X</Badge>);
+    expect(screen.getByText("X").className).toContain(expectedClass);
+  });
+
+  it("defaults to the default variant", () => {
+    render(<Badge>X</Badge>);
+    expect(screen.getByText("X").className).toContain("bg-primary");
+  });
+
+  it("outline variant is transparent with a border, not a filled background", () => {
+    render(<Badge variant="outline">X</Badge>);
+    const classes = screen.getByText("X").className;
+    expect(classes).toContain("bg-transparent");
+    expect(classes).toContain("border");
+  });
 });
 
-describe("Badge className", () => {
-  it("applies custom className", () => {
-    render(<Badge text="X" className="custom" />);
-    const badge = screen.getByText("X").parentElement;
-    expect(badge?.className).toContain("custom");
+describe("Badge size prop", () => {
+  const sizeCases: Array<[BadgeSize, string]> = [
+    ["sm", "text-[11px]"],
+    ["md", "text-xs"],
+    ["lg", "text-sm"],
+  ];
+
+  it.each(sizeCases)('size="%s" applies class "%s"', (size, expectedClass) => {
+    render(<Badge size={size}>X</Badge>);
+    expect(screen.getByText("X").className).toContain(expectedClass);
   });
 
-  it("merges with default classes", () => {
-    render(<Badge text="X" type="success" className="extra" />);
-    const badge = screen.getByText("X").parentElement;
-    expect(badge?.className).toContain("bg-success");
-    expect(badge?.className).toContain("extra");
-  });
-});
-
-describe("Badge structure", () => {
-  it("inline mode has no wrapper", () => {
-    const { container } = renderBadge();
-    const root = container.firstElementChild;
-    expect(root?.className).not.toContain("relative inline-flex");
+  it("defaults to the md size", () => {
+    render(<Badge>X</Badge>);
+    expect(screen.getByText("X").className).toContain("text-xs");
   });
 
-  it("attached mode has wrapper", () => {
-    const { container } = render(
-      <Badge mode="attached" text="1">
-        <div>child</div>
+  it("uses circular counter sizing for the notification variant instead of pill padding", () => {
+    render(
+      <Badge variant="notification" size="lg">
+        9
       </Badge>
     );
+    const classes = screen.getByText("9").className;
+    expect(classes).toContain("h-6");
+    expect(classes).toContain("min-w-[24px]");
+  });
+});
 
+describe("Badge icon slot", () => {
+  it("renders the icon before the children", () => {
+    render(
+      <Badge icon={<span data-testid="icon">*</span>}>
+        Active
+      </Badge>
+    );
+    const icon = screen.getByTestId("icon");
+    const badge = screen.getByText("Active").closest("span[class]");
+    expect(icon).toBeInTheDocument();
+    expect(badge?.textContent?.indexOf("*")).toBeLessThan(badge?.textContent?.indexOf("Active") ?? -1);
+  });
+
+  it("marks the icon wrapper as aria-hidden", () => {
+    const { container } = render(<Badge icon={<span data-testid="icon">*</span>}>Active</Badge>);
+    const wrapper = container.querySelector('[aria-hidden="true"]');
+    expect(wrapper).toContainElement(screen.getByTestId("icon"));
+  });
+
+  it("omits the icon wrapper when no icon is provided", () => {
+    const { container } = render(<Badge>Active</Badge>);
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeInTheDocument();
+  });
+});
+
+describe("Badge dismiss button", () => {
+  it("renders a dismiss button when onRemove is provided", () => {
+    render(<Badge onRemove={vi.fn()}>Removable</Badge>);
+    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+  });
+
+  it("omits the dismiss button when onRemove is not provided", () => {
+    render(<Badge>Not removable</Badge>);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("calls onRemove when the dismiss button is clicked", () => {
+    const onRemove = vi.fn();
+    render(<Badge onRemove={onRemove}>Removable</Badge>);
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a custom removeLabel for the dismiss button's accessible name", () => {
+    render(
+      <Badge onRemove={vi.fn()} removeLabel="Remove Draft tag">
+        Draft
+      </Badge>
+    );
+    expect(screen.getByRole("button", { name: "Remove Draft tag" })).toBeInTheDocument();
+  });
+});
+
+describe("Badge anchor (attached positioning)", () => {
+  it("renders the anchor content alongside the badge", () => {
+    render(
+      <Badge anchor={<button>Bell</button>} variant="notification">
+        3
+      </Badge>
+    );
+    expect(screen.getByRole("button", { name: "Bell" })).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("wraps the anchor and badge in a relative inline-flex container", () => {
+    const { container } = render(<Badge anchor={<div>child</div>}>1</Badge>);
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toContain("relative");
     expect(wrapper?.className).toContain("inline-flex");
   });
 
-  it("badge has rounded-full", () => {
-    renderBadge();
-    const badge = screen.getByText("Badge Text").parentElement;
-    expect(badge?.className).toContain("rounded-full");
+  it("positions the badge absolutely in the corner when anchored", () => {
+    render(<Badge anchor={<div>child</div>}>1</Badge>);
+    expect(screen.getByText("1").className).toContain("absolute");
+  });
+
+  it("renders the badge itself as the root when not anchored, with no extra wrapper", () => {
+    const { container } = render(<Badge>1</Badge>);
+    expect(container.children).toHaveLength(1);
+    expect(container.firstElementChild?.textContent).toBe("1");
   });
 });
 
-describe("Badge displayName", () => {
-  it("has correct displayName", () => {
-    expect(Badge.displayName).toBe("Badge");
+describe("Badge className", () => {
+  it("applies a custom className", () => {
+    render(<Badge className="custom">X</Badge>);
+    expect(screen.getByText("X").className).toContain("custom");
+  });
+
+  it("merges custom className with variant classes", () => {
+    render(
+      <Badge variant="success" className="extra">
+        X
+      </Badge>
+    );
+    const classes = screen.getByText("X").className;
+    expect(classes).toContain("bg-success");
+    expect(classes).toContain("extra");
+  });
+});
+
+describe("Badge structure", () => {
+  it("has rounded-full", () => {
+    render(<Badge>X</Badge>);
+    expect(screen.getByText("X").className).toContain("rounded-full");
+  });
+
+  it("passes through extra HTML attributes", () => {
+    render(<Badge data-testid="my-badge">X</Badge>);
+    expect(screen.getByTestId("my-badge")).toBeInTheDocument();
   });
 });

--- a/packages/registry/components/badge/badge.test.tsx
+++ b/packages/registry/components/badge/badge.test.tsx
@@ -32,6 +32,13 @@ describe("Badge rendering", () => {
   it("has correct displayName", () => {
     expect(Badge.displayName).toBe("Badge");
   });
+
+  it("forwards a ref to the underlying badge element", () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(<Badge ref={ref}>Draft</Badge>);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+    expect(ref.current?.textContent).toBe("Draft");
+  });
 });
 
 describe("Badge variant prop", () => {
@@ -144,6 +151,19 @@ describe("Badge dismiss button", () => {
       </Badge>
     );
     expect(screen.getByRole("button", { name: "Remove Draft tag" })).toBeInTheDocument();
+  });
+
+  it("does not bubble the dismiss click to the badge's own onClick", () => {
+    const onRemove = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <Badge onRemove={onRemove} onClick={onClick}>
+        Removable
+      </Badge>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -1,148 +1,164 @@
 import React from "react";
 import { motion, type Variants } from "framer-motion";
+import { X } from "lucide-react";
 import { cn } from "../../../utils/cn";
 
-type BadgeBaseProps = {
-  text?: string;
-  type?: "primary" | "secondary" | "success" | "warning" | "error";
-  variant?: "pulse" | "bounce" | "tinypop" | "none";
+export type BadgeVariant =
+  | "default"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "destructive"
+  | "info"
+  | "purple"
+  | "outline"
+  | "notification";
+
+export type BadgeSize = "sm" | "md" | "lg";
+
+export type BadgeAnimation = "none" | "pulse" | "bounce" | "tinypop";
+
+export interface BadgeProps
+  extends Omit<
+    React.HTMLAttributes<HTMLSpanElement>,
+    "children" | "color" | "onAnimationStart" | "onAnimationEnd" | "onDrag" | "onDragStart" | "onDragEnd"
+  > {
+  children?: React.ReactNode;
+  /** Color/style of the badge. `"notification"` reproduces the original circular counter look. */
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  /** Leading icon, rendered before the content. */
+  icon?: React.ReactNode;
+  /** Renders a dismiss button after the content; called when it's clicked. */
+  onRemove?: () => void;
+  /** Accessible label for the dismiss button. Default `"Remove"`. */
+  removeLabel?: string;
+  /**
+   * Anchors the badge to the top-right corner of this element instead of rendering inline -
+   * reproduces the original `mode="attached"` notification-badge positioning.
+   */
+  anchor?: React.ReactNode;
+  /** Motion applied to the badge. Defaults to `"tinypop"` for `variant="notification"`, `"none"` otherwise. */
+  animate?: BadgeAnimation;
   className?: string;
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  default: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+  success: "bg-success text-success-foreground",
+  warning: "bg-warning text-warning-foreground",
+  destructive: "bg-destructive text-destructive-foreground",
+  info: "bg-info text-info-foreground",
+  purple: "bg-purple text-purple-foreground",
+  outline: "bg-transparent text-foreground border border-border",
+  notification: "bg-primary text-primary-foreground shadow-lg shadow-primary/25 ring-2 ring-primary/20",
 };
 
-export type InlineBadgeProps = BadgeBaseProps & {
-  mode?: "inline";
-  children?: never;
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "text-[11px] px-2 py-0.5 gap-1",
+  md: "text-xs px-2.5 py-0.5 gap-1.5",
+  lg: "text-sm px-3 py-1 gap-1.5",
 };
 
-export type AttachedBadgeProps = BadgeBaseProps & {
-  mode: "attached";
-  children: React.ReactNode;
+// The notification variant is a circular counter, not a text pill, so it gets its own
+// size scale (fixed height/min-width) instead of SIZE_CLASSES' padding-based one.
+const NOTIFICATION_SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: "h-4 min-w-[16px] px-1 text-[10px]",
+  md: "h-5 min-w-[20px] px-1.5 text-xs",
+  lg: "h-6 min-w-[24px] px-2 text-sm",
 };
 
-export type BadgeProps = InlineBadgeProps | AttachedBadgeProps;
+const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
+  pulse: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.1, 1], transition: { duration: 2, repeat: Infinity, ease: "easeOut" } },
+  },
+  bounce: {
+    initial: { y: 0, scale: 1 },
+    animate: {
+      y: [0, -6, 0],
+      scale: [1, 1.15, 1],
+      transition: { duration: 0.8, repeat: Infinity, ease: "easeOut" },
+    },
+  },
+  tinypop: {
+    initial: { scale: 1 },
+    animate: { scale: [1, 1.25, 1], transition: { duration: 1.5, repeat: Infinity, ease: "easeInOut" } },
+  },
+};
 
-const Badge: React.FC<BadgeProps> = ({
-  text,
-  type = "primary",
-  variant = "tinypop",
-  mode = "inline",
-  className,
+const NONE_VARIANT: Variants = { initial: {}, animate: {} };
+
+export const Badge: React.FC<BadgeProps> = ({
   children,
+  variant = "default",
+  size = "md",
+  icon,
+  onRemove,
+  removeLabel = "Remove",
+  anchor,
+  animate,
+  className,
+  ...props
 }) => {
-  const types = {
-    primary: cn(
-      "bg-primary text-primary-foreground",
-      "shadow-lg shadow-primary/25",
-      "ring-2 ring-primary/20"
-    ),
-    secondary: cn(
-      "bg-secondary text-secondary-foreground",
-      "shadow-lg shadow-secondary/25",
-      "ring-2 ring-secondary/20"
-    ),
-    success: cn(
-      "bg-success text-success-foreground",
-      "shadow-lg shadow-success/25",
-      "ring-2 ring-success/20"
-    ),
-    warning: cn(
-      "bg-warning text-warning-foreground",
-      "shadow-lg shadow-warning/25",
-      "ring-2 ring-warning/30"
-    ),
-    error: cn(
-      "bg-destructive text-destructive-foreground",
-      "shadow-lg shadow-destructive/25",
-      "ring-2 ring-destructive/20"
-    ),
-  };
+  const isNotification = variant === "notification";
+  const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
+  const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
-  const animationVariants: Record<string, Variants> = {
-    none: {
-      initial: {},
-      animate: {},
-    },
-    pulse: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.1, 1],
-        transition: {
-          duration: 2,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    bounce: {
-      initial: { y: 0, scale: 1 },
-      animate: {
-        y: [0, -6, 0],
-        scale: [1, 1.15, 1],
-        transition: {
-          duration: 0.8,
-          repeat: Infinity,
-          ease: "easeOut",
-        },
-      },
-    },
-    tinypop: {
-      initial: { scale: 1 },
-      animate: {
-        scale: [1, 1.25, 1],
-        transition: {
-          duration: 1.5,
-          repeat: Infinity,
-          ease: "easeInOut",
-        },
-      },
-    },
-  };
-
-  const isAttached = mode === "attached";
-
-  // Base styles
-  const baseStyles = cn(
-    "flex items-center justify-center",
-    "rounded-full font-bold tracking-tight",
-    "text-xs sm:text-sm px-1.5 sm:px-2 h-5 sm:h-6 min-w-[20px]",
-
-    types[type],
-    className
-  );
-
-  const positionStyles = isAttached
-    ? "absolute -top-1 -right-1 sm:-top-2 sm:-right-2"
-    : "relative -top-2 sm:-top-2";
-
-  const badgeContent = (
-    <motion.div
-      variants={animationVariants[variant]}
+  const content = (
+    <motion.span
+      variants={motionVariants}
       initial="initial"
       animate="animate"
-      className={cn(baseStyles, positionStyles)}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-full font-medium leading-none whitespace-nowrap",
+        VARIANT_CLASSES[variant],
+        isNotification ? NOTIFICATION_SIZE_CLASSES[size] : SIZE_CLASSES[size],
+        anchor && "absolute -top-1 -right-1 sm:-top-2 sm:-right-2",
+        className
+      )}
+      {...props}
     >
-      <span className="leading-none">{text}</span>
-
-      <div
-        className="absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10 pointer-events-none"
-        aria-hidden="true"
-      />
-    </motion.div>
+      {icon && (
+        <span className="shrink-0" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {children}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {isNotification && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-full bg-gradient-to-t from-transparent to-white/20 dark:to-white/10"
+          aria-hidden="true"
+        />
+      )}
+    </motion.span>
   );
 
-  if (isAttached) {
+  if (anchor) {
     return (
-      <div className="relative inline-flex items-center">
-        {children}
-        {badgeContent}
-      </div>
+      <span className="relative inline-flex items-center">
+        {anchor}
+        {content}
+      </span>
     );
   }
 
-  return badgeContent;
+  return content;
 };
 
 Badge.displayName = "Badge";
-export { Badge };
+
+export default Badge;

--- a/packages/registry/components/badge/index.tsx
+++ b/packages/registry/components/badge/index.tsx
@@ -90,7 +90,11 @@ const ANIMATION_VARIANTS: Record<Exclude<BadgeAnimation, "none">, Variants> = {
 
 const NONE_VARIANT: Variants = { initial: {}, animate: {} };
 
-export const Badge: React.FC<BadgeProps> = ({
+/**
+ * Badge is a versatile, theme-aware status indicator - color pill, outline tag, or (via
+ * `variant="notification"`) a floating counter attached to an icon or button.
+ */
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(({
   children,
   variant = "default",
   size = "md",
@@ -101,13 +105,14 @@ export const Badge: React.FC<BadgeProps> = ({
   animate,
   className,
   ...props
-}) => {
+}, ref) => {
   const isNotification = variant === "notification";
   const resolvedAnimation = animate ?? (isNotification ? "tinypop" : "none");
   const motionVariants = resolvedAnimation === "none" ? NONE_VARIANT : ANIMATION_VARIANTS[resolvedAnimation];
 
   const content = (
     <motion.span
+      ref={ref}
       variants={motionVariants}
       initial="initial"
       animate="animate"
@@ -131,7 +136,10 @@ export const Badge: React.FC<BadgeProps> = ({
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
           aria-label={removeLabel}
           className="-mr-0.5 ml-0.5 shrink-0 rounded-full p-0.5 hover:bg-black/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-current dark:hover:bg-white/10"
         >
@@ -157,7 +165,7 @@ export const Badge: React.FC<BadgeProps> = ({
   }
 
   return content;
-};
+});
 
 Badge.displayName = "Badge";
 

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -396,9 +396,10 @@
     },
     "badge": {
       "name": "Badge",
-      "description": "A badge component with animation and different variants",
+      "description": "A versatile, theme-aware badge for status indicators, colored action pills, and notification counters - with icon slot, dismiss button, and size variants.",
       "dependencies": [
-        "framer-motion"
+        "framer-motion",
+        "lucide-react"
       ],
       "files": {
         "main": {

--- a/packages/registry/templates/pages/list-view-page/index.tsx
+++ b/packages/registry/templates/pages/list-view-page/index.tsx
@@ -793,10 +793,12 @@ function Toolbar({
                                     Filters
                                     {activeFilterCount > 0 && (
                                         <Badge
-                                            text={String(activeFilterCount)}
-                                            variant="pulse"
+                                            variant="notification"
+                                            animate="pulse"
                                             className="h-5 min-w-5 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground"
-                                        />
+                                        >
+                                            {activeFilterCount}
+                                        </Badge>
                                     )}
                                 </Button>
                             )}
@@ -1237,15 +1239,13 @@ function StatusBadge({
 }) {
     const s = styles?.[status] ?? DEFAULT_STATUS_STYLE;
     return (
-        <span
-            className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                s.className
-            )}
+        <Badge
+            variant="outline"
+            icon={<span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />}
+            className={cn("gap-1.5 px-2 py-0.5 text-[11px] font-medium", s.className)}
         >
-            <span className={cn("h-1.5 w-1.5 rounded-full", s.dotClassName)} />
             {status}
-        </span>
+        </Badge>
     );
 }
 
@@ -1452,12 +1452,14 @@ function ViewDialog({
                         </div>
                         {item.status && statusStyles?.[item.status] && (
                             <Badge
+                                variant="outline"
                                 className={cn(
                                     "shrink-0 gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium whitespace-nowrap",
                                     statusStyles[item.status].className
                                 )}
-                                text={item.status}
-                            />
+                            >
+                                {item.status}
+                            </Badge>
                         )}
                     </div>
 

--- a/packages/registry/templates/pages/list-view-page/index.tsx
+++ b/packages/registry/templates/pages/list-view-page/index.tsx
@@ -1230,6 +1230,7 @@ function SkeletonRow() {
 /*                                BADGES                                      */
 /* -------------------------------------------------------------------------- */
 
+/** Renders an item's status as a labeled Badge with a colored dot, using a per-status style map. */
 function StatusBadge({
     status,
     styles,

--- a/packages/registry/templates/pages/timeline-view-page/index.tsx
+++ b/packages/registry/templates/pages/timeline-view-page/index.tsx
@@ -36,19 +36,16 @@ export function StatusBadge({
     status: TimelineStatus;
     className?: string;
 }) {
-    const typeMap = {
+    const variantMap = {
         completed: "success",
         in_progress: "warning",
         pending: "secondary",
     } as const;
 
     return (
-        <Badge
-            text={STATUS_LABELS[status]}
-            type={typeMap[status]}
-            variant="none"
-            className={className}
-        />
+        <Badge variant={variantMap[status]} className={className}>
+            {STATUS_LABELS[status]}
+        </Badge>
     );
 }
 

--- a/packages/registry/templates/pages/timeline-view-page/index.tsx
+++ b/packages/registry/templates/pages/timeline-view-page/index.tsx
@@ -29,6 +29,7 @@ export const STATUS_LABELS: Record<TimelineStatus, string> = {
 
 // Constants
 
+/** Renders a timeline item's status as a labeled Badge, colored by {@link TimelineStatus}. */
 export function StatusBadge({
     status,
     className,


### PR DESCRIPTION

## Description

### What does this PR do?

Replaces the single-purpose notification-counter `Badge` with a full, versatile Badge system for status indicators, colored action pills, and dismissible tags — while preserving all of the original notification-counter behavior as a dedicated `variant="notification"`.

### Related Issues

- Closes #971 
## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

### Docs
<img width="1887" height="1024" alt="image" src="https://github.com/user-attachments/assets/ebf6de45-eea9-425f-bcc9-71c52cdaf0e4" />

### Storybook
<img width="1889" height="1041" alt="image" src="https://github.com/user-attachments/assets/2ac1c622-be7e-43d9-8045-0d7909735d47" />


## Additional Context

- Added 9 color variants: `default`, `secondary`, `success`, `warning`, `destructive`, `info`, `purple`, `outline`, `notification`
- Added 3 sizes: `sm`, `md`, `lg`
---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New components or component API changes**
  - Replaced the legacy Badge API with a theme-aware `Badge` component.
  - Added nine variants, three sizes, icon support, dismiss actions, anchored counters, animations, and HTML span attributes.
  - Preserved notification counters through `variant="notification"`.
  - Migrated list and timeline status badges to the new API.

- **Bug fixes**
  - Replaced deprecated `text`, `type`, and `mode` props across Badge consumers.
  - Added dedicated notification sizing and styling.
  - Added purple Tailwind theme tokens for light and dark modes.

- **Tooling / config changes**
  - Added `lucide-react` to the Badge registry dependencies.
  - Updated registry metadata for the new Badge capabilities.

- **Docs / Storybook updates**
  - Updated Badge documentation, demos, installation examples, usage examples, and props.
  - Added Storybook stories for variants, sizes, status pills, icons, dismissal, notification counters, and animations.
  - Rewrote unit tests for variants, sizes, icons, dismissal, anchoring, class merging, and attribute passthrough.

### Breaking changes
- Removed `text`, `type`, and `mode` props.
- Replaced `mode="attached"` with `anchor`.
- Moved animation selection from `variant` to `animate`.
- Replaced `error` with `destructive`.
- Badge content must use `children`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->